### PR TITLE
Handle blocks when using `method_missing`

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -198,16 +198,16 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
     end
 
     class GeneralUpdateMethodNamesDecorator < SimpleDelegator
-      def method_missing(method_name, *args)
+      def method_missing(method_name, *args, &block)
         str_method_name = method_name.to_s
         if str_method_name =~ /update_.*!/
           attribute_to_update = str_method_name.split("update_")[1].delete('!')
-          send("#{attribute_to_update}=", *args)
+          send("#{attribute_to_update}=", *args, &block)
         else
           # This is requied becasue of Ovirt::Vm strage behaviour - while rhevm.respond_to?(:nics)
           # returns false, rhevm.nics actually works.
           begin
-            __getobj__.send(method_name, *args)
+            __getobj__.send(method_name, *args, &block)
           rescue NoMethodError
             super
           end


### PR DESCRIPTION
Currently the mechanism used to support version 3 of the oVirt API uses
the Ruby `method_missing` mechanism to transform certain method calls
that are intended for the Ruby SDK into the corresponding methods of the
`ovirt` gem. But the implementation didn't take into account that some
of those methods take blocks as parameters. For example, the `start`
method of the `Vm` class takes a block that is used to customize the
request body, in particular to include the `use_cloud_init`parameter:

```ruby
# From .../ovirt_services/strategies/v3.rb:
def vm_start(vm, cloud_init)
  vm.with_provider_object do |rhevm_vm|
    rhevm_vm.start { |action| action.use_cloud_init(true) if cloud_init }
  end
rescue Ovirt::VmAlreadyRunning
end
```

With the current implementation those blocks are silently ignored. That
means, for example, that virtual machines are always started with
cloud-init disabled, even if ManageIQ is explicitly enabling it. To fix
that issue this patch changes the use of `method_missing`so that it
also handles correctly the passed blocks.

https://bugzilla.redhat.com/1448231