### PR TITLE
Require version 0.18 or newer of ovirt gem

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "ovirt", "~>0.17.1"
+  s.add_runtime_dependency "ovirt", "~>0.18.0"
   s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
Version 0.18 or newer of the 'ovirt' gem is needed in order to work
correctly with custom TLS trusted CA certificates.

This patch addresses the following bug:

  Service order request for VM provision from template fail on SSL Certificate verification
  https://bugzilla.redhat.com/1483303