### PR TITLE
No revert for "active" snapshot

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
 
     supports :revert_to_snapshot do
       unless allowed_to_revert?
-        unsupported_reason_add(:revert_to_snapshot, _("Revert is allowed only when vm is down. Current state is %{state}") % {:state => current_state})
+        unsupported_reason_add(:revert_to_snapshot, revert_unsupported_message)
       end
     end
 
@@ -55,11 +55,20 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
     current_state == 'off'
   end
 
+  def revert_to_snapshot_denied_message(active = false)
+    return revert_unsupported_message unless allowed_to_revert?
+    return _("Revert is not allowed for a snapshot that is the active one") if active
+  end
+
   def snapshotting_memory_allowed?
     current_state == 'on'
   end
 
   private
+
+  def revert_unsupported_message
+    _("Revert is allowed only when vm is down. Current state is %{state}") % {:state => current_state}
+  end
 
   def with_snapshots_service(vm_uid_ems)
     closeable_service = closeable_snapshots_service(ext_management_system, vm_uid_ems)

--- a/spec/models/manageiq/providers/redhat/infra_manager/operations/snapshot_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/operations/snapshot_spec.rb
@@ -47,4 +47,39 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe "#revert_to_snapshot_denied_message" do
+    let(:ems) { FactoryGirl.create(:ems_redhat_with_authentication) }
+    let(:vm)  { FactoryGirl.create(:vm_redhat, :ext_management_system => ems) }
+    let(:allowed_to_revert) { true }
+    let(:supported_api_versions) { [] }
+    let(:active) { true }
+    subject { vm.revert_to_snapshot_denied_message(active) }
+    before do
+      allow(vm).to receive(:allowed_to_revert?).and_return(allowed_to_revert)
+    end
+
+    context "allowed to revert" do
+      context "active snapshot" do
+        it { is_expected.to eq("Revert is not allowed for a snapshot that is the active one") }
+      end
+
+      context "inactive snapshot" do
+        let(:active) { false }
+        it { is_expected.to eq(nil) }
+      end
+    end
+
+    context "not allowed to revert" do
+      let(:allowed_to_revert) { false }
+      context "active snapshot" do
+        it { is_expected.to eq("Revert is allowed only when vm is down. Current state is on") }
+      end
+
+      context "inactive snapshot" do
+        let(:active) { false }
+        it { is_expected.to eq("Revert is allowed only when vm is down. Current state is on") }
+      end
+    end
+  end
 end


### PR DESCRIPTION
In the snapshot screen when the "active" snapshot is selected
the revert button should be disabled for RHV.

If VM is up, the 'revert' button is disabled due to VM status not 'DOWN'.
If VM is down and the active snapshot is selected, the 'revert' button
is disabled due to selection of 'active' snapshot.

http://bugzilla.redhat.com/1396068