### PR TITLE
Update parse_new_target to standard refresh hashes

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/event_parsing/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_parsing/parser.rb
@@ -61,28 +61,34 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParsing
     end
 
     def self.parse_new_target(full_data, message, ems, event_type)
-      cluster = parse_new_cluster(ems, full_data[:cluster])
+      folders = parse_new_folders(full_data[:data_center])
+      dc      = folders.detect { |f| f[:type] == 'Datacenter' }
+
+      cluster = parse_new_cluster(ems, full_data[:cluster], dc)
       rp      = parse_new_rp(cluster)
-      dc      = parse_new_dc(full_data[:data_center])
-      vm      = parse_new_vm(ems, full_data[:vm], cluster, message, event_type)
+      vm      = parse_new_vm(ems, full_data[:vm], dc, cluster, message, event_type)
 
       target_hash = {
         :vms            => [vm],
         :clusters       => [cluster],
         :resource_pools => [rp],
-        :folders        => [dc]
+        :folders        => [*folders]
       }
 
       return target_hash, 'ManageIQ::Providers::Redhat::InfraManager::Vm', {:uid_ems => vm[:uid_ems]}
     end
 
-    def self.parse_new_vm(vm, message, event_type, ems)
+    def self.parse_new_vm(ems, vm_data, datacenter, cluster, message, event_type)
       ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm_data[:href])
       parser = ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::ParserBuilder.new(ems).build
 
       vm_hash = parser.create_vm_hash(ems_ref.include?('/templates/'), ems_ref, vm_data[:id], parse_target_name(message, event_type))
+
       vm_hash[:ems_cluster] = cluster
       cluster[:ems_children][:resource_pools].first[:ems_children][:vms] << vm_hash
+
+      vm_folder = datacenter[:ems_children][:folders].detect { |f| f[:name] == 'vm' }
+      vm_folder[:ems_children] = {:vms => [vm_hash]}
 
       vm_hash
     end
@@ -101,17 +107,22 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParsing
       end
     end
 
-    def self.parse_new_cluster(ems, cluster_data)
+    def self.parse_new_cluster(ems, cluster_data, datacenter)
       cluster_ref  = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(cluster_data[:href])
       cluster_name = ems.ovirt_services.cluster_name_href(cluster_ref)
 
-      {
-        :ems_ref     => cluster_ref,
-        :ems_ref_obj => cluster_ref,
-        :uid_ems     => cluster_data[:id],
-        :name        => cluster_name,
+      cluster_hash = {
+        :ems_ref      => cluster_ref,
+        :ems_ref_obj  => cluster_ref,
+        :uid_ems      => cluster_data[:id],
+        :name         => cluster_name,
         :ems_children => {:resource_pools => []}
       }
+
+      host_folder = datacenter[:ems_children][:folders].detect { |f| f[:name] == 'host' }
+      host_folder[:ems_children] = {:clusters => [cluster_hash]}
+
+      cluster_hash
     end
 
     def self.parse_new_rp(cluster)
@@ -127,11 +138,31 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParsing
       rp_hash
     end
 
-    def self.parse_new_dc(dc)
-      {
-        :type    => 'Datacenter',
-        :ems_ref => ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(dc[:href])
+    def self.parse_new_folders(dc)
+      vm_folder_hash = {
+        :type    => 'EmsFolder',
+        :name    => 'vm',
+        :uid_ems => "#{dc[:id]}_vm",
+        :hidden  => true
       }
+
+      host_folder_hash = {
+        :type    => 'EmsFolder',
+        :name    => 'host',
+        :uid_ems => "#{dc[:id]}_host",
+        :hidden  => true
+      }
+
+      dc_ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(dc[:href])
+      dc_hash = {
+        :type         => 'Datacenter',
+        :ems_ref      => dc_ems_ref,
+        :ems_ref_obj  => dc_ems_ref,
+        :uid_ems      => dc[:id],
+        :ems_children => {:folders => [vm_folder_hash, host_folder_hash]}
+      }
+
+      [dc_hash, vm_folder_hash, host_folder_hash]
     end
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
@@ -91,7 +91,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
       target_hash, target_klass, target_find = ep_class.parse_new_target(add_vm_event, description, @ems, name)
 
-      new_vm = VCR.use_cassette("#{described_class.name.underscore}_target_new_vm") do
+      new_vm = VCR.use_cassette("#{described_class.name.underscore}_target_new_vm", :allow_unused_http_interactions => true) do
         EmsRefresh.refresh_new_target(@ems, target_hash, target_klass, target_find)
       end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
@@ -81,7 +81,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     end
 
     it "should refresh new vm" do
-      allow(@ems.ovirt_services).to receive(:cluster_name_href).and_return(@cluster.name)
+      allow(@ems.ovirt_services).to receive(:cluster_name_href).with(@cluster.ems_ref).and_return(@cluster.name)
       allow(@ems.refresher).to      receive(:refresh)
 
       description = add_vm_event[:description]
@@ -95,10 +95,19 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         EmsRefresh.refresh_new_target(@ems, target_hash, target_klass, target_find)
       end
 
+      # Check the new vm's uid matches the event
       expect(new_vm.uid_ems).to eq(add_vm_event[:vm][:id])
 
-      expect(new_vm.ems_cluster).not_to be_nil
+      # Check that the new vm is linked up to a cluster
+      expect(new_vm.ems_cluster).not_to     be_nil
       expect(new_vm.ems_cluster.uid_ems).to eq(add_vm_event[:cluster][:id])
+
+      # Check that the vm and cluster are linked to a datacenter
+      expect(new_vm.parent_datacenter).not_to             be_nil
+      expect(new_vm.ems_cluster.parent_datacenter).not_to be_nil
+
+      expect(new_vm.parent_datacenter.uid_ems).to             eq(add_vm_event[:data_center][:id])
+      expect(new_vm.ems_cluster.parent_datacenter.uid_ems).to eq(add_vm_event[:data_center][:id])
     end
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
@@ -95,7 +95,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         EmsRefresh.refresh_new_target(@ems, target_hash, target_klass, target_find)
       end
 
+      expect(new_vm.uid_ems).to eq(add_vm_event[:vm][:id])
+
       expect(new_vm.ems_cluster).not_to be_nil
+      expect(new_vm.ems_cluster.uid_ems).to eq(add_vm_event[:cluster][:id])
     end
   end
 


### PR DESCRIPTION
This will allow `parse_new_target` to work with standard `save_ems_inventory`