### PR TITLE
Add method to check if vm exists on provider

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -57,6 +57,14 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       end
     end
 
+    def exists_on_provider?(vm)
+      vm.with_provider_object do |_rhevm_vm|
+        true
+      end
+    rescue Ovirt::MissingResourceError
+      false
+    end
+
     def populate_phase_context(phase_context, vm)
       phase_context[:new_vm_ems_ref] = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm[:href])
       phase_context[:clone_task_ref] = vm.creation_status_link

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -49,6 +49,15 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       end
     end
 
+    def exists_on_provider?(vm)
+      vm.with_provider_object(VERSION_HASH) do |vm_proxy|
+        vm_proxy.get
+        true
+      end
+    rescue OvirtSDK4::Error
+      false
+    end
+
     def populate_phase_context(phase_context, vm)
       phase_context[:new_vm_ems_ref] = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm.href)
     end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -69,6 +69,11 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
     ext_management_system.ovirt_services.collect_disks_by_hrefs(disks.compact)
   end
 
+  def exists_on_provider?
+    return false unless ext_management_system
+    ext_management_system.ovirt_services.vm_exists_on_provider?(self)
+  end
+
   def disconnect_inv
     disconnect_storage
 


### PR DESCRIPTION
The way it was done before is by checking for an exception when refreshing the vm.

This is part of a fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1478108

This is required for: https://github.com/ManageIQ/manageiq-automation_engine/pull/66