### PR TITLE
Allow to receive datastore by name or by id

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/disk.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/disk.rb
@@ -36,14 +36,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Disk
   end
 
   def prepare_disk_for_add(disk_spec)
-    storage_name = disk_spec[:datastore]
-    raise MiqException::MiqProvisionError, "Storage is required for disk: <#{disk_spec.inspect}>" if storage_name.blank?
-
-    storage = Storage.find_by(:name => storage_name)
-    if storage.nil?
-      raise MiqException::MiqProvisionError, "Unable to find storage: <#{storage_name}> for disk: <#{disk_spec.inspect}>"
-    end
-
+    storage = find_storage!(disk_spec)
     da_options = {
       :size_in_mb       => disk_spec[:sizeInMB],
       :storage          => storage,
@@ -55,5 +48,21 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Disk
 
     disk_attachment_builder = ManageIQ::Providers::Redhat::InfraManager::DiskAttachmentBuilder.new(da_options)
     disk_attachment_builder.disk_attachment
+  end
+
+  def find_storage!(disk_spec)
+    storage_id = disk_spec[:datastore_id]
+    storage_name = disk_spec[:datastore]
+    if storage_name.blank? && storage_id.blank?
+      raise MiqException::MiqProvisionError, "Storage is required for disk: <#{disk_spec.inspect}>"
+    end
+
+    storage = Storage.search_by_id_or_name(storage_id, storage_name)
+    if storage.nil?
+      error = "Unable to find storage: <#{storage_id || storage_name}> for disk: <#{disk_spec.inspect}>"
+      raise MiqException::MiqProvisionError, error
+    end
+
+    storage
   end
 end


### PR DESCRIPTION
Datastores on the same setup may have the same name. In order to add a
disk on a specific datastore, it is better to use the datastore id.

https://bugzilla.redhat.com/show_bug.cgi?id=1450952
https://bugzilla.redhat.com/show_bug.cgi?id=1427498