### PR TITLE
Change method return value for consistency

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -234,7 +234,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
   end
 
   def highest_allowed_api_version
-    return 3 unless use_ovirt_sdk?
+    return '3' unless use_ovirt_sdk?
     highest_supported_api_version
   end
 


### PR DESCRIPTION
Change method highest_allowed_api_version return value from integer to string for consistency.