### PR TITLE
Renderer fails when calling validate_import_vm

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
@@ -31,7 +31,7 @@ module ManageIQ::Providers::Redhat::InfraManager::VmImport
   end
 
   def validate_import_vm
-    api_version >= '4.0'
+    highest_supported_api_version && highest_supported_api_version >= '4'
   end
 
   private

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
@@ -54,4 +54,18 @@ describe ManageIQ::Providers::Redhat::InfraManager::VmImport do
       )
     end
   end
+
+  context 'checks version during validation' do
+    let(:ems) { FactoryGirl.create(:ems_redhat) }
+
+    it 'validates successfully' do
+      allow(ems).to receive(:highest_supported_api_version).and_return('4')
+      expect(ems.validate_import_vm).to be_truthy
+    end
+
+    it 'validates before connecting' do
+      allow(ems).to receive(:highest_supported_api_version).and_return(nil)
+      expect(ems.validate_import_vm).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
When using automation we see that there is an issue in validate_import_vm
and there is a time when api_version is not avialbale. We need to make sure
that validation passes.