### PR TITLE
Fix host targeted refresh in v4

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
@@ -14,6 +14,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
         @connection = connection
         res = {}
         res[:host] = collect_host(get_uuid_from_target(target))
+        res[:network] = collect_networks
         res
       end
     end


### PR DESCRIPTION
When performing host targeted refresh in v4, the networks should be
collected as well, so the vlan and network name will be updated for the
host.

http://bugzilla.redhat.com/1449092