### PR TITLE
Misleading message when provider is down

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -88,6 +88,9 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
   end
 
   def supports_the_api_version?(version)
+    if supported_api_versions.empty?
+      raise MiqException::MiqUnreachableError, "Not able to connect to the server."
+    end
     supported_api_versions.map(&:to_s).include?(version.to_s)
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher_builder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher_builder.rb
@@ -9,6 +9,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
     def build
       strategy_model = ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
       api_version = ext_management_system.highest_allowed_api_version
+      if api_version.nil?
+        # versions not fetched due to connectivity issues
+        api_version = '4'
+      end
       "#{strategy_model}::Api#{api_version}".constantize
     end
   end


### PR DESCRIPTION
When a provider is down there is incorrect message displayed on the UI.
The cause of it is that we are unable to get supported versions from a
server. This PR fixes error handling which provide meaningful message.

Bug:
https://bugzilla.redhat.com/1452157