### PR TITLE
Fix host targeted refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
     result[:storages], uids[:storages] = storage_inv_to_hashes(inv[:storage])
     result[:clusters], uids[:clusters], result[:resource_pools] = cluster_inv_to_hashes(inv[:cluster])
     result[:hosts], uids[:hosts], uids[:lans], uids[:switches], uids[:guest_devices], uids[:scsi_luns] = host_inv_to_hashes(inv[:host], inv, uids[:clusters], uids[:storages])
-    vms_inv = inv[:vm] + inv[:template]
+    vms_inv = Array(inv[:vm]) + Array(inv[:template])
     result[:vms], uids[:vms], added_hosts_from_vms =
       vm_inv_to_hashes(vms_inv, inv[:storage], uids[:storages], uids[:clusters], uids[:hosts], uids[:lans])
     result[:folders] = datacenter_inv_to_hashes(inv[:datacenter], uids[:clusters], uids[:vms], uids[:storages], uids[:hosts])

--- a/lib/manageiq/providers/ovirt/legacy/inventory.rb
+++ b/lib/manageiq/providers/ovirt/legacy/inventory.rb
@@ -92,8 +92,8 @@ module ManageIQ
             @service.get_resource_by_ems_ref(uri_suffix, element_name)
           end
 
-          def get_resources_by_uri_path(uri_suffix, element_name = nil)
-            @service.get_resources_by_uri_path(uri_suffix, element_name)
+          def get_resources_by_uri_path(uri_suffix, element_name = nil, xpath = nil)
+            @service.get_resources_by_uri_path(uri_suffix, element_name, xpath)
           end
 
           def refresh
@@ -166,13 +166,14 @@ module ManageIQ
 
           def collect_primary_targeted_jobs(jobs)
             results = collect_in_parallel(jobs) do |key, ems_ref|
+              xpath = key == :host ? '/host' : nil
               if ems_ref.kind_of?(Array)
-                ems_ref.flat_map { |item| get_resources_by_uri_path(item) rescue Array.new }
+                ems_ref.flat_map { |item| get_resources_by_uri_path(item, nil, xpath) rescue Array.new }
               elsif ems_ref.kind_of?(Hash)
                 collection, element_name = ems_ref.first
                 standard_collection(collection, element_name, true)
               else
-                get_resources_by_uri_path(ems_ref) rescue Array.new
+                get_resources_by_uri_path(ems_ref, nil, xpath) rescue Array.new
               end
             end
 

--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "ovirt", "~>0.16.0"
+  s.add_runtime_dependency "ovirt", "~>0.17.0"
   s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
The PR handles two issues with host targeting refresh:
1. When targeting a refresh of a single host, no vms or templates are
reported. Therefore the vm or template collected array should be handled
in case of nil.

2. In V3 the host resources retrieved by
/ovirt-engine/api/hosts/{host:id} contains the statistics element. The
statistics element contains a reference to the host element. The xpath
used to collect similar host entries considered the host sub-element
as a resource to collect, which lead to collecting the same host
multiple times. By specifying the exact top level host path, this will
be avoided.

https://bugzilla.redhat.com/show_bug.cgi?id=1448690