### PR TITLE
Move code from manageiq-gems-pending

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -305,7 +305,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     # Connect to the engine using version 3 of the API and the `ovirt` gem.
     def raw_connect_v3(options = {})
       require 'ovirt'
-      require 'ovirt_provider/inventory/ovirt_inventory'
+      require 'manageiq/providers/ovirt/legacy/inventory'
       Ovirt.logger = $rhevm_log
 
       params = {
@@ -321,7 +321,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       read_timeout, open_timeout = ems_timeouts(:ems_redhat, options[:service])
       params[:timeout]      = read_timeout if read_timeout
       params[:open_timeout] = open_timeout if open_timeout
-      const = options[:service] == "Inventory" ? OvirtInventory : Ovirt.const_get(options[:service])
+      const = options[:service] == "Inventory" ? ManageIQ::Providers::Ovirt::Legacy::Inventory : Ovirt.const_get(options[:service])
       conn = const.new(params)
       OvirtConnectionDecorator.new(conn)
     end

--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -1,7 +1,8 @@
+require 'manageiq/providers/ovirt/legacy/event_monitor'
+
 class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
   def event_monitor_handle
-    require 'ovirt_provider/events/ovirt_event_monitor'
-    @event_monitor_handle ||= OvirtEventMonitor.new(event_monitor_options)
+    @event_monitor_handle ||= ManageIQ::Providers::Ovirt::Legacy::EventMonitor.new(event_monitor_options)
   end
 
   def event_monitor_options

--- a/lib/manageiq/providers/ovirt/legacy/event_monitor.rb
+++ b/lib/manageiq/providers/ovirt/legacy/event_monitor.rb
@@ -1,0 +1,50 @@
+require 'ovirt'
+require 'manageiq/providers/ovirt/legacy/inventory'
+
+module ManageIQ
+  module Providers
+    module Ovirt
+      module Legacy
+        class EventMonitor
+          def initialize(options = {})
+            @options = options
+          end
+
+          def inventory
+            ::Ovirt.logger = $rhevm_log if $rhevm_log
+
+            @inventory ||= ManageIQ::Providers::Ovirt::Legacy::Inventory.new(@options)
+          end
+
+          def start
+            trap(:TERM) { $rhevm_log.info "EventMonitor#start: ignoring SIGTERM" }
+            @since          = nil
+            @inventory      = nil
+            @monitor_events = true
+          end
+
+          def stop
+            @monitor_events = false
+          end
+
+          def each_batch
+            while @monitor_events
+              # grab only the most recent event if this is the first time through
+              query_options = @since ? {:since => @since} : {:max => 1}
+              events = inventory.events(query_options).sort_by { |e| e[:id].to_i }
+              @since = events.last[:id].to_i unless events.empty?
+
+              yield events
+            end
+          end
+
+          def each
+            each_batch do |events|
+              events.each { |e| yield e }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/ovirt/legacy/inventory.rb
+++ b/lib/manageiq/providers/ovirt/legacy/inventory.rb
@@ -1,0 +1,215 @@
+require 'ovirt'
+
+module ManageIQ
+  module Providers
+    module Ovirt
+      module Legacy
+        class Inventory
+          attr_accessor :service
+
+          def initialize(options = {})
+            @service = ::Ovirt::Service.new(options)
+          end
+
+          def api
+            standard_collection('api').first
+          end
+
+          def capabilities
+            standard_collection("capabilities")
+          end
+
+          def clusters
+            standard_collection("clusters")
+          end
+
+          def datacenters
+            standard_collection("datacenters", "data_center")
+          end
+
+          def domains
+            standard_collection("domains")
+          end
+
+          def events(options = {})
+            if options[:since]
+              standard_collection("events?from=#{options[:since]}", "event")
+            elsif options[:max]
+              standard_collection("events;max=#{options[:max]}", "event", false, "time", :desc)
+            else
+              standard_collection("events")
+            end
+          end
+
+          def groups
+            standard_collection("groups")
+          end
+
+          def hosts
+            standard_collection("hosts", nil, true)
+          end
+
+          def networks
+            standard_collection("networks")
+          end
+
+          def roles
+            standard_collection("roles")
+          end
+
+          def storagedomains
+            standard_collection("storagedomains", "storage_domain", true)
+          end
+
+          def tags
+            standard_collection("tags")
+          end
+
+          def templates
+            standard_collection("templates")
+          end
+
+          def users
+            standard_collection("users")
+          end
+
+          def vms
+            standard_collection("vms", nil, true)
+          end
+
+          def vmpools
+            standard_collection("vmpools")
+          end
+
+          def get_vm(path)
+            vm_guid = ::File.basename(path, '.*')
+            vm      = get_resource_by_ems_ref("/api/vms/#{vm_guid}") rescue nil
+            vm      = get_resource_by_ems_ref("/api/templates/#{vm_guid}") if vm.blank?
+            vm
+          end
+
+          def get_resource_by_ems_ref(uri_suffix, element_name = nil)
+            @service.get_resource_by_ems_ref(uri_suffix, element_name)
+          end
+
+          def get_resources_by_uri_path(uri_suffix, element_name = nil)
+            @service.get_resources_by_uri_path(uri_suffix, element_name)
+          end
+
+          def refresh
+            # TODO: Change to not return native objects to the caller.  The caller
+            #       should just expect raw data.
+            primary_items = collect_primary_jobs(primary_item_jobs)
+            collect_secondary_items(primary_items, SECONDARY_ITEMS)
+          end
+
+          def targeted_refresh(methods)
+            primary_items = collect_primary_targeted_jobs(methods[:primary].to_a)
+            collect_secondary_items(primary_items, methods[:secondary])
+          end
+
+          def api_path
+            @service.api_path
+          end
+
+          private
+
+          def standard_collection(uri_suffix, element_name = nil, paginate = false, sort_by = :name, direction = :asc)
+            @service.standard_collection(uri_suffix, element_name, paginate, sort_by, direction)
+          end
+
+          # TODO: Remove this key/method translation and just use the method name as
+          #       the key directly.
+          PRIMARY_ITEMS = {
+            # Key          RHEVM API method
+            :cluster    => :clusters,
+            :vmpool     => :vmpools,
+            :network    => :networks,
+            :storage    => :storagedomains,
+            :datacenter => :datacenters,
+            :host       => :hosts,
+            :vm         => :vms,
+            :template   => :templates
+          }
+
+          SECONDARY_ITEMS = {
+            # Key          RHEVM API methods
+            :datacenter => [:storagedomains],
+            :host       => [:statistics, :host_nics], # :cdroms, tags
+            :vm         => [:disks, :snapshots, :nics],
+            :template   => [:disks]
+          }
+
+          def primary_item_jobs
+            PRIMARY_ITEMS.to_a
+          end
+
+          # Returns all combinations of primary resources and the methods to run on those resources.
+          #
+          # > secondary_item_jobs({:vm, => [v1, v2]})
+          #  => [[v1, :disks], [v1, :snapshots], [v1, :nics], [v2, :disks], [v2, :snapshots], [v2, :nics]]
+          def secondary_item_jobs(primary_items, secondary_items)
+            secondary_items.flat_map do |key, methods|
+              primary_items[key].product(methods)
+            end
+          end
+
+          def collect_primary_jobs(jobs)
+            results = collect_in_parallel(jobs) do |_, method|
+              send(method)
+            end
+
+            jobs.zip(results).each_with_object({}) do |((key, _), result), hash|
+              hash[key] = result
+            end
+          end
+
+          def collect_primary_targeted_jobs(jobs)
+            results = collect_in_parallel(jobs) do |key, ems_ref|
+              if ems_ref.kind_of?(Array)
+                ems_ref.flat_map { |item| get_resources_by_uri_path(item) rescue Array.new }
+              elsif ems_ref.kind_of?(Hash)
+                collection, element_name = ems_ref.first
+                standard_collection(collection, element_name, true)
+              else
+                get_resources_by_uri_path(ems_ref) rescue Array.new
+              end
+            end
+
+            jobs.zip(results).each_with_object({}) do |((key, _), result), hash|
+              hash[key] = result
+            end
+          end
+
+          def collect_secondary_items(primary_items, secondary_items)
+            jobs = secondary_item_jobs(primary_items, secondary_items)
+
+            results = collect_in_parallel(jobs) do |resource, method|
+              resource.send(method) rescue nil
+            end
+
+            jobs.zip(results).each do |(resource, method), result|
+              resource.attributes[method] = result
+            end
+
+            primary_items
+          end
+
+          def collect_in_parallel(jobs, &block)
+            require 'parallel'
+            Parallel.map(jobs, :in_threads => num_threads, &block)
+          end
+
+          def num_threads
+            use_threads? ? 8 : 0
+          end
+
+          # HACK: VCR is not threadsafe, and so tests running under VCR fail
+          def use_threads?
+            !defined?(VCR)
+          end
+        end
+      end
+    end
+  end
+end

--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -13,6 +13,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
+  s.add_runtime_dependency "ovirt", "~>0.15.0"
+  s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
+
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
Now that the oVirt provider has been extracted to a separate repository,
it makes sense to move all the oVirt specific code from
'manageiq-gems-pending' to this repository.

This patch moves the 'ovirt_event_monitor.rb' and 'ovirt_inventory.rb'
files. These files implement event monitoring and inventory collection,
using version 3 of the oVirt API and the 'ovirt' gem. As there is an
ongoing effort to use version 4 of the oVirt API, and the oVirt SDK,
these files have been added to a new 'ManageIQ::Providers::Ovirt::Legacy'
module, to make it explicit that this code will eventually be removed.

https://github.com/ManageIQ/manageiq-providers-ovirt/issues/8