### PR TITLE
Block unsupported VMs reset

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -23,6 +23,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
   end
 
   supports_not :publish
+  supports_not :reset
 
   POWER_STATES = {
     'up'        => 'on',


### PR DESCRIPTION
RHV doesn't support VM reset action and should block it when VMs are
being selected for reset via the VMs center dialog.

https://bugzilla.redhat.com/show_bug.cgi?id=1476592