### PR TITLE
Use 'ovirt' >= 0.17.1

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "ovirt", "~>0.17.0"
+  s.add_runtime_dependency "ovirt", "~>0.17.1"
   s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
Version 0.17.1 of the 'ovirt' gem fixes an issue with the Content-Type
and Accept headers sent to the oVirt server. See the following pull
request for details:

  Use 'application/xml' explicitly
  https://github.com/ManageIQ/ovirt/pull/83

This patch is related to the fix for the following bug:

  Can't Provision Vm via V3 (using ovirt gem)
  https://bugzilla.redhat.com/1466417