### PR TITLE
Fix unhandled exception in metrics collection when missing credentials

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
@@ -31,8 +31,13 @@ class ManageIQ::Providers::Redhat::InfraManager::MetricsCapture < ManageIQ::Prov
   #
 
   def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
-    log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
+    target_description = "[#{target.class.name}], [#{target.id}], [#{target.name}]"
+    unless target.ext_management_system.has_authentication_type?(:metrics)
+      _log.warn("No C&U credentials defined for: #{target_description} returning empty stats")
+      return {}, {}
+    end
 
+    log_header = "[#{interval_name}] for: #{target_description}"
     start_time ||= Metric::Capture.historical_start_time
 
     begin

--- a/spec/models/manageiq/providers/redhat/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/metrics_capture_spec.rb
@@ -12,5 +12,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::MetricsCapture do
       expect(OvirtMetrics).to receive(:host_realtime).with(host.uid_ems, start_time, nil)
       host.perf_collect_metrics("realtime")
     end
+
+    context 'ems has no metrics authentication' do
+      let(:ems) { FactoryGirl.create(:ems_redhat) }
+      it 'returns empty results when no credentials are defined' do
+        expect(host.perf_collect_metrics("realtime")).to eq([{}, {}])
+      end
+    end
   end
 end


### PR DESCRIPTION
When trying to collect C&U data from an Ovirt provider with missing credentials a warning will
be shown in the log but no exception will be risen.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1450644