### PR TITLE
remove invalid rescue statement

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
   extend ActiveSupport::Concern
 
   require 'ovirtsdk4'
+  require 'ovirt'
 
   included do
     process_api_features_support

--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -284,6 +284,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       # values, so we need to check the value passed and make a list only if it won't be empty. If it will be empty then
       # we should just pass 'nil'.
       ca_certs = options[:ca_certs]
+      ca_certs = nil if ca_certs.blank?
       ca_certs = [ca_certs] if ca_certs
 
       url = URI::Generic.build(
@@ -310,6 +311,11 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       require 'manageiq/providers/ovirt/legacy/inventory'
       Ovirt.logger = $rhevm_log
 
+      # If 'ca_certs' is an empty string then the 'ovirt' gem will trust nothing, but we want it to trust the system CA
+      # certificates. To get that behaviour we need to pass 'nil' instead of the empty string.
+      ca_certs = options[:ca_certs]
+      ca_certs = nil if ca_certs.blank?
+
       params = {
         :server     => options[:server],
         :port       => options[:port].presence && options[:port].to_i,
@@ -317,7 +323,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
         :username   => options[:username],
         :password   => options[:password],
         :verify_ssl => options[:verify_ssl],
-        :ca_certs   => options[:ca_certs]
+        :ca_certs   => ca_certs
       }
 
       read_timeout, open_timeout = ems_timeouts(:ems_redhat, options[:service])


### PR DESCRIPTION
When investigating the available methods for https://github.com/ManageIQ/manageiq-providers-ovirt/pull/66, I noticed that the `#verify_credentials_for_rhevm`method was not working and was raising a 

```
NameError:
       uninitialized constant ManageIQ::Providers::Redhat::InfraManager::ApiIntegration::RestClient
```

error because of what appears to be an invalid `rescue`. I looked for the `RestClient` that it may want, but was unable to find it. Perhaps somebody more familiar with Ovirt may be able to point it out, but without this removed currently, the method does not work at all.

Added a test that fails without this change for good measure.

@miq-bot add_label bug 