### PR TITLE
Fixed hosts filtering when no ems selected

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -105,6 +105,7 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
 
   def filter_allowed_hosts(all_hosts)
     ems = source_ems
+    return all_hosts unless ems
     ovirt_services = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Builder.new(ems).build(:use_highest_supported_version => true).new(:ems => ems)
     ovirt_services.filter_allowed_hosts(self, all_hosts)
   end


### PR DESCRIPTION
When network profiles were added, the default implementation of
filter_allowed_hosts was overridden.
The previous behavior used to return all of the hosts if couldn't
determine the vlan.

Same behavior should be maintained if there isn't ems available in the
context of the current selection.