### PR TITLE
Support host maintenance actions

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/host.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/host.rb
@@ -24,4 +24,34 @@ class ManageIQ::Providers::Redhat::InfraManager::Host < ::Host
       unsupported_reason_add(:quick_stats, 'RHV API version does not support quick_stats')
     end
   end
+
+  def validate_enter_maint_mode
+    return inactive_provider_message unless has_active_ems?
+
+    result = validate_power_state('on')
+    return result unless result.nil?
+
+    { :available => true, :message => nil }
+  end
+
+  def validate_exit_maint_mode
+    return inactive_provider_message unless has_active_ems?
+
+    result = validate_power_state('maintenance')
+    return result unless result.nil?
+
+    { :available => true, :message => nil }
+  end
+
+  def inactive_provider_message
+    { :available => false, :message => _('The Host is not connected to an active provider') }
+  end
+
+  def enter_maint_mode
+    ext_management_system.ovirt_services.host_deactivate(self)
+  end
+
+  def exit_maint_mode
+    ext_management_system.ovirt_services.host_activate(self)
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -206,6 +206,14 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       raise ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error, err
     end
 
+    def host_activate(host)
+      host.with_provider_object(&:activate)
+    end
+
+    def host_deactivate(host)
+      host.with_provider_object(&:deactivate)
+    end
+
     def event_fetcher
       EventFetcher.new(ext_management_system)
     end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -279,6 +279,14 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       raise ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error, err
     end
 
+    def host_activate(host)
+      host.with_provider_object(&:activate)
+    end
+
+    def host_deactivate(host)
+      host.with_provider_object(&:deactivate)
+    end
+
     class VmProxyDecorator < SimpleDelegator
       attr_reader :service
       def initialize(vm, service)


### PR DESCRIPTION
The patch adds support for host maintenance actions (activate
and deactivate host) to the host power operations.