### PR TITLE
Remove seemingly unnecessary ignoring of SIGTERM

### DIFF
--- a/lib/manageiq/providers/ovirt/legacy/event_monitor.rb
+++ b/lib/manageiq/providers/ovirt/legacy/event_monitor.rb
@@ -12,7 +12,6 @@ module ManageIQ
           end
 
           def start
-            trap(:TERM) { $rhevm_log.info "EventMonitor#start: ignoring SIGTERM" }
             @since          = nil
             @event_fetcher  = nil
             @monitor_events = true


### PR DESCRIPTION
It was added originally back in 2011 in manageiq:
946657b11a0a65abbcdca9975206d71f7c2b7afc

This was actually copied from the vmware vim monitoring events
code from 2009: 22a911716b40428b6d822f0f1e95aabd022e59c9

```
def monitorEvents
  raise "monitorEvents: no block given" if !block_given?

 trap(:TERM) { $log.info "monitorEvents: ignoring SIGTERM" }
...
```

First of all, trap with logging doesn't work since ruby 2.0+:

```
irb(main):001:0> require 'logger'
=> true
irb(main):002:0> trap(:TERM) { Logger.new("stdout").info
"EventMonitor#start: ignoring SIGTERM" }
=> "DEFAULT"
irb(main):003:0> `kill #{Process.pid}`
log writing failed. can't be called from trap context
=> ""
```

See https://github.com/ManageIQ/manageiq/pull/2386

Second, we need to TERM processes in container land.