### PR TITLE
Broken host targeted refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
@@ -13,6 +13,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
       ems.with_provider_connection(VERSION_HASH) do |connection|
         @connection = connection
         res = {}
+        res[:cluster] = collect_cluster(get_uuid_from_target(target.ems_cluster))
         res[:host] = collect_host(get_uuid_from_target(target))
         res[:network] = collect_networks
         res
@@ -58,6 +59,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
 
     def collect_clusters
       connection.system_service.clusters_service.list
+    end
+
+    def collect_cluster(uuid)
+      Array(connection.system_service.clusters_service.cluster_service(uuid).get)
     end
 
     def collect_storages

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
@@ -3,6 +3,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
     def host_targeted_refresh(inventory, target)
       methods = {
         :primary   => {
+          :cluster => target.ems_cluster.ems_ref,
           :host    => target.ems_ref,
           :network => { :networks => "network" }
         },


### PR DESCRIPTION
When we target refresh for a host there is an issue when parsing
because parser code depends on availability of a cluster hash.

We fix this issue by fetching host cluster for this type of a refresh.

Bug:
https://bugzilla.redhat.com/1393942