### PR TITLE
RHV VM not saving FQDN

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -533,6 +533,11 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
       guest_device[:network] = result.first unless guest_device.nil?
     end
 
+    # RHV reports hostname for the entire vm and not per specific network interface.
+    # Therefore, the hostname will be set for the first nic.
+    fqdn = inv.attributes.fetch_path(:guest_info, :fqdn)
+    result[0][:hostname] = fqdn if !result.blank? && fqdn
+
     result
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
@@ -169,6 +169,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         guest_device[:network] = result.first unless guest_device.nil?
       end
 
+      # RHV reports hostname for the entire vm and not per specific network interface.
+      # Therefore, the hostname will be set for the first nic.
+      result[0][:hostname] = inv.fqdn if !result.blank? && inv.respond_to?(:fqdn)
       result
     end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
@@ -391,7 +391,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(v.hardware.networks.size).to eq(1)
     network = v.hardware.networks.first
     expect(network).to have_attributes(
-      :hostname    => nil, # TODO: Should be miq-winxpsp3 (or something like that)?
+      :hostname    => "server.example.com",
       :ipaddress   => "192.168.253.45",
       :ipv6address => nil
     )

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -317,6 +317,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :product_name => "other"
     )
 
+    expect(v.hostnames).to match_array(%w(vm-18-82.eng.lab.tlv.redhat.com))
     expect(v.custom_attributes.size).to eq(0)
 
     expect(v.snapshots.size).to eq(2)

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1.yml
@@ -1218,7 +1218,7 @@ http_interactions:
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>715128832</guaranteed>\n
         \       </memory_policy>\n        <guest_info>\n            <ips>\n                <ip
-        address=\"192.168.253.45\"/>\n            </ips>\n        </guest_info>\n
+        address=\"192.168.253.45\"/>\n            </ips>\n        <fqdn>server.example.com</fqdn>        </guest_info>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </vm>\n    <vm href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
         id=\"4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\">\n        <actions>\n            <link


### PR DESCRIPTION
The PR allows to save the FQDN when it is reported by the VM's
guest agent.

https://bugzilla.redhat.com/show_bug.cgi?id=1417965