### PR TITLE
Getting nics for templates is not required during refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
@@ -199,7 +199,6 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
       def initialize(template, connection, preloaded_disks = nil)
         @obj = template
         @disks = AttachedDisksFetcher.get_attached_disks(template, connection, preloaded_disks)
-        @nics = connection.follow_link(template.nics)
         super(template)
       end
     end

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -396,7 +396,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
     hardware_disks(persister_hardware, disks)
     addresses = hardware_networks(persister_hardware, vm) unless template
-    hardware_guest_devices(persister_hardware, vm, addresses)
+    hardware_guest_devices(persister_hardware, vm, addresses) unless template
   end
 
   def hardware_networks(persister_hardware, vm)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/templates.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/templates.yml
@@ -3,7 +3,6 @@
   :__v2__:
   - :@obj
   - :@disks
-  - :@nics
   ? - &1 !ruby/object:OvirtSDK4::Template
       href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
       comment: 
@@ -222,16 +221,11 @@
         ivars:
           :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/watchdogs"
     - []
-    - !ruby/array:OvirtSDK4::List
-      internal: []
-      ivars:
-        :@href: 
   : *1
 - !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::TemplatePreloadedAttributesDecorator
   :__v2__:
   - :@obj
   - :@disks
-  - :@nics
   ? - &2 !ruby/object:OvirtSDK4::Template
       href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79"
       comment: 
@@ -607,105 +601,11 @@
         storage_type: image
         uses_scsi_reservation: 
         wipe_after_delete: false
-    - !ruby/array:OvirtSDK4::List
-      internal:
-      - !ruby/object:OvirtSDK4::Nic
-        href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/nics/b2761a52-fdfb-4424-8ef9-8ec49335bfb4"
-        comment: 
-        description: 
-        id: b2761a52-fdfb-4424-8ef9-8ec49335bfb4
-        name: nic1
-        instance_type: 
-        template: !ruby/object:OvirtSDK4::Template
-          href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79"
-          comment: 
-          description: 
-          id: 785e845e-baa0-4812-8a8c-467f37ad6c79
-          name: 
-          bios: 
-          cluster: 
-          console: 
-          cpu: 
-          cpu_profile: 
-          cpu_shares: 
-          creation_time: 
-          custom_compatibility_version: 
-          custom_cpu_model: 
-          custom_emulated_machine: 
-          custom_properties: 
-          delete_protected: 
-          display: 
-          domain: 
-          high_availability: 
-          initialization: 
-          io: 
-          large_icon: 
-          memory: 
-          memory_policy: 
-          migration: 
-          migration_downtime: 
-          origin: 
-          os: 
-          quota: 
-          rng_device: 
-          serial_number: 
-          small_icon: 
-          soundcard_enabled: 
-          sso: 
-          start_paused: 
-          stateless: 
-          storage_domain: 
-          time_zone: 
-          tunnel_migration: 
-          type: 
-          usb: 
-          virtio_scsi: 
-          cdroms: 
-          disk_attachments: 
-          graphics_consoles: 
-          nics: 
-          permissions: 
-          status: 
-          tags: 
-          version: 
-          vm: 
-          watchdogs: 
-        vm: 
-        vms: 
-        boot_protocol: 
-        interface: virtio
-        linked: true
-        mac: 
-        network: 
-        network_attachments: 
-        network_labels: 
-        on_boot: 
-        plugged: true
-        reported_devices: 
-        statistics: 
-        virtual_function_allowed_labels: 
-        virtual_function_allowed_networks: 
-        vnic_profile: !ruby/object:OvirtSDK4::VnicProfile
-          href: "/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903"
-          comment: 
-          description: 
-          id: 361634d2-4975-4ef7-8429-c009871ce903
-          name: 
-          custom_properties: 
-          network: 
-          network_filter: 
-          pass_through: 
-          permissions: 
-          port_mirroring: 
-          qos: 
-      ivars:
-        :@href: 
   : *2
 - !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::TemplatePreloadedAttributesDecorator
   :__v2__:
   - :@obj
   - :@disks
-  - :@nics
   ? - &3 !ruby/object:OvirtSDK4::Template
       href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b"
       comment: 
@@ -972,8 +872,4 @@
         ivars:
           :@href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/watchdogs"
     - []
-    - !ruby/array:OvirtSDK4::List
-      internal: []
-      ivars:
-        :@href: 
   : *3

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -171,7 +171,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(CustomAttribute.count).to eq(0) # TODO: 3.0 spec has values for this
     expect(CustomizationSpec.count).to eq(0)
     expect(Disk.count).to eq(5)
-    expect(GuestDevice.count).to eq(7)
+    expect(GuestDevice.count).to eq(6)
     expect(Hardware.count).to eq(13)
     # the old code expects 3 and new 2
     expect(Lan.count).to eq(lan_number)
@@ -716,8 +716,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     )
     expect(disk.storage).to eq(@storage)
 
-    expect(v.hardware.guest_devices.size).to eq(1)
-    expect(v.hardware.nics.size).to eq(1)
+    expect(v.hardware.guest_devices.size).to eq(0)
+    expect(v.hardware.nics.size).to eq(0)
     expect(v.hardware.networks.size).to eq(0)
 
     expect(v.parent_datacenter).to have_attributes(


### PR DESCRIPTION
Remove getting the nics of templates during full refresh v4 and graph refresh.