### PR TITLE
Fix allowed vlans to allow no provider

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -100,7 +100,7 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
 
   def load_allowed_vlans(hosts, vlans)
     ems = source_ems
-    ems.ovirt_services.load_allowed_networks(hosts, vlans, self)
+    ems.ovirt_services.load_allowed_networks(hosts, vlans, self) if ems
   end
 
   def filter_allowed_hosts(all_hosts)


### PR DESCRIPTION
A template might loose its association with a provider when a template
is being removed from the provider. In that case the template will
become archived or orphan and its ext_management_system will return
nil.

The service catalog filters such vms or templates. However, an existing
service doesn't produce a meaningful error in such case.

Letting the service to allow nil value for EMS at dialog load will
produce a descriptive error when trying to provision.

https://bugzilla.redhat.com/show_bug.cgi?id=1471124