### PR TITLE
Fix provisioning PXE for version 4

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -229,6 +229,12 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       end
     end
 
+    def find_mac_address_on_network(nics, network, log)
+      nic = nics.detect { |n| n.network.try(:id) == network[:id] }
+      log.warn "Cannot find NIC with network id=#{network[:id].inspect}" if nic.nil?
+      nic && nic[:mac] && nic[:mac][:address]
+    end
+
     private
 
     #

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -344,6 +344,16 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       URI(ems_ref).path.split('/').last
     end
 
+    def find_mac_address_on_network(nics, network, log)
+      ext_management_system.with_provider_connection(VERSION_HASH) do |connection|
+        nic = nics.detect do |n|
+          connection.follow_link(n.vnic_profile).network.id == network[:id]
+        end
+        log.warn "Cannot find NIC with network id=#{network[:id].inspect}" if nic.nil?
+        nic && nic.mac && nic.mac.address
+      end
+    end
+
     private
 
     #

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/network.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/network.rb
@@ -24,10 +24,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Netw
     network = find_network_in_cluster(get_option(:vlan))
     return nil if network.nil?
 
-    nic = find_nic_on_network(network)
-    return nil if nic.nil?
-
-    nic[:mac][:address]
+    find_mac_address_on_network(network)
   end
 
   private
@@ -48,11 +45,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Netw
     destination.ext_management_system.ovirt_services.nics_for_vm(destination)
   end
 
-  def find_nic_on_network(network)
-    nic = nics.detect { |n| n.network.try(:id) == network[:id] }
-
-    _log.warn "Cannot find NIC with network id=#{network[:id].inspect}" if nic.nil?
-    nic
+  def find_mac_address_on_network(network)
+    destination.ext_management_system.ovirt_services.find_mac_address_on_network(nics, network, _log)
   end
 
   def configure_dialog_nic

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
@@ -117,6 +117,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
   end
 
   context "#get_mac_address_of_nic_on_requested_vlan" do
+    before do
+      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => false } })
+    end
+
     it "NIC found" do
       expect(@task.get_mac_address_of_nic_on_requested_vlan).to eq(mac_address)
     end


### PR DESCRIPTION
Part of the PXE provisioning process which had to do with finding the mac address
was broken. It is now fixed and split between ovirt_services for v3 and v4.

https://bugzilla.redhat.com/show_bug.cgi?id=1454861