### PR TITLE
Change RHVM to RHV

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -34,7 +34,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def self.description
-    @description ||= "Red Hat Virtualization Manager".freeze
+    @description ||= "Red Hat Virtualization".freeze
   end
 
   def self.default_blacklisted_event_names

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
   end
 
   it ".description" do
-    expect(described_class.description).to eq('Red Hat Virtualization Manager')
+    expect(described_class.description).to eq('Red Hat Virtualization')
   end
 
   describe ".metrics_collector_queue_name" do


### PR DESCRIPTION
Change "Red Hat Virtualization Manager" to "Red Hat Virtualization"

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1403358

This goes with:
https://github.com/ManageIQ/manageiq-ui-classic/pull/973
https://github.com/ManageIQ/manageiq/pull/14703