### PR TITLE
Parse ems attributes like normal inventory

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
   def self.ems_inv_to_hashes(inv)
     uids = {}
     result = {:uid_lookup => uids}
+    result[:ems] = inv[:ems]
     result[:storages], uids[:storages] = storage_inv_to_hashes(inv[:storage])
     result[:clusters], uids[:clusters], result[:resource_pools] = cluster_inv_to_hashes(inv[:cluster])
     result[:hosts], uids[:hosts], uids[:lans], uids[:switches], uids[:guest_devices], uids[:scsi_luns] = host_inv_to_hashes(inv[:host], inv, uids[:clusters], uids[:storages])

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
@@ -22,12 +22,11 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
 
         end
 
+        data[:ems] = {:api_version => inventory.service.version_string}
+
         _log.info "Filtering inventory...Complete"
         [target, data]
       end
-
-      ems.api_version = inventory.service.version_string
-      ems.save
 
       targets_with_data
     end


### PR DESCRIPTION
Don't update the ems directly from the refresh_parser

~~Depends: https://github.com/ManageIQ/manageiq/pull/15252~~