### PR TITLE
Use nil ca_certs to trust system CAs

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -284,6 +284,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       # values, so we need to check the value passed and make a list only if it won't be empty. If it will be empty then
       # we should just pass 'nil'.
       ca_certs = options[:ca_certs]
+      ca_certs = nil if ca_certs.blank?
       ca_certs = [ca_certs] if ca_certs
 
       url = URI::Generic.build(
@@ -310,6 +311,11 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       require 'manageiq/providers/ovirt/legacy/inventory'
       Ovirt.logger = $rhevm_log
 
+      # If 'ca_certs' is an empty string then the 'ovirt' gem will trust nothing, but we want it to trust the system CA
+      # certificates. To get that behaviour we need to pass 'nil' instead of the empty string.
+      ca_certs = options[:ca_certs]
+      ca_certs = nil if ca_certs.blank?
+
       params = {
         :server     => options[:server],
         :port       => options[:port].presence && options[:port].to_i,
@@ -317,7 +323,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
         :username   => options[:username],
         :password   => options[:password],
         :verify_ssl => options[:verify_ssl],
-        :ca_certs   => options[:ca_certs]
+        :ca_certs   => ca_certs
       }
 
       read_timeout, open_timeout = ems_timeouts(:ems_redhat, options[:service])


### PR DESCRIPTION
Currently when the user sets the TLS certification validation switch to
"Yes" and does not provide a custom CA certificate, the provider doesn't
trust the system CA certificates, it trust no certificates at all
instead. This isn't the intended behaviour. To address that issue this
patch changes the provider so that it sets the 'ca_certs' parameter to
'nil' in this case. That 'nil' value indicates to both the 'ovirt' and
'ovirt-engine-sdk' gems that the system CA certificates should be
trusted.

Note that when using version 4 of the API and the 'ovirt-engine-sdk'
gem, the system CA certificates are loaded only once, when the gem is
loaded. If any CA certificate is added to the system, then the affected
ManageIQ workers will need to be reloaded. The affected workers are all
the provider workers and the UI worker. It may be more convenient to
just restart the appliances.

The complete sequence to verify this is the following:

1. Get the CA certificate used by the oVirt system. If it is a
   self-signed certificate it will be available in the 'ca.pem' file
   inside the '/etc/pki/ovirt-engine' directory:

```
# scp ovirt.example.com:/etc/pki/ovirt-engine/ca.pem .
```

2. Add the CA certificate to the directory containing the CA
   certificates that are added to the system database:

```
# cp ca.pem /etc/pki/ca-trust/source/anchors/ovirt.example.com.pem
```

3. Update the system database:

```
# udpate-ca-trust
```

4. At this point the database is updated, but it won't be reloaded if
   using version 4 of the API and the 'ovirt-engine-sdk' gem, so restart
   the appliance.

5. Check that the authentication verification works setting TLS
   certificate validation to 'Yes', but without pasting any certificate
   in the text box for trusted CA certificates.

By default the provider uses version 3 of the API, make check this with
version 3 of the API and also with version 4, changing the settings to
do so:

```
:ems:
  :ems_redhat:
    :use_ovirt_engine_sdk: true
```

This patch addresses the following bug:

  RHV provider does not trust certificate authorities from the system CA database
  https://bugzilla.redhat.com/1459569