### PR TITLE
Disable delete button for the active snapshot on oVirt

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
@@ -60,6 +60,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
     return _("Revert is not allowed for a snapshot that is the active one") if active
   end
 
+  def remove_snapshot_denied_message(active = false)
+    return _("Delete is not allowed for a snapshot that is the active one") if active
+  end
+
   def snapshotting_memory_allowed?
     current_state == 'on'
   end


### PR DESCRIPTION
Disable the delete button when the active snapshot is selected
for a vm on oVirt.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1443411

Required for: https://github.com/ManageIQ/manageiq-ui-classic/pull/1628