### PR TITLE
Move logging in trap context to a normal signal handler

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -26,6 +26,12 @@ class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ
       @queue.enq events
       sleep_poll_normal
     end
+  rescue SignalException => e
+    if e.message == "SIGTERM"
+      _log.info("#{self.class.name}##{__method__}: ignoring SIGTERM")
+    else
+      raise
+    end
   ensure
     reset_event_monitor_handle
   end

--- a/lib/manageiq/providers/ovirt/legacy/event_monitor.rb
+++ b/lib/manageiq/providers/ovirt/legacy/event_monitor.rb
@@ -12,7 +12,6 @@ module ManageIQ
           end
 
           def start
-            trap(:TERM) { $rhevm_log.info "EventMonitor#start: ignoring SIGTERM" }
             @since          = nil
             @event_fetcher  = nil
             @monitor_events = true


### PR DESCRIPTION
Note, this is nearly identical to
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/95

Since ruby 2.0, you cannot use a mutex in a trap context such as writing
a log message.

```
irb(main):001:0> require 'logger'
=> true
irb(main):002:0> trap(:TERM) { Logger.new("stdout").info "EventMonitor#start: ignoring SIGTERM" }
=> "DEFAULT"
irb(main):003:0> `kill #{Process.pid}`
log writing failed. can't be called from trap context
=> ""
```

Move this logic up to the caller of start and rescue a SignalException
with "SIGTERM" message instead.

See also: https://github.com/ManageIQ/manageiq/pull/2386