### PR TITLE
Fix fetching ISO images from non active domains

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -107,10 +107,10 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     @rhevm_inventory ||= connect(:service => "Inventory")
   end
 
-  def ovirt_services
+  def ovirt_services(args = {})
     @ovirt_services ||= begin
                           ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Builder.new(self)
-                                                                                           .build.new(:ems => self)
+                                                                                           .build(args).new(:ems => self)
                         end
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -190,6 +190,16 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       _log.info("#{log_header} Completed.")
     end
 
+    def advertised_images
+      ext_management_system.with_provider_connection do |rhevm|
+        rhevm.iso_images.collect { |image| image[:name] }
+      end
+    rescue Ovirt::Error => err
+      name = ext_management_system.try(:name)
+      _log.error("Error Getting ISO Images on ISO Datastore on Management System <#{name}>: #{err.class.name}: #{err}")
+      raise ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error, err
+    end
+
     class NicsDecorator < SimpleDelegator
       def name
         self[:name]

--- a/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4_spec.rb
@@ -1,0 +1,73 @@
+describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4 do
+  describe "#advertised_images" do
+    let(:ems) { FactoryGirl.create(:ems_redhat_with_authentication) }
+    let(:vm) { FactoryGirl.create(:vm_redhat, :ext_management_system => ems) }
+    let(:ems_service) { instance_double(OvirtSDK4::Connection) }
+    let(:system_service) { instance_double(OvirtSDK4::SystemService) }
+    let(:data_centers_service) { instance_double(OvirtSDK4::DataCentersService) }
+    let(:data_center_up) { OvirtSDK4::DataCenter.new(:status => OvirtSDK4::DataCenterStatus::UP) }
+    let(:data_center_down) { OvirtSDK4::DataCenter.new(:status => OvirtSDK4::DataCenterStatus::MAINTENANCE) }
+    let(:active_data_centers) { [data_center_up] }
+    let(:storage_domain_list_1) { instance_double(OvirtSDK4::List) }
+    let(:storage_domains) { [storage_domain_data, storage_domain_iso_down, storage_domain_iso_up] }
+    let(:storage_domain_data) { OvirtSDK4::StorageDomain.new(:status => nil, :type => "data") }
+    let(:storage_domain_iso_down) { OvirtSDK4::StorageDomain.new(:status => "maintenance", :type => "iso") }
+    let(:storage_domain_iso_up) { OvirtSDK4::StorageDomain.new(:status => "active", :type => "iso", :id => "iso_sd_id") }
+    let(:storage_domains_service) { instance_double(OvirtSDK4::StorageDomainsService) }
+    let(:storage_domain_iso_up_service) { instance_double(OvirtSDK4::StorageDomainService) }
+    let(:files_service) { instance_double(OvirtSDK4::FilesService) }
+    let(:iso_images) { [double("iso1", :name => "iso_1"), double("iso2", :name => "iso_2")] }
+    let(:query) { { :search => "status=#{OvirtSDK4::DataCenterStatus::UP}" } }
+
+    before do
+      allow(ems).to receive(:with_provider_connection).and_yield(ems_service)
+      allow(ems_service).to receive(:system_service).and_return(system_service)
+      allow(system_service).to receive(:data_centers_service).and_return(data_centers_service)
+      allow(data_centers_service).to receive(:list).with(:query => query).and_return(active_data_centers)
+      allow(data_center_up).to receive(:storage_domains).and_return(storage_domain_list_1)
+      allow(ems_service).to receive(:follow_link).with(storage_domain_list_1).and_return(storage_domains)
+      allow(system_service).to receive(:storage_domains_service).and_return(storage_domains_service)
+      allow(storage_domains_service).to receive(:storage_domain_service).with(storage_domain_iso_up.id).and_return(storage_domain_iso_up_service)
+      allow(storage_domain_iso_up_service).to receive(:files_service).and_return(files_service)
+      allow(files_service).to receive(:list).and_return(iso_images)
+    end
+
+    subject(:advertised_images) do
+      described_class.new(:ems => ems).advertised_images
+    end
+
+    context "there is a an active data-center" do
+      context "there are iso domains attached to the data-center" do
+        context "there are active iso domains" do
+          it 'returns iso images from an active domain' do
+            expect(advertised_images).to match_array(%w(iso_1 iso_2))
+          end
+        end
+
+        context "there are no active iso domains" do
+          let(:storage_domains) { [storage_domain_data, storage_domain_iso_down] }
+
+          it 'returns an empty array' do
+            expect(advertised_images).to match_array([])
+          end
+        end
+      end
+
+      context "there are no iso domains attached to the data-center" do
+        let(:storage_domains) { [storage_domain_data] }
+
+        it 'returns an empty array' do
+          expect(advertised_images).to match_array([])
+        end
+      end
+    end
+
+    context "there are no active data-centers" do
+      let(:active_data_centers) { [] }
+
+      it 'returns an empty array' do
+        expect(advertised_images).to match_array([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix fetching ISO images from non active domains

We used to ignore the data-center level when looking for an ISO domain,
as a result we would sometimes take an ISO domain which was not attached to
an active data-center.
We now first find a data-center which is "up" and then take an ISO domain which is
attached to it and is active.
This fix is applied for providers that support version 4 of the api.

https://bugzilla.redhat.com/show_bug.cgi?id=1447560

Please note: this PR will have an actual effect only when https://github.com/ManageIQ/manageiq/pull/15053 is merged.
