### PR TITLE
Fixed cases causing waiting on timeout in vm_import

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -148,7 +148,9 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def version_higher_than?(version)
-    ems_version = api_version[/\d+\.\d+/x]
+    return false if api_version.nil?
+
+    ems_version = api_version[/\d+\.\d+\.?\d*/x]
     Gem::Version.new(ems_version) >= Gem::Version.new(version)
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
@@ -45,20 +45,29 @@ module ManageIQ::Providers::Redhat::InfraManager::VmImport
     end
   end
 
+  def check_task!(t, msg)
+    raise msg if t.nil? || MiqTask.status_error?(t.status) || MiqTask.status_timeout?(t.status)
+  end
+
   def submit_import_vm(userid, source_vm_id, target_params)
     task_id = queue_self_method_call(userid, 'Import VM', 'import_vm', source_vm_id, target_params)
     task = MiqTask.wait_for_taskid(task_id)
+
+    check_task!(task, _('Error while importing the VM.'))
 
     task.task_results
   end
 
   def validate_import_vm
-    Gem::Version.new(api_version) >= Gem::Version.new('4')
+    # The version of the RHV needs to be at least 4.1.5 due to https://bugzilla.redhat.com/1477375
+    version_higher_than?('4.1.5')
   end
 
   def submit_configure_imported_vm_networks(userid, vm_id)
     task_id = queue_self_method_call(userid, "Configure imported VM's networks", 'configure_imported_vm_networks', vm_id)
     task = MiqTask.wait_for_taskid(task_id)
+
+    check_task!(task, _('Error while configuring VM network.'))
 
     task.task_results
   end
@@ -68,7 +77,7 @@ module ManageIQ::Providers::Redhat::InfraManager::VmImport
   def check_import_supported!(source_provider)
     raise _('Cannot import archived VMs') if source_provider.nil?
 
-    raise _('Cannot import to a RHEV provider of version < 4.0') unless api_version >= '4.0'
+    raise _('Cannot import to a RHEV provider of version < 4.1.5') unless validate_import_vm
     unless source_provider.type == ManageIQ::Providers::Vmware::InfraManager.name
       raise _('Source provider must be of type Vmware')
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
@@ -105,8 +105,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::VmImport do
     let(:ems) { FactoryGirl.create(:ems_redhat) }
 
     it 'validates successfully' do
-      allow(ems).to receive(:api_version).and_return('4')
+      allow(ems).to receive(:api_version).and_return('4.1.5')
       expect(ems.validate_import_vm).to be_truthy
+    end
+
+    it 'fails validation on old api version' do
+      allow(ems).to receive(:api_version).and_return('4.1.4')
+      expect(ems.validate_import_vm).to be_falsey
     end
 
     it 'validates before connecting' do

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -338,6 +338,9 @@ describe ManageIQ::Providers::Redhat::InfraManager do
 
         ems.api_version = "4.2.0_master"
         expect(ems.version_higher_than?("4.1")).to be_truthy
+
+        ems.api_version = "4.2.1_master"
+        expect(ems.version_higher_than?("4.2.0")).to be_truthy
       end
     end
 
@@ -351,6 +354,18 @@ describe ManageIQ::Providers::Redhat::InfraManager do
 
         ems.api_version = "4.0.0_master"
         expect(ems.version_higher_than?("4.1")).to be_falsey
+
+        ems.api_version = "4.0.1_master"
+        expect(ems.version_higher_than?("4.0.2")).to be_falsey
+      end
+    end
+
+    context "api version not set" do
+      let(:api_version) { nil }
+      it 'always return false' do
+        expect(ems.version_higher_than?("10.1")).to be_falsey
+
+        expect(ems.version_higher_than?("0")).to be_falsey
       end
     end
   end


### PR DESCRIPTION
2 problems fixed:
- allow to import only using 4.1.5+ provider.
  The reason is that the required fix (https://bugzilla.redhat.com/1477375) is
  present in 4.1.5+ and without this fix manageiq will wait until timeout
  reached.
- check if submit to the provider succeeded.
  The reason is that if the result is not checked, this state will always
  succeed and the import will again wait until timeout.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1473169