### PR TITLE
Use version 0.16.0 of the 'ovirt' gem

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "ovirt", "~>0.15.0"
+  s.add_runtime_dependency "ovirt", "~>0.16.0"
   s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
The new version of the gem fixes the following problems:

  Add VM FQDN to guest_info
  https://bugzilla.redhat.com/1417965

  Fix handling of version 4.y in Vm.attach_payload
  https://bugzilla.redhat.com/1441746