### PR TITLE
Support memory limit

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -146,4 +146,9 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   def supports_migrate_for_all?(vms)
     vms.map(&:ems_cluster).uniq.compact.size == 1
   end
+
+  def version_higher_than?(version)
+    ems_version = api_version[/\d+\.\d+/x]
+    Gem::Version.new(ems_version) >= Gem::Version.new(version)
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -268,6 +268,11 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
           end
         end
       end
+
+      def update_memory!(memory, _limit = nil)
+        # memory limit is not supported in v3
+        self.memory= memory
+      end
     end
 
     def get_mac_address_of_nic_on_requested_vlan(args)

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -307,9 +307,10 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
         update(vm)
       end
 
-      def update_memory!(memory)
+      def update_memory!(memory, limit)
         vm = get
-        vm.memory = memory
+        vm.memory = memory unless memory.zero?
+        vm.memory_policy.max = limit unless limit.zero?
         update(vm)
       end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/container.rb
@@ -9,9 +9,12 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Cont
 
   def configure_memory(rhevm_vm)
     vm_memory = get_option(:vm_memory).to_i * 1.megabyte
-    return if vm_memory.zero?
-    _log.info "Setting memory to:<#{vm_memory.inspect}>"
-    rhevm_vm.update_memory!(vm_memory)
+    memory_limit = get_option(:memory_limit).to_i * 1.megabyte
+    return if vm_memory.zero? && memory_limit.zero?
+
+    limit_message = ", total: <#{memory_limit}>" unless memory_limit.zero?
+    _log.info("Setting memory to:<#{vm_memory.inspect}>#{limit_message}")
+    rhevm_vm.update_memory!(vm_memory, memory_limit)
   end
 
   def configure_memory_reserve(rhevm_vm)

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
@@ -62,6 +62,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
 
         additional = {
           :memory_reserve    => vm_memory_reserve(vm_inv),
+          :memory_limit      => extract_vm_memory_policy(vm_inv, :max),
           :raw_power_state   => raw_power_state,
           :boot_time         => boot_time,
           :connection_state  => 'connected',
@@ -280,7 +281,11 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
     require 'ostruct'
 
     def vm_memory_reserve(vm_inv)
-      in_bytes = vm_inv.dig(:memory_policy, :guaranteed)
+      extract_vm_memory_policy(vm_inv, :guaranteed)
+    end
+
+    def extract_vm_memory_policy(vm_inv, type)
+      in_bytes = vm_inv.dig(:memory_policy, type)
       in_bytes.nil? ? nil : in_bytes / Numeric::MEGABYTE
     end
   end

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -324,4 +324,34 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       end
     end
   end
+
+  context "#version_higher_than?" do
+    let(:api_version) { "4.2" }
+    let(:ems) { FactoryGirl.create(:ems_redhat, :api_version => api_version) }
+
+    context "api version is higher or equal than checked version" do
+      it 'supports the right features' do
+        expect(ems.version_higher_than?("4.1")).to be_truthy
+
+        ems.api_version = "4.1.3.2-0.1.el7"
+        expect(ems.version_higher_than?("4.1")).to be_truthy
+
+        ems.api_version = "4.2.0_master"
+        expect(ems.version_higher_than?("4.1")).to be_truthy
+      end
+    end
+
+    context "api version is lowergit  than checked version" do
+      let(:api_version) { "4.0" }
+      it 'supports the right features' do
+        expect(ems.version_higher_than?("4.1")).to be_falsey
+
+        ems.api_version = "4.0.3.2-0.1.el7"
+        expect(ems.version_higher_than?("4.1")).to be_falsey
+
+        ems.api_version = "4.0.0_master"
+        expect(ems.version_higher_than?("4.1")).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
Memory limit feature was introduced in RHV 4.1.
It is already supported by manageiq as part of the vm provision process.
The patch adds support for total memory for providers of version 4.1 and
above, both for VM provision and for the VM refresh process.

https://bugzilla.redhat.com/show_bug.cgi?id=1461560