### PR TITLE
Use only cached version for vm import check

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
@@ -38,7 +38,7 @@ module ManageIQ::Providers::Redhat::InfraManager::VmImport
   end
 
   def validate_import_vm
-    highest_supported_api_version && highest_supported_api_version >= '4'
+    Gem::Version.new(api_version) >= Gem::Version.new('4')
   end
 
   private

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
@@ -70,12 +70,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::VmImport do
     let(:ems) { FactoryGirl.create(:ems_redhat) }
 
     it 'validates successfully' do
-      allow(ems).to receive(:highest_supported_api_version).and_return('4')
+      allow(ems).to receive(:api_version).and_return('4')
       expect(ems.validate_import_vm).to be_truthy
     end
 
     it 'validates before connecting' do
-      allow(ems).to receive(:highest_supported_api_version).and_return(nil)
+      allow(ems).to receive(:api_version).and_return(nil)
       expect(ems.validate_import_vm).to be_falsey
     end
   end


### PR DESCRIPTION
When called from UI context (i.e. an appliance with only UI role) the provider
model may not see the actual RHEV instance (by not having the ems_operations
role). This may be a problem in complex production environments so here we do
the safe fallback - when the version is nil we mark the import as not
supported.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1449