### PR TITLE
v2v: Normalize drivers_iso to nil on empty string

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
@@ -28,7 +28,7 @@ module ManageIQ::Providers::Redhat::InfraManager::VmImport
       :cluster_id        => EmsCluster.find(target_params[:cluster_id]).uid_ems,
       :storage_domain_id => Storage.find(target_params[:storage_id]).ems_ref_obj.split('/').last,
       :sparse            => target_params[:sparse],
-      :drivers_iso       => target_params[:drivers_iso]
+      :drivers_iso       => target_params[:drivers_iso] != '' ? target_params[:drivers_iso] : nil
     )
   end
 


### PR DESCRIPTION
When the "Install Drivers" option was unchecked an '' empty string value was
passed to the backend as the ISO name which resulted in an incorrect path being
sent to the RHV api, in turn causing a failure.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1467795