### PR TITLE
Fix missing number_of_nics on host hardware

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
@@ -196,6 +196,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         result[:model] = hw_info.product_name
       end
 
+      result[:number_of_nics] = inv.nics.count
+
       result
     end
 

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -203,7 +203,8 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       :cpu_sockets          => cpu_sockets,
       :cpu_total_cores      => cpu_sockets * cpu_cores,
       :manufacturer         => hw_info.manufacturer,
-      :model                => hw_info.product_name
+      :model                => hw_info.product_name,
+      :number_of_nics       => nics.count
     )
 
     host_guest_devices(persister_hardware, host, nics, networks)

--- a/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
@@ -478,7 +478,8 @@ class ManageIQ::Providers::Redhat::InventoryCollectionDefault::InfraManager < Ma
           :manufacturer,
           :memory_mb,
           :model,
-          :networks
+          :networks,
+          :number_of_nics
         ]
       }
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -338,7 +338,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :cpu_type             => "Westmere E56xx/L56xx/X56xx (Nehalem-C)",
       :manufacturer         => "Red Hat",
       :model                => "RHEV Hypervisor",
-      :number_of_nics       => nil,
+      :number_of_nics       => 1,
       :memory_mb            => 3789,
       :memory_console       => nil,
       :cpu_sockets          => 2,


### PR DESCRIPTION
This field used to be populated in v3 but we missed it in the new parser.
Added it back to v4 parser.