### PR TITLE
Make full refresh through OvirSDK use asynchronous calls to oVirt

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -316,6 +316,8 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
         :insecure => options[:verify_ssl] == OpenSSL::SSL::VERIFY_NONE,
         :ca_certs => ca_certs,
         :log      => $rhevm_log,
+        :connections => options[:connections] || ::Settings.ems.ems_redhat.connections,
+        :pipeline    => options[:pipeline] || ::Settings.ems.ems_redhat.pipeline
       )
     end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/futures_collector.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/futures_collector.rb
@@ -1,0 +1,100 @@
+class ManageIQ::Providers::Redhat::InfraManager::FuturesCollector
+  attr_reader :keyed_futures_queue, :keyed_requests_queue, :parallel_processing_capacity
+  attr_accessor :result_hash
+
+  include Vmdb::Logging
+
+  DEFAULT_PARALLEL_PROCESSING_CAPACITY = ::Settings.ems_refresh.rhevm.pipeline * ::Settings.ems_refresh.rhevm.connections
+
+  def self.process_keyed_requests_queue(keyed_requests_queue, batch_size = nil)
+    collector = new(:batch_size => batch_size)
+    collector.queue_keyed_request_tasks(keyed_requests_queue)
+    collector.process_queues
+  end
+
+  def initialize(args)
+    @keyed_futures_queue = []
+    @keyed_requests_queue = []
+    @parallel_processing_capacity = args[:batch_size] || DEFAULT_PARALLEL_PROCESSING_CAPACITY
+    @result_hash = {}
+  end
+
+  def process_queues
+    process_keyed_requests_queue
+    while tasks_present?
+      process_keyed_futures_queue if keyed_futures_queue.present?
+      process_keyed_requests_queue
+    end
+    result_hash
+  rescue => e
+    _log.error("failed to process queues, due to: #{e.message}")
+    wait_on_all_futures_ignoring_results
+    return nil
+  end
+
+  def queue_keyed_request_tasks(keyed_request_tasks)
+    @keyed_requests_queue += keyed_request_tasks.collect { |kv| KeyedValue.from_hash(kv) }
+  end
+
+  private
+
+  def process_keyed_requests_queue
+    parallel_processing_capacity.times do
+      return if keyed_requests_queue.empty?
+      process_one_keyed_request
+    end
+  rescue => e
+    _log.warn("could not process keyed_requests due to: #{e.message}")
+    raise e
+  end
+
+  def process_one_keyed_request
+    return if keyed_requests_queue.empty?
+    keyed_request = keyed_requests_queue.shift
+    keyed_futures_queue << KeyedValue.from_key_value(keyed_request.key, keyed_request.value.call)
+  rescue => e
+    _log.warn("could not create future out of #{keyed_request.inspect}, due to: #{e.message}")
+    raise e
+  end
+
+  def process_keyed_futures_queue
+    while keyed_futures_queue.present?
+      begin
+        keyed_future = keyed_futures_queue.shift
+        result_hash[keyed_future.key] = keyed_future.value.wait
+        process_one_keyed_request if keyed_requests_queue.present?
+      end
+    end
+  end
+
+  # In the case of OvirtSDK futures, if we do not call wait on them, they will stay in memroy
+  # so in case of an error we need to wait on all of them.
+  def wait_on_all_futures_ignoring_results
+    keyed_futures_queue.each do |keyed_future|
+      begin
+        keyed_future.value.wait
+      rescue => e
+        _log.error("failed waiting on #{keyed_future.inspect}, due to: #{e.message}")
+      end
+    end
+  end
+
+  def tasks_present?
+    keyed_futures_queue.present? || keyed_requests_queue.present?
+  end
+
+  class KeyedValue
+    attr_reader :key, :value
+    def initialize(key_value_hash)
+      @key, @value = key_value_hash.first
+    end
+
+    def self.from_key_value(key, value)
+      new(key => value)
+    end
+
+    def self.from_hash(h)
+      new(h)
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
@@ -42,18 +42,90 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
       get_uuid_from_href(object.ems_ref)
     end
 
+    TOP_LEVEL_INVENTORY_TYPES = %w(cluster storage host vm template network datacenter disk)
+
+    # This hash contains the attributes to be fetched for diffrent types of inventory.
+    ATTRIBUTES_TO_FETCH_FOR_INV_TYPE = {
+      :host        => [:nics, :statistics],
+      :data_center => [:storage_domains],
+      :vm          => [:nics, :reported_devices, :snapshots, :disk_attachments],
+      :template    => [:disk_attachments]
+    }.freeze
+
     def refresh
       ems.with_provider_connection(VERSION_HASH) do |connection|
         @connection = connection
-        res = {}
-        res[:cluster] = collect_clusters
-        res[:storage] = collect_storages
-        res[:host] = collect_hosts
-        res[:vm] = collect_vms
-        res[:template] = collect_templates
-        res[:network] = collect_networks
-        res[:datacenter] = collect_datacenters
+        top_level_futures_hash = collect_top_level_futures
+        res = wait_on_top_level_collections(top_level_futures_hash)
+        res.each { |inv_name, inv| res[inv_name] = collect_inv_with_attributes_async(inv, inv_name_to_inv_type(inv_name)) }
+        preloaded_disks = collect_disks_as_hash(res[:disk])
+        collect_disks_from_attachments(res[:vm], preloaded_disks)
+        collect_disks_from_attachments(res[:template], preloaded_disks)
         res
+      end
+    end
+
+    def collect_disks_from_attachments(inv, preloaded_disks)
+      inv.each do |inv_item|
+        disks = AttachedDisksFetcher.attached_disks(inv_item, connection, preloaded_disks)
+        inv_item.singleton_class.send(:attr_accessor, :disks)
+        inv_item.disks = disks
+      end
+    end
+
+    def collect_inv_with_attributes_async(inv, inv_type)
+      return inv if ATTRIBUTES_TO_FETCH_FOR_INV_TYPE[inv_type].blank?
+      inv_keyed_requests = collect_inv_attributes_request(inv, inv_type)
+      inv_fetched_attributes = ManageIQ::Providers::Redhat::InfraManager::FuturesCollector.process_keyed_requests_queue(inv_keyed_requests)
+      raise "Failed to fetch attributes for #{inv_type}" unless inv_fetched_attributes
+      set_inv_attributes!(inv, inv_fetched_attributes, inv_type)
+    end
+
+    def set_inv_attributes!(inv, inv_fetched_attributes, inv_type)
+      inv.each do |obj|
+        key = base_key_for_obj(obj, inv_type)
+        ATTRIBUTES_TO_FETCH_FOR_INV_TYPE[inv_type].each do |attribute_name|
+          obj.instance_variable_set("@#{attribute_name}", inv_fetched_attributes["#{key}#{attribute_name}"])
+        end
+      end
+    end
+
+    def collect_inv_attributes_request(objs, obj_type)
+      obj_requests = []
+      objs.each do |obj|
+        ATTRIBUTES_TO_FETCH_FOR_INV_TYPE[obj_type].each do |attribute_name|
+          obj_requests << obj_attribute_request(obj, obj_type, attribute_name)
+        end
+      end
+      obj_requests
+    end
+
+    def wait_on_top_level_collections(top_level_futures_hash)
+      top_level_futures_hash.each do |k, v|
+        top_level_futures_hash[k] = v.wait
+      end
+      top_level_futures_hash
+    end
+
+    def collect_top_level_futures
+      res = {}
+      TOP_LEVEL_INVENTORY_TYPES.each { |inv_name| res[inv_name.to_sym] = collect_inv_future(inv_name.to_sym) }
+      res
+    end
+
+    def collect_inv_future(inv_name)
+      inv_type = inv_name_to_inv_type(inv_name)
+      connection.system_service.send("#{inv_type}s_service").list(:wait => false)
+    end
+
+    def inv_name_to_inv_type(inv_name)
+      case inv_name
+      when :datacenter
+        :data_center
+      when :storage
+        :storage_domain
+      else
+        inv_name.to_sym
       end
     end
 
@@ -96,8 +168,19 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
       @preloaded_disks ||= collect_disks_as_hash
     end
 
-    def collect_disks_as_hash
-      Hash[connection.system_service.disks_service.list.collect { |d| [d.id, d] }]
+    def collect_disks_as_hash(disks = nil)
+      disks ||= connection.system_service.disks_service.list
+      Hash[disks.collect { |d| [d.id, d] }]
+    end
+
+    def collect_future_vm_disk_attachments(vms, vms_service)
+      vms_attachments = vms.collect do |vm|
+        vm_service = vms_service.vm_service(vm.id)
+        disk_attachments_service = vm_service.disk_attachments_service
+        disk_attachments_future = disk_attachments_service.list(:wait => false)
+        [vm.id, disk_attachments_future]
+      end
+      Hash[vms_attachments]
     end
 
     def collect_vm_by_uuid(uuid)
@@ -107,10 +190,37 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
       []
     end
 
+    def collect_templates_future
+      connection.system_service.templates_service.list(:wait => false)
+    end
+
+    def base_key_for_obj(obj, obj_type)
+      "#{obj_type}_#{obj.id}_"
+    end
+
+    def obj_attribute_request(obj, obj_type, attr_name)
+      objs_service = connection.system_service.send("#{obj_type}s_service")
+      procedure = proc do
+        objs_service.send("#{obj_type}_service", obj.id).send("#{attr_name}_service").list(:wait => false)
+      end
+      key = "#{base_key_for_obj(obj, obj_type)}#{attr_name}"
+      { key => procedure}
+    end
+
     def collect_templates
       connection.system_service.templates_service.list.collect do |template|
         TemplatePreloadedAttributesDecorator.new(template, connection, preloaded_disks)
       end
+    end
+
+    def collect_future_template_disk_attachments(templates, templates_service)
+      templates_attachments = templates.collect do |template|
+        template_service = templates_service.template_service(template.id)
+        atts_service = template_service.disk_attachments_service
+        atts_future = atts_service.list(:wait => false)
+        [template.id, atts_future]
+      end
+      Hash[templates_attachments]
     end
 
     def search_templates(search)
@@ -164,22 +274,32 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
       attr_reader :disks, :nics, :reported_devices, :snapshots
       def initialize(vm, connection, preloaded_disks = nil)
         @obj = vm
-        @disks = self.class.get_attached_disks(vm, connection, preloaded_disks)
+        @disks = self.class.get_attached_disks_from_futures(vm, connection, preloaded_disks)
         @nics = connection.follow_link(vm.nics)
         @reported_devices = connection.follow_link(vm.reported_devices)
         @snapshots = connection.follow_link(vm.snapshots)
         super(vm)
       end
 
-      def self.get_attached_disks(vm, connection, preloaded_disks = nil)
-        AttachedDisksFetcher.get_attached_disks(vm, connection, preloaded_disks)
+      def self.get_attached_disks_from_futures(vm, connection, preloaded_disks = nil)
+        AttachedDisksFetcher.get_attached_disks_from_futures(vm, connection, preloaded_disks)
       end
     end
 
     class AttachedDisksFetcher
-      def self.get_attached_disks(disks_owner, connection, preloaded_disks = nil)
-        attachments = connection.follow_link(disks_owner.disk_attachments)
+      def self.get_attached_disks_from_futures(disks_owner, connection, preloaded_disks = nil, future_disk_attachments = nil)
+        attachments = future_disk_attachments ? future_disk_attachments.wait : connection.follow_link(disks_owner.disk_attachments)
         attachments.map do |attachment|
+          res = disk_from_attachment(connection, attachment, preloaded_disks)
+          res.interface = attachment.interface
+          res.bootable = attachment.bootable
+          res.active = attachment.active
+          res
+        end
+      end
+
+      def self.attached_disks(disks_owner, connection, preloaded_disks)
+        disks_owner.disk_attachments.map do |attachment|
           res = disk_from_attachment(connection, attachment, preloaded_disks)
           res.interface = attachment.interface
           res.bootable = attachment.bootable
@@ -195,10 +315,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
     end
 
     class TemplatePreloadedAttributesDecorator < SimpleDelegator
-      attr_reader :disks, :nics
-      def initialize(template, connection, preloaded_disks = nil)
+      attr_reader :disks
+      def initialize(template, connection, preloaded_disks = nil, future_disk_attachments = nil)
         @obj = template
-        @disks = AttachedDisksFetcher.get_attached_disks(template, connection, preloaded_disks)
+        @disks = AttachedDisksFetcher.get_attached_disks_from_futures(template, connection, preloaded_disks, future_disk_attachments[template.id])
         super(template)
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,8 @@
 :ems_refresh:
   :rhevm:
     :inventory_object_refresh: false
+    :pipeline: 40
+    :connections: 10
 :log:
   :level_rhevm: info
 :workers:

--- a/spec/models/manageiq/providers/redhat/infra_manager/futures_collector_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/futures_collector_spec.rb
@@ -1,0 +1,103 @@
+describe ManageIQ::Providers::Redhat::InfraManager::FuturesCollector do
+  let(:future_collection) { FutureCollection.new }
+  let(:keyed_requests) { [] }
+  let(:futures) { [] }
+  before do
+    (1..10).each do |i|
+      f = future_collection.new_future("f_#{i}")
+      futures << f
+      keyed_requests << future_collection.create_keyed_request("key_#{i}", f)
+    end
+  end
+
+  context 'no failure' do
+    it 'calls wait on all futures' do
+      futures.each do |f|
+        expect(f).to receive(:wait).and_call_original
+      end
+      described_class.process_keyed_requests_queue(keyed_requests, 5)
+    end
+  end
+
+  context 'exception in future' do
+    before do
+      prc = proc do
+        raise "Exception"
+      end
+      f = future_collection.new_future("f", prc)
+      keyed_requests.insert(4, future_collection.create_keyed_request("key", f))
+    end
+
+    it 'calls wait on all pending futures' do
+      futures[0, 7].each do |f|
+        expect(f).to receive(:wait).and_call_original
+      end
+      described_class.process_keyed_requests_queue(keyed_requests, 4)
+    end
+
+    it 'does not process pending keyed requests' do
+      keyed_requests[8, 9].each do |kr|
+        expect(kr.first[1]).not_to receive(:call)
+      end
+      described_class.process_keyed_requests_queue(keyed_requests, 4)
+    end
+  end
+
+  context 'exception in processing request' do
+    before do
+      prc = proc do
+        raise "Exception"
+      end
+      keyed_requests[4]["key_5"] = prc
+    end
+
+    it 'calls wait on all pending futures' do
+      futures[0, 4].each do |f|
+        expect(f).to receive(:wait).and_call_original
+      end
+      described_class.process_keyed_requests_queue(keyed_requests, 4)
+    end
+
+    it 'does not process pending keyed requests' do
+      keyed_requests[5, 9].each do |kr|
+        expect(kr.first[1]).not_to receive(:call)
+      end
+      described_class.process_keyed_requests_queue(keyed_requests, 4)
+    end
+  end
+end
+
+class FutureCollection
+  attr_reader :futures
+
+  def initialize
+    @futures = []
+  end
+
+  def new_future(name, blk = nil)
+    f = Future.new(self, name, blk)
+    futures << f
+    f
+  end
+
+  def create_keyed_request(key, future = nil)
+    procedure = proc do
+      future || new_future(key)
+    end
+    { key => procedure}
+  end
+
+  class Future
+    attr_reader :future_collection, :name, :blk_to_execute
+
+    def initialize(future_collection, name, blk_to_execute = nil)
+      @blk_to_execute = blk_to_execute
+      @future_collection = future_collection
+      @name = name
+    end
+
+    def wait
+      blk_to_execute.call if blk_to_execute
+    end
+  end
+end

--- a/spec/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4_spec.rb
@@ -1,52 +1,30 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4 do
-  require 'yaml'
-  def load_response_mock_for(filename)
-    prefix = described_class.name.underscore
-    YAML.load_file(File.join('spec', 'models', prefix, 'response_yamls', filename.to_s + '.yml'))
+  before(:each) do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
+                              :port => 8443)
+    @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
+    @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
+    allow(@ems).to(receive(:supported_api_versions).and_return([3, 4]))
+    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
+    allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).and_call_original
+    allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).with(kind_of(Hash)) do |opts|
+      Spec::Support::OvirtSDK::ConnectionVCR.new(opts, File.join('spec/vcr_cassettes/', described_class.name.underscore, 'collect_disks.yml'))
+    end
+    stub_const("OvirtSDK4::Connection", Spec::Support::OvirtSDK::ConnectionVCR)
   end
 
   describe "#collect_vms" do
-    let(:ems) { FactoryGirl.create(:ems_redhat_with_authentication) }
-    let(:vm) { FactoryGirl.create(:vm_redhat, :ext_management_system => ems) }
-    let(:ems_service) { instance_double(OvirtSDK4::Connection) }
-    let(:system_service) { instance_double(OvirtSDK4::SystemService) }
-    let(:vms_service) { instance_double(OvirtSDK4::VmsService) }
-    let(:disks_service) { instance_double(OvirtSDK4::DisksService) }
-    let(:query) { { :search => "status=#{OvirtSDK4::DataCenterStatus::UP}" } }
-    let(:vm1) { load_response_mock_for(:vm1_obj) }
-    let(:vm2) { load_response_mock_for(:vm2_obj) }
-    let(:vm3) { load_response_mock_for(:vm3_obj) }
-    let(:vms_list) { [vm1, vm2, vm3] }
-    let(:disks_list) { load_response_mock_for(:disks_list) }
-
-    RSpec::Matchers.define :has_same_href_as do |x|
-      match { |actual| x.href == actual.href }
-    end
-
-    before do
-      allow(ems).to receive(:with_provider_connection).and_yield(ems_service)
-      allow(ems_service).to receive(:system_service).and_return(system_service)
-      allow(system_service).to receive(:vms_service).and_return(vms_service)
-      allow(vms_service).to receive(:list).and_return(vms_list)
-      allow(system_service).to receive(:disks_service).and_return(disks_service)
-      allow(disks_service).to receive(:list).and_return(disks_list)
-      vms_list.each_with_index do |v, i|
-        allow(ems_service).to receive(:follow_link).with(has_same_href_as(v.nics)).and_return(load_response_mock_for("vm#{i + 1}_nics"))
-        allow(ems_service).to receive(:follow_link).with(has_same_href_as(v.reported_devices)).and_return(load_response_mock_for("vm#{i + 1}_devices"))
-        allow(ems_service).to receive(:follow_link).with(has_same_href_as(v.snapshots)).and_return(load_response_mock_for("vm#{i + 1}_snapshots"))
-        allow(ems_service).to receive(:follow_link).with(has_same_href_as(v.disk_attachments)).and_return(load_response_mock_for("vm#{i + 1}_attachments"))
-      end
-    end
-
-    it 'fetches the vms with proper disks' do
-      inventory = described_class.new(:ems => ems)
-      allow(inventory).to receive(:connection).and_return(ems_service)
+    it 'collects the disks properly' do
+      inventory = described_class.new(:ems => @ems)
+      inventory.instance_variable_set(:@connection, @ems.connect)
       vms = inventory.collect_vms
-      expect(vms[0].disks.count).to eq(1)
-      expect(vms[1].disks.count).to eq(1)
-      expect(vms[2].disks.count).to eq(0)
-      expect(vms[0].disks[0].id).to eq("10c3dd0e-90b4-4708-bcba-b71dc4bda979")
-      expect(vms[1].disks[0].id).to eq("f067ba7a-563e-4592-8f09-9789cb8cb2c9")
+      vm1_disks = vms[0].disks
+      expect(vm1_disks.count).to eq(1)
+      expect(vm1_disks.first.id).to eq("e0001bb7-3e18-457d-af89-8e5b565cc84f")
+      vm13_disks = vms[13].disks
+      expect(vm13_disks.count).to eq(2)
+      expect(vm13_disks.collect(&:id)).to match_array(%w(9a3e866c-4497-46df-801a-d1739c31c69d 1f702a46-6a95-46ce-a682-a3ff26dbcee3))
     end
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -26,38 +26,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       .and_return(OpenStruct.new(:version_string => '4.2.0_master'))
   end
 
-  it "will perform a full refresh on v4.1" do
-    allow_any_instance_of(@inventory_wrapper_class)
-      .to receive(:collect_clusters).and_return(load_response_mock_for('clusters'))
-    allow_any_instance_of(@inventory_wrapper_class)
-      .to receive(:collect_storages).and_return(load_response_mock_for('storages'))
-    allow_any_instance_of(@inventory_wrapper_class)
-      .to receive(:collect_hosts).and_return(load_response_mock_for('hosts'))
-    allow_any_instance_of(@inventory_wrapper_class)
-      .to receive(:collect_vms).and_return(load_response_mock_for('vms'))
-    allow_any_instance_of(@inventory_wrapper_class)
-      .to receive(:collect_templates).and_return(load_response_mock_for('templates'))
-    allow_any_instance_of(@inventory_wrapper_class)
-      .to receive(:collect_networks).and_return(load_response_mock_for('networks'))
-    allow_any_instance_of(@inventory_wrapper_class)
-      .to receive(:collect_datacenters).and_return(load_response_mock_for('datacenters'))
-
-    VCR.use_cassette("#{described_class.name.underscore}_4_1", :allow_unused_http_interactions => true, :allow_playback_repeats => true, :record => :new_episodes) do
-      EmsRefresh.refresh(@ems)
-    end
-    @ems.reload
-
-    assert_table_counts(3)
-    assert_ems
-    assert_specific_cluster
-    assert_specific_storage
-    assert_specific_host
-    assert_specific_vm_powered_on
-    assert_specific_vm_powered_off
-    assert_specific_template
-    assert_relationship_tree
-  end
-
   it "will perform a graph full refresh" do
     stub_settings_merge(:ems_refresh => { :rhevm => {:inventory_object_refresh => true }})
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -1,0 +1,655 @@
+describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
+  before(:each) do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
+                              :port => 8443)
+    @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
+    @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
+    allow(@ems).to(receive(:supported_api_versions).and_return(%w(3 4)))
+    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
+    allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).and_call_original
+    allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).with(kind_of(Hash)) do |opts|
+      Spec::Support::OvirtSDK::ConnectionVCR.new(opts, 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml')
+    end
+    stub_const("OvirtSDK4::Connection", Spec::Support::OvirtSDK::ConnectionVCR)
+  end
+
+  before(:each) do
+    @inventory_wrapper_class = ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4
+
+    allow_any_instance_of(@inventory_wrapper_class).to(receive(:api).and_return("4.2.0_master."))
+    allow_any_instance_of(@inventory_wrapper_class).to(receive(:service)
+      .and_return(OpenStruct.new(:version_string => '4.2.0_master.')))
+  end
+
+  it "will perform a full refresh on v4.1" do
+    EmsRefresh.refresh(@ems)
+    @ems.reload
+
+    assert_table_counts(3)
+    assert_ems
+    assert_specific_cluster
+    assert_specific_storage
+    assert_specific_host
+    assert_specific_vm_powered_on
+    assert_specific_vm_powered_off
+    assert_specific_template
+    assert_relationship_tree
+  end
+
+  def assert_table_counts(_lan_number)
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(EmsFolder.count).to eq(7)
+    expect(EmsCluster.count).to eq(3)
+    expect(Host.count).to eq(3)
+    expect(ResourcePool.count).to eq(3)
+    expect(VmOrTemplate.count).to eq(17)
+    expect(Vm.count).to eq(14)
+    expect(MiqTemplate.count).to eq(3)
+    expect(Storage.count).to eq(5)
+
+    expect(CustomAttribute.count).to eq(0) # TODO: 3.0 spec has values for this
+    expect(CustomizationSpec.count).to eq(0)
+    expect(Disk.count).to eq(15)
+    expect(GuestDevice.count).to eq(18)
+    expect(Hardware.count).to eq(20)
+    # the old code expects 3 and new 2
+    expect(Lan.count).to eq(3)
+    expect(MiqScsiLun.count).to eq(0)
+    expect(MiqScsiTarget.count).to eq(0)
+    expect(Network.count).to eq(7)
+    expect(OperatingSystem.count).to eq(20)
+    expect(Snapshot.count).to eq(17)
+    # the old code expects 3 and new 2
+    expect(Switch.count).to eq(3)
+    expect(SystemService.count).to eq(0)
+
+    expect(Relationship.count).to eq(45)
+    expect(MiqQueue.count).to eq(20)
+  end
+
+  def assert_ems
+    expect(@ems).to have_attributes(
+      :api_version => "4.2.0_master.",
+      :uid_ems     => nil
+    )
+
+    expect(@ems.ems_folders.size).to eq(7)
+    expect(@ems.ems_clusters.size).to eq(3)
+    expect(@ems.resource_pools.size).to eq(3)
+    expect(@ems.storages.size).to eq(4)
+    expect(@ems.hosts.size).to eq(3)
+    expect(@ems.vms_and_templates.size).to eq(17)
+    expect(@ems.vms.size).to eq(14)
+    expect(@ems.miq_templates.size).to eq(3)
+
+    expect(@ems.customization_specs.size).to eq(0)
+  end
+
+  def assert_specific_cluster
+    @cluster = EmsCluster.find_by(:name => 'cc1')
+    expect(@cluster).to have_attributes(
+      :ems_ref                 => "/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf",
+      :ems_ref_obj             => "/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf",
+      :uid_ems                 => "504ae500-3476-450e-8243-f6df0f7f7acf",
+      :name                    => "cc1",
+      :ha_enabled              => nil, # TODO: Should be true
+      :ha_admit_control        => nil,
+      :ha_max_failures         => nil,
+      :drs_enabled             => nil, # TODO: Should be true
+      :drs_automation_level    => nil,
+      :drs_migration_threshold => nil
+    )
+
+    expect(@cluster.all_resource_pools_with_default.size).to eq(1)
+    @default_rp = @cluster.default_resource_pool
+
+    expect(@default_rp).to have_attributes(
+      :ems_ref               => nil,
+      :ems_ref_obj           => nil,
+      :uid_ems               => "504ae500-3476-450e-8243-f6df0f7f7acf_respool",
+      :name                  => "Default for Cluster cc1",
+      :memory_reserve        => nil,
+      :memory_reserve_expand => nil,
+      :memory_limit          => nil,
+      :memory_shares         => nil,
+      :memory_shares_level   => nil,
+      :cpu_reserve           => nil,
+      :cpu_reserve_expand    => nil,
+      :cpu_limit             => nil,
+      :cpu_shares            => nil,
+      :cpu_shares_level      => nil,
+      :is_default            => true
+    )
+  end
+
+  def assert_specific_storage
+    @storage = Storage.find_by(:name => "data1")
+    expect(@storage).to have_attributes(
+      :ems_ref                       => "/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02",
+      :ems_ref_obj                   => "/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02",
+      :name                          => "data1",
+      :store_type                    => "NFS",
+      :total_space                   => 53_687_091_200,
+      :free_space                    => 46_170_898_432,
+      :uncommitted                   => -97_710_505_984,
+      :multiplehostaccess            => 1, # TODO: Should this be a boolean column?
+      :location                      => "spider.eng.lab.tlv.redhat.com:/vol/vol_bodnopoz/data1",
+      :directory_hierarchy_supported => nil,
+      :thin_provisioning_supported   => nil,
+      :raw_disk_mappings_supported   => nil
+    )
+
+    @storage2 = Storage.find_by(:name => "data2")
+    expect(@storage2).to have_attributes(
+      :ems_ref                       => "/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb",
+      :ems_ref_obj                   => "/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb",
+      :name                          => "data2",
+      :store_type                    => "NFS",
+      :total_space                   => 53_687_091_200,
+      :free_space                    => 46_170_898_432,
+      :uncommitted                   => 53_687_091_200,
+      :multiplehostaccess            => 1, # TODO: Should this be a boolean column?
+      :location                      => "spider.eng.lab.tlv.redhat.com:/vol/vol_bodnopoz/data2",
+      :directory_hierarchy_supported => nil,
+      :thin_provisioning_supported   => nil,
+      :raw_disk_mappings_supported   => nil
+    )
+
+    def assert_specific_host
+      @host = ManageIQ::Providers::Redhat::InfraManager::Host.find_by(:name => "bodh1")
+      expect(@host).to have_attributes(
+        :ems_ref          => "/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a",
+        :ems_ref_obj      => "/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a",
+        :name             => "bodh1",
+        :hostname         => "bodh1.usersys.redhat.com",
+        :ipaddress        => "10.35.19.12",
+        :uid_ems          => "5bf6b336-f86d-4551-ac08-d34621ec5f0a",
+        :vmm_vendor       => "redhat",
+        :vmm_version      => "7",
+        :vmm_product      => "rhel",
+        :vmm_buildnumber  => nil,
+        :power_state      => "on",
+        :connection_state => "connected"
+      )
+
+      @host_cluster = EmsCluster.find_by(:ems_ref => "/api/clusters/00000002-0002-0002-0002-000000000092")
+      expect(@host.ems_cluster).to eq(@host_cluster)
+      expect(@host.storages.size).to eq(1)
+      expect(@host.storages).to include(@storage2) ### MIGHT BE WRONG, CHECK MANUALLY
+
+      expect(@host.operating_system).to have_attributes(
+        :name         => "bodh1.usersys.redhat.com",
+        :product_name => "RHEL",
+        :version      => "7 - 1.1503.el7.centos.2.8",
+        :build_number => nil,
+        :product_type => "linux"
+      )
+
+      expect(@host.system_services.size).to eq(0)
+
+      expect(@host.switches.size).to eq(1)
+
+      switch = @host.switches.first
+      expect(switch).to have_attributes(
+        :uid_ems           => "00000000-0000-0000-0000-000000000009",
+        :name              => "ovirtmgmt",
+        :ports             => nil,
+        :allow_promiscuous => nil,
+        :forged_transmits  => nil,
+        :mac_changes       => nil
+      )
+
+      expect(switch.lans.size).to eq(1)
+
+      @lan = switch.lans.first
+      expect(@lan).to have_attributes(
+        :uid_ems                    => "00000000-0000-0000-0000-000000000009",
+        :name                       => "ovirtmgmt",
+        :tag                        => nil,
+        :allow_promiscuous          => nil,
+        :forged_transmits           => nil,
+        :mac_changes                => nil,
+        :computed_allow_promiscuous => nil,
+        :computed_forged_transmits  => nil,
+        :computed_mac_changes       => nil
+      )
+
+      expect(@host.hardware).to have_attributes(
+        :cpu_speed            => 2400,
+        :cpu_type             => "Westmere E56xx/L56xx/X56xx (Nehalem-C)",
+        :manufacturer         => "Red Hat",
+        :model                => "RHEV Hypervisor",
+        :number_of_nics       => 1,
+        :memory_mb            => 3789,
+        :memory_console       => nil,
+        :cpu_sockets          => 2,
+        :cpu_total_cores      => 2,
+        :cpu_cores_per_socket => 1,
+        :guest_os             => nil,
+        :guest_os_full_name   => nil,
+        :vmotion_enabled      => nil,
+        :cpu_usage            => nil,
+        :memory_usage         => nil
+      )
+
+      expect(@host.hardware.networks.size).to eq(1)
+
+      network = @host.hardware.networks.find_by(:description => "eth0")
+      expect(network).to have_attributes(
+        :description  => "eth0",
+        :dhcp_enabled => nil,
+        :ipaddress    => "10.35.19.12",
+        :subnet_mask  => "255.255.252.0"
+      )
+
+      # TODO: Verify this host should have 3 nics, 2 cdroms, 1 floppy, any storage adapters?
+      expect(@host.hardware.guest_devices.size).to eq(1)
+
+      expect(@host.hardware.nics.size).to eq(1)
+      nic = @host.hardware.nics.first
+
+      expect(nic).to have_attributes(
+        :uid_ems         => "01c2d4a8-5d7a-4960-bfc4-ca1b400a9bdd",
+        :device_name     => "eth0",
+        :device_type     => "ethernet",
+        :location        => "0",
+        :present         => true,
+        :controller_type => "ethernet"
+      )
+      expect(nic.switch).to eq(switch)
+      expect(nic.network).to eq(network)
+
+      expect(@host.hardware.storage_adapters.size).to eq(0) # TODO: See @host.hardware.guest_devices TODO
+    end
+
+    def assert_specific_vm_powered_on
+      v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by(:name => "vm1")
+      expect(v).to have_attributes(
+        :template              => false,
+        :ems_ref               => "/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f",
+        :ems_ref_obj           => "/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f",
+        :uid_ems               => "3a9401a0-bf3d-4496-8acf-edd3e903511f",
+        :vendor                => "redhat",
+        :raw_power_state       => "up",
+        :power_state           => "on",
+        :location              => "3a9401a0-bf3d-4496-8acf-edd3e903511f.ovf",
+        :tools_status          => nil,
+        :boot_time             => Time.zone.parse("2017-08-02T06:53:36.148"),
+        :standby_action        => nil,
+        :connection_state      => "connected",
+        :cpu_affinity          => nil,
+        :memory_reserve        => 2024,
+        :memory_reserve_expand => nil,
+        :memory_limit          => 8096,
+        :memory_shares         => nil,
+        :memory_shares_level   => nil,
+        :cpu_reserve           => nil,
+        :cpu_reserve_expand    => nil,
+        :cpu_limit             => nil,
+        :cpu_shares            => nil,
+        :cpu_shares_level      => nil
+      )
+
+      expect(v.ext_management_system).to eq(@ems)
+      expect(v.ems_cluster).to eq(@cluster)
+      expect(v.parent_resource_pool).to eq(@default_rp)
+
+      host = ManageIQ::Providers::Redhat::InfraManager::Host.find_by(:name => "bodh2")
+      expect(v.host).to eq(host)
+      expect(v.storages).to eq([@storage]) # CHECK MANUALLY
+
+      expect(v.operating_system).to have_attributes(
+        :product_name => "other"
+      )
+
+      expect(v.hostnames).to match_array(["vm-18-82.eng.lab.tlv.redhat.com"])
+      expect(v.custom_attributes.size).to eq(0)
+
+      expect(v.snapshots.size).to eq(3)
+
+      # TODO: Fix this boolean column
+      snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
+      expect(snapshot).to have_attributes(
+        :uid         => "6e3e547f-9544-42cf-842d-9104828d8511",
+        :parent_uid  => "05ff445a-0bfc-44c3-90d1-a338e9095510",
+        :uid_ems     => "6e3e547f-9544-42cf-842d-9104828d8511",
+        :name        => "Active VM",
+        :description => "Active VM",
+        :current     => 1,
+        :total_size  => nil,
+        :filename    => nil
+      )
+      snapshot_parent = ::Snapshot.find_by(:name => "vm1_snap")
+      expect(snapshot.parent).to eq(snapshot_parent)
+
+      expect(v.hardware).to have_attributes(
+        :guest_os             => "other",
+        :guest_os_full_name   => nil,
+        :bios                 => nil,
+        :cpu_cores_per_socket => 1,
+        :cpu_total_cores      => 4,
+        :cpu_sockets          => 4,
+        :annotation           => nil,
+        :memory_mb            => 2024
+      )
+
+      expect(v.hardware.disks.size).to eq(1)
+
+      disk = v.hardware.disks.find_by(:device_name => "vm1_Disk1")
+      expect(disk).to have_attributes(
+        :device_name     => "vm1_Disk1",
+        :device_type     => "disk",
+        :controller_type => "virtio",
+        :present         => true,
+        :filename        => "af578e0e-b222-4754-aefc-879bf37eacec",
+        :location        => "0",
+        :size            => 6_442_450_944,
+        :size_on_disk    => 93_106_176,
+        :mode            => "persistent",
+        :disk_type       => "thin",
+        :start_connected => true
+      )
+      expect(disk.storage).to eq(@storage) ## CHECK MANUALLY
+
+      expect(v.hardware.guest_devices.size).to eq(1)
+      expect(v.hardware.nics.size).to eq(1)
+
+      nic = v.hardware.nics.find_by(:device_name => "nic1")
+      expect(nic).to have_attributes(
+        :uid_ems         => "6a538d86-38a2-4ac9-98f5-9d401a596e93",
+        :device_name     => "nic1",
+        :device_type     => "ethernet",
+        :controller_type => "ethernet",
+        :present         => true,
+        :start_connected => true,
+        :address         => "00:1a:4a:16:01:51"
+      )
+      # nic.lan.should == @lan # TODO: Hook up this connection
+
+      expect(v.parent_datacenter).to have_attributes(
+        :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+        :ems_ref_obj => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+        :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+        :name        => "dc1",
+        :type        => "Datacenter",
+        :folder_path => "Datacenters/dc1"
+      )
+
+      expect(v.parent_folder).to have_attributes(
+        :ems_ref     => nil,
+        :ems_ref_obj => nil,
+        :uid_ems     => "root_dc",
+        :name        => "Datacenters",
+        :type        => nil,
+        :folder_path => "Datacenters"
+      )
+
+      expect(v.parent_blue_folder).to have_attributes(
+        :ems_ref     => nil,
+        :ems_ref_obj => nil,
+        :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1_vm",
+        :name        => "vm",
+        :type        => nil,
+        :folder_path => "Datacenters/dc1/vm"
+      )
+    end
+
+    def assert_specific_vm_powered_off
+      v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by(:name => "iso_t2")
+      expect(v).to have_attributes(
+        :template              => false,
+        :ems_ref               => "/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d",
+        :ems_ref_obj           => "/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d",
+        :uid_ems               => "1010ec66-5d68-4ae6-b72b-824f5885259d",
+        :vendor                => "redhat",
+        :raw_power_state       => "down",
+        :power_state           => "off",
+        :location              => "1010ec66-5d68-4ae6-b72b-824f5885259d.ovf",
+        :tools_status          => nil,
+        :boot_time             => nil,
+        :standby_action        => nil,
+        :connection_state      => "connected",
+        :cpu_affinity          => nil,
+        :memory_reserve        => 1024,
+        :memory_reserve_expand => nil,
+        :memory_limit          => 4096,
+        :memory_shares         => nil,
+        :memory_shares_level   => nil,
+        :cpu_reserve           => nil,
+        :cpu_reserve_expand    => nil,
+        :cpu_limit             => nil,
+        :cpu_shares            => nil,
+        :cpu_shares_level      => nil
+      )
+
+      expect(v.ext_management_system).to eq(@ems)
+      expect(v.ems_cluster).to eq(@cluster)
+      expect(v.parent_resource_pool).to eq(@default_rp)
+      expect(v.storages).to eq([@storage]) # CHECK MANUALLY
+
+      expect(v.operating_system).to have_attributes(
+        :product_name => "other"
+      )
+
+      expect(v.hostnames).to match_array([])
+      expect(v.custom_attributes.size).to eq(0)
+
+      expect(v.snapshots.size).to eq(1)
+      # TODO: Fix this boolean column
+      snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
+      expect(snapshot).to have_attributes(
+        :uid         => "c4b36a70-faf4-45e9-bd7d-e7d6470d1855",
+        :parent_uid  => nil,
+        :uid_ems     => "c4b36a70-faf4-45e9-bd7d-e7d6470d1855",
+        :name        => "Active VM",
+        :description => "Active VM",
+        :current     => 1,
+        :total_size  => nil,
+        :filename    => nil
+      )
+      expect(snapshot.parent).to be_nil
+
+      expect(v.hardware).to have_attributes(
+        :guest_os             => "other",
+        :guest_os_full_name   => nil,
+        :bios                 => nil,
+        :cpu_cores_per_socket => 1,
+        :cpu_total_cores      => 4,
+        :cpu_sockets          => 4,
+        :annotation           => "",
+        :memory_mb            => 1024
+      )
+
+      expect(v.hardware.disks.size).to eq(1)
+
+      disk = v.hardware.disks.find_by(:device_name => "vm1_Disk1")
+      expect(disk).to have_attributes(
+        :device_name     => "vm1_Disk1",
+        :device_type     => "disk",
+        :controller_type => "virtio",
+        :present         => true,
+        :filename        => "e0001bb7-3e18-457d-af89-8e5b565cc84f",
+        :location        => "0",
+        :size            => 6_442_450_944,
+        :size_on_disk    => 0,
+        :mode            => "persistent",
+        :disk_type       => "thin",
+        :start_connected => true
+      )
+      expect(disk.storage).to eq(@storage) ## CHECK MANUALLY
+
+      expect(v.hardware.guest_devices.size).to eq(1)
+      expect(v.hardware.nics.size).to eq(1)
+
+      nic = v.hardware.nics.find_by(:device_name => "nic1")
+      expect(nic).to have_attributes(
+        :uid_ems         => "cbcf2311-8577-49d4-9670-4e97f9fec853",
+        :device_name     => "nic1",
+        :device_type     => "ethernet",
+        :controller_type => "ethernet",
+        :present         => true,
+        :start_connected => true,
+        :address         => "00:1a:4a:16:01:53"
+      )
+      # nic.lan.should == @lan # TODO: Hook up this connection
+
+      expect(v.parent_datacenter).to have_attributes(
+        :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+        :ems_ref_obj => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+        :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+        :name        => "dc1",
+        :type        => "Datacenter",
+        :folder_path => "Datacenters/dc1"
+      )
+
+      expect(v.parent_folder).to have_attributes(
+        :ems_ref     => nil,
+        :ems_ref_obj => nil,
+        :uid_ems     => "root_dc",
+        :name        => "Datacenters",
+        :type        => nil,
+        :folder_path => "Datacenters"
+      )
+
+      expect(v.parent_blue_folder).to have_attributes(
+        :ems_ref     => nil,
+        :ems_ref_obj => nil,
+        :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1_vm",
+        :name        => "vm",
+        :type        => nil,
+        :folder_path => "Datacenters/dc1/vm"
+      )
+    end
+
+    def assert_specific_template
+      v = ManageIQ::Providers::Redhat::InfraManager::Template.find_by(:name => "template_cd1")
+      expect(v).to have_attributes(
+        :template              => true,
+        :ems_ref               => "/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79",
+        :ems_ref_obj           => "/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79",
+        :uid_ems               => "785e845e-baa0-4812-8a8c-467f37ad6c79",
+        :vendor                => "redhat",
+        :power_state           => "never",
+        :location              => "785e845e-baa0-4812-8a8c-467f37ad6c79.ovf",
+        :tools_status          => nil,
+        :boot_time             => nil,
+        :standby_action        => nil,
+        :connection_state      => "connected",
+        :cpu_affinity          => nil,
+        :memory_reserve        => 4024,
+        :memory_reserve_expand => nil,
+        :memory_limit          => 16_096,
+        :memory_shares         => nil,
+        :memory_shares_level   => nil,
+        :cpu_reserve           => nil,
+        :cpu_reserve_expand    => nil,
+        :cpu_limit             => nil,
+        :cpu_shares            => nil,
+        :cpu_shares_level      => nil
+      )
+
+      expect(v.ext_management_system).to eq(@ems)
+      expect(v.ems_cluster).to eq(@cluster)
+      expect(v.parent_resource_pool).to  be_nil
+      expect(v.host).to                  be_nil
+      expect(v.storages).to eq([@storage]) # CHECK MANUALLY
+      # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
+
+      expect(v.operating_system).to have_attributes(
+        :product_name => "other"
+      )
+
+      expect(v.custom_attributes.size).to eq(0)
+      expect(v.snapshots.size).to eq(0)
+
+      expect(v.hardware).to have_attributes(
+        :guest_os             => "other",
+        :guest_os_full_name   => nil,
+        :bios                 => nil,
+        :cpu_cores_per_socket => 1,
+        :cpu_total_cores      => 4,
+        :cpu_sockets          => 4,
+        :annotation           => nil,
+        :memory_mb            => 4024
+      )
+
+      expect(v.hardware.disks.size).to eq(1)
+
+      disk = v.hardware.disks.find_by(:device_name => "vm1_Disk1")
+      expect(disk).to have_attributes(
+        :device_name     => "vm1_Disk1",
+        :device_type     => "disk",
+        :controller_type => "virtio",
+        :present         => true,
+        :filename        => "7917730e-39fb-4da4-9256-da652c33e5b6",
+        :location        => "0",
+        :size            => 6_442_450_944,
+        :size_on_disk    => 1_838_448_640,
+        :mode            => "persistent",
+        :disk_type       => "thin",
+        :start_connected => true
+      )
+      expect(disk.storage).to eq(@storage) ## CHECK MANUALLY
+
+      expect(v.hardware.guest_devices.size).to eq(0)
+      expect(v.hardware.nics.size).to eq(0)
+      expect(v.hardware.networks.size).to eq(0)
+
+      expect(v.parent_datacenter).to have_attributes(
+        :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+        :ems_ref_obj => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+        :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+        :name        => "dc1",
+        :type        => "Datacenter",
+        :folder_path => "Datacenters/dc1"
+      )
+
+      expect(v.parent_folder).to have_attributes(
+        :ems_ref     => nil,
+        :ems_ref_obj => nil,
+        :uid_ems     => "root_dc",
+        :name        => "Datacenters",
+        :type        => nil,
+        :folder_path => "Datacenters"
+      )
+
+      expect(v.parent_blue_folder).to have_attributes(
+        :ems_ref     => nil,
+        :ems_ref_obj => nil,
+        :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1_vm",
+        :name        => "vm",
+        :type        => nil,
+        :folder_path => "Datacenters/dc1/vm"
+      )
+    end
+
+    def assert_relationship_tree
+      expect(@ems.descendants_arranged).to match_relationship_tree(
+        [EmsFolder, "Datacenters", {:hidden=>true}] => {
+          [Datacenter, "Default"] => {
+            [EmsFolder, "host", {:hidden=>true}] => {
+              [EmsCluster, "Default"] => {
+                [ResourcePool, "Default for Cluster Default"] => {}
+              }
+            }, [EmsFolder, "vm", {:hidden=>true}] => {
+              [ManageIQ::Providers::Redhat::InfraManager::Template, "template_ex_default"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Template, "test_template_1"] => {}
+            }
+          }, [Datacenter, "dc1"] => {
+            [EmsFolder, "host", {:hidden=>true}] => {
+              [EmsCluster, "cc1"] => {
+                [ResourcePool, "Default for Cluster cc1"] => {
+                  [ManageIQ::Providers::Redhat::InfraManager::Vm, "iso_t2"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "iso_t3"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "iso_test_4"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_gaps_p2"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_a1"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_a2"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_b3"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_b5"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_b6"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_c1"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_f2"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_f5"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm1"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm2"] => {}
+                }
+              }, [EmsCluster, "dccc2"] => {
+                [ResourcePool, "Default for Cluster dccc2"] => {}
+              }
+            }, [EmsFolder, "vm", {:hidden=>true}] => {
+              [ManageIQ::Providers::Redhat::InfraManager::Template, "template_cd1"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "iso_t2"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "iso_t3"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "iso_test_4"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_gaps_p2"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_a1"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_a2"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_b3"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_b5"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_b6"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_c1"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_f2"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "test_iso_f5"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm1"] => {}, [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm2"] => {}
+            }
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/support/ovirt_sdk/connection_vcr.rb
+++ b/spec/support/ovirt_sdk/connection_vcr.rb
@@ -1,0 +1,46 @@
+module Spec::Support::OvirtSDK
+  require 'ovirtsdk4'
+  class ConnectionVCR < OvirtSDK4::Connection
+    attr_accessor :all_req_hash
+    attr_reader :path_to_recording, :is_recording
+    DEFAULT_REC_PATH = 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml'.freeze
+    def initialize(opts = {}, path_to_recording = DEFAULT_REC_PATH, is_recording = false)
+      @all_req_hash = {}
+      @path_to_recording = path_to_recording
+      @is_recording = is_recording
+      if File.file?(path_to_recording) && !opts[:force_recording]
+        @all_req_hash = YAML.load_file(path_to_recording)
+      end
+      super(opts)
+    end
+
+    def wait(request)
+      req_key = "#{request.url}#{request.query}#{request.method}#{request.body}"
+      @all_req_hash[req_key] ||= []
+      res = @all_req_hash[req_key].shift
+      return http_response_hash_to_obj(res) if res
+      res = super(request)
+      @all_req_hash[req_key] << http_response_to_hash(res)
+      File.write(path_to_recording, @all_req_hash.to_yaml)
+      res
+    end
+
+    def create_access_token
+      return "access" unless is_recording
+      super
+    end
+
+    def http_response_to_hash(http_response)
+      {
+        :body    => http_response.body,
+        :code    => http_response.code,
+        :headers => http_response.headers,
+        :message => http_response.message
+      }
+    end
+
+    def http_response_hash_to_obj(http_response_hash)
+      OvirtSDK4::HttpResponse.new(http_response_hash)
+    end
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/inventory/strategies/v4/collect_disks.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/inventory/strategies/v4/collect_disks.yml
@@ -1,0 +1,4046 @@
+---
+https://localhost:8443/ovirt-engine/api/vms{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vms>
+        <vm href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d" id="1010ec66-5d68-4ae6-b72b-824f5885259d">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/suspend" rel="suspend"/>
+            </actions>
+            <name>iso_t2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-04T16:35:36.956+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:21:26.104+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88" id="2971952a-d2ba-456c-b090-7d2c2299fe88">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/suspend" rel="suspend"/>
+            </actions>
+            <name>iso_t3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-04T16:55:57.168+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-04T16:55:57.171+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8" id="c586d7dc-a7c0-4e92-8db0-b4eadaed87e8">
+            <actions>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/suspend" rel="suspend"/>
+            </actions>
+            <name>iso_test_4</name>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-05T17:39:23.521+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4219469824</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-05T17:39:40.051+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526" id="71bc98a1-0073-405f-bf0a-6ca68a24b526">
+            <actions>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/suspend" rel="suspend"/>
+            </actions>
+            <name>test_gaps_p2</name>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>2</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-23T14:45:38.616+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>2147483648</memory>
+            <memory_policy>
+                <guaranteed>2147483648</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-23T14:45:46.774+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839" id="51fbdd58-be99-4cb2-9ee5-8cd43efc8839">
+            <actions>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_a1</name>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T11:18:36.537+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4219469824</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:18:45.260+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4" id="4eae23a7-a218-41aa-991c-1f0c07aedfd4">
+            <actions>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_a2</name>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T11:23:36.438+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:23:45.828+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5" id="57cf204b-2938-4245-9bb2-a9e416a486b5">
+            <actions>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_b3</name>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T11:40:38.801+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:40:47.698+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b" id="155ecdc7-c2ed-48ee-a6d0-493c7df9a02b">
+            <actions>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_b5</name>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T11:48:53.858+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:49:11.673+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90" id="cf52ed48-3ff0-4c86-b938-eff4acb5fe90">
+            <actions>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_b6</name>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T13:31:01.380+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T13:31:10.272+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471" id="2698dfeb-c8ba-468b-8125-f3e082bf8471">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_c1</name>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T14:20:17.342+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4219469824</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T14:20:22.239+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52" id="1c59b294-15ab-4630-8715-8850b6e5fd52">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_f2</name>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T14:52:29.490+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T14:52:38.499+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289" id="78e60d40-1fd9-42e7-aa07-4ef4439b5289">
+            <actions>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_f5</name>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T15:40:21.443+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-23T10:05:37.376+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/suspend" rel="suspend"/>
+            </actions>
+            <name>vm1</name>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>true</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2016-06-28T13:31:17.000+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <address>10.35.17.69</address>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <secure_port>5900</secure_port>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>2122317824</memory>
+            <memory_policy>
+                <guaranteed>2122317824</guaranteed>
+                <max>8489271296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <fqdn>vm-18-82.eng.lab.tlv.redhat.com</fqdn>
+            <guest_operating_system>
+                <architecture>x86_64</architecture>
+                <codename>Core</codename>
+                <distribution>CentOS Linux</distribution>
+                <family>Linux</family>
+                <kernel>
+                    <version>
+                        <build>0</build>
+                        <full_version>3.10.0-123.el7.x86_64</full_version>
+                        <major>3</major>
+                        <minor>10</minor>
+                        <revision>123</revision>
+                    </version>
+                </kernel>
+                <version>
+                    <build>1406</build>
+                    <full_version>7.0.1406</full_version>
+                    <major>7</major>
+                    <minor>0</minor>
+                </version>
+            </guest_operating_system>
+            <guest_time_zone>
+                <name>Asia/Jerusalem</name>
+                <utc_offset>+02:00</utc_offset>
+            </guest_time_zone>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <run_once>false</run_once>
+            <start_time>2017-08-02T09:53:36.148+03:00</start_time>
+            <status>up</status>
+            <stop_time>2017-05-24T11:54:41.708+03:00</stop_time>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf" id="072093dc-3492-4cb1-b240-dbf88a8f4fbf">
+            <actions>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/suspend" rel="suspend"/>
+            </actions>
+            <name>vm2</name>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>true</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2016-07-05T14:48:58.000+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>network</device>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_reason></stop_reason>
+            <stop_time>2016-11-17T17:24:40.816+02:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+    </vms>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '5706'
+    correlation-id: ed2bc7cd-89bc-4c23-9d0a-a704454104b9
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/disks{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disks>
+        <disk href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9" id="29d19082-9406-4a14-992c-3f3bcea305d9">
+            <actions>
+                <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/copy" rel="copy"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/statistics" rel="statistics"/>
+            <actual_size>134750208</actual_size>
+            <alias>OVF_STORE</alias>
+            <format>raw</format>
+            <image_id>1c1acd15-1753-4dc6-b30e-5fb3b92aef3d</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881" id="a8f6f43e-9fdc-4d9b-9195-90213f8d1881">
+            <actions>
+                <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/copy" rel="copy"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/statistics" rel="statistics"/>
+            <actual_size>134750208</actual_size>
+            <alias>OVF_STORE</alias>
+            <format>raw</format>
+            <image_id>fcecce72-af95-4b1d-b08c-10bf6f561525</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8" id="b932057a-3990-49ab-b22e-bed62151f0d8">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/copy" rel="copy"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/statistics" rel="statistics"/>
+            <actual_size>134750208</actual_size>
+            <alias>OVF_STORE</alias>
+            <format>raw</format>
+            <image_id>d7c89f1b-861d-4e99-a6c5-bb474fa80d45</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/b1f0065e-9aef-4eb1-8939-aaad13eee28e" id="b1f0065e-9aef-4eb1-8939-aaad13eee28e"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb" id="4672fe17-c260-4ecc-aab0-b535f4d0dbeb"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182" id="cf96c431-f7bb-4dbb-8409-9a648f6c9182">
+            <actions>
+                <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/copy" rel="copy"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/statistics" rel="statistics"/>
+            <actual_size>134750208</actual_size>
+            <alias>OVF_STORE</alias>
+            <format>raw</format>
+            <image_id>4fddda2d-516d-40ac-8518-f6fdc397086d</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/b1f0065e-9aef-4eb1-8939-aaad13eee28e" id="b1f0065e-9aef-4eb1-8939-aaad13eee28e"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb" id="4672fe17-c260-4ecc-aab0-b535f4d0dbeb"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf" id="9d010e66-eee5-472c-be88-ad38685e7ebf">
+            <actions>
+                <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/copy" rel="copy"/>
+            </actions>
+            <name>qwue</name>
+            <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>qwue</alias>
+            <format>cow</format>
+            <image_id>48d46972-fbfe-4766-9e0e-7389cdb79d98</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>53687091200</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>locked</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931" id="0df228b6-2d75-4fc4-b475-8ac0be90f931">
+            <actions>
+                <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>e27dbb5a-73c7-4c37-a3a1-234e0678dab0</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d" id="25bc5579-196f-4558-bf6d-3722b1f25b5d">
+            <actions>
+                <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>ffee8dc4-c0a0-4ebb-ae36-197794d15e69</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4" id="6537938a-4438-4dec-b65f-61a3403b13b4">
+            <actions>
+                <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>06f24728-5fad-44d4-aa42-b30cd4705f5a</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7" id="7728e6b1-7544-43cb-9066-8f4732351bd7">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>1f777566-028d-4613-b7e1-c74aad6b73cd</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6" id="7917730e-39fb-4da4-9256-da652c33e5b6">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/statistics" rel="statistics"/>
+            <actual_size>1838448640</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>raw</format>
+            <image_id>cea4905b-0d4a-4d10-9943-1721ddc454eb</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e" id="88c441ca-1a6d-428f-913a-8092947e1f4e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>1ca72211-c4ea-449a-ab18-6bc2e973f886</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9" id="90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9">
+            <actions>
+                <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>6436e1cc-d49b-4fcd-9b62-e88e8a678ce4</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38" id="a38cccb5-9345-4185-9ef3-600285627e38">
+            <actions>
+                <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/statistics" rel="statistics"/>
+            <actual_size>113172480</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>1d9485ad-f0d9-41d9-aad3-83e7ad9ed022</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5" id="ab6affb1-cab1-4156-930d-bb6b87edced5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>1eb4e9c1-99cb-4c21-92a1-4f003620900c</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec" id="af578e0e-b222-4754-aefc-879bf37eacec">
+            <actions>
+                <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/statistics" rel="statistics"/>
+            <actual_size>93106176</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>d85f85c7-a266-4c06-888c-fd4d498acc63</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8" id="b4ba391b-d617-4353-8aef-c2b3f721a0c8">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>b7073994-1ea5-43c5-b9ee-624a7c03582a</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1" id="c32ee8fe-8328-4021-891f-633cde5d5ce1">
+            <actions>
+                <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>raw</format>
+            <image_id>9deca41a-bf83-4621-b5b9-9facd2ca2277</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f" id="e0001bb7-3e18-457d-af89-8e5b565cc84f">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>raw</format>
+            <image_id>b0f15001-881c-4564-811c-823ca1659e2f</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29" id="e7820fec-15c1-4561-a4c3-63a08f889b29">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>5957000c-11e3-4f30-9a6a-48ab19d61178</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/1f702a46-6a95-46ce-a682-a3ff26dbcee3" id="1f702a46-6a95-46ce-a682-a3ff26dbcee3">
+            <actions>
+                <link href="/ovirt-engine/api/disks/1f702a46-6a95-46ce-a682-a3ff26dbcee3/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/1f702a46-6a95-46ce-a682-a3ff26dbcee3/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/1f702a46-6a95-46ce-a682-a3ff26dbcee3/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/1f702a46-6a95-46ce-a682-a3ff26dbcee3/copy" rel="copy"/>
+            </actions>
+            <name>vm2_AnotherDisk</name>
+            <link href="/ovirt-engine/api/disks/1f702a46-6a95-46ce-a682-a3ff26dbcee3/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/1f702a46-6a95-46ce-a682-a3ff26dbcee3/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>vm2_AnotherDisk</alias>
+            <format>raw</format>
+            <image_id>7e0ffdb7-e1d6-45e5-bd7f-8b621e0dc1d9</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>1073741824</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d" id="9a3e866c-4497-46df-801a-d1739c31c69d">
+            <actions>
+                <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/copy" rel="copy"/>
+            </actions>
+            <name>vm2_Disk1</name>
+            <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm2_Disk1</alias>
+            <format>cow</format>
+            <image_id>b181984a-e625-48c7-895c-f2cbac41d5db</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>5368709120</provisioned_size>
+            <qcow_version>qcow2_v2</qcow_version>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+    </disks>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '2687'
+    correlation-id: 6cb1fab4-7e82-4787-8a33-812ab820213c
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/diskattachments/e0001bb7-3e18-457d-af89-8e5b565cc84f" id="e0001bb7-3e18-457d-af89-8e5b565cc84f">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f" id="e0001bb7-3e18-457d-af89-8e5b565cc84f"/>
+            <vm href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d" id="1010ec66-5d68-4ae6-b72b-824f5885259d"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '310'
+    correlation-id: 44e7b014-8681-429e-bad8-bffe8dc2c6ed
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853" id="cbcf2311-8577-49d4-9670-4e97f9fec853">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d" id="1010ec66-5d68-4ae6-b72b-824f5885259d"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:53</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '410'
+    correlation-id: dbef2a55-eef3-4616-b0c7-579fecc07804
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 48ef6936-473e-43ec-ac76-22c7fc0c4dfc
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/snapshots/c4b36a70-faf4-45e9-bd7d-e7d6470d1855" id="c4b36a70-faf4-45e9-bd7d-e7d6470d1855">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/snapshots/c4b36a70-faf4-45e9-bd7d-e7d6470d1855/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-04T16:35:37.004+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 0c9cfb1c-aa95-45bf-9ee1-ecda93534b0e
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/diskattachments/c32ee8fe-8328-4021-891f-633cde5d5ce1" id="c32ee8fe-8328-4021-891f-633cde5d5ce1">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1" id="c32ee8fe-8328-4021-891f-633cde5d5ce1"/>
+            <vm href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88" id="2971952a-d2ba-456c-b090-7d2c2299fe88"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: abbccb11-1de7-4ecf-a5fa-6bad0c29d076
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5" id="831c5646-4792-46c6-91c6-fb04475694b5">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88" id="2971952a-d2ba-456c-b090-7d2c2299fe88"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:54</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '410'
+    correlation-id: 8e50302e-e686-4edd-ac87-bf91497bd762
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 7e682c42-9d39-4c0f-9bcf-7e446e150776
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/snapshots/4015d7c7-3384-4842-a14d-786d73b488d0" id="4015d7c7-3384-4842-a14d-786d73b488d0">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/snapshots/4015d7c7-3384-4842-a14d-786d73b488d0/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-04T16:55:57.180+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: cb8e75f2-b4e8-45d0-8fb9-4403d2ed896f
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/diskattachments/ab6affb1-cab1-4156-930d-bb6b87edced5" id="ab6affb1-cab1-4156-930d-bb6b87edced5">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5" id="ab6affb1-cab1-4156-930d-bb6b87edced5"/>
+            <vm href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8" id="c586d7dc-a7c0-4e92-8db0-b4eadaed87e8"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '307'
+    correlation-id: ea62b205-7f2b-4aef-a1d0-cc081ccf9d6b
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1" id="52096e94-0ccb-44ea-af10-a691d58c61d1">
+            <actions>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8" id="c586d7dc-a7c0-4e92-8db0-b4eadaed87e8"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:55</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '407'
+    correlation-id: 2c8e8bf4-712b-47b2-a047-e459ac0a883e
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: d1086114-5ee1-420c-b15d-79841131800b
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/snapshots/c487889a-5975-4465-8b2f-d85e2e21ecfb" id="c487889a-5975-4465-8b2f-d85e2e21ecfb">
+            <actions>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/snapshots/c487889a-5975-4465-8b2f-d85e2e21ecfb/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-05T17:39:23.650+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '331'
+    correlation-id: 5f5b17cc-fabb-43c6-97e7-b78211f1dbef
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/diskattachments/25bc5579-196f-4558-bf6d-3722b1f25b5d" id="25bc5579-196f-4558-bf6d-3722b1f25b5d">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d" id="25bc5579-196f-4558-bf6d-3722b1f25b5d"/>
+            <vm href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526" id="71bc98a1-0073-405f-bf0a-6ca68a24b526"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '310'
+    correlation-id: b2235a88-0024-4677-959c-93eb5b2c61d1
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75" id="ab9ae042-3e4d-42f1-a162-7726beab3c75">
+            <actions>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526" id="71bc98a1-0073-405f-bf0a-6ca68a24b526"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5e</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '409'
+    correlation-id: bbe659b3-a790-4ca0-a27b-3097fdbb78ed
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 52d05341-7442-4a59-9749-bc5fe789482c
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/snapshots/2588b2ac-22c7-4557-8a4b-c15293b0aa6b" id="2588b2ac-22c7-4557-8a4b-c15293b0aa6b">
+            <actions>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/snapshots/2588b2ac-22c7-4557-8a4b-c15293b0aa6b/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-23T14:45:38.704+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: b7651c21-bd7c-4852-aac9-e55d0c03eb6d
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/diskattachments/e7820fec-15c1-4561-a4c3-63a08f889b29" id="e7820fec-15c1-4561-a4c3-63a08f889b29">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29" id="e7820fec-15c1-4561-a4c3-63a08f889b29"/>
+            <vm href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839" id="51fbdd58-be99-4cb2-9ee5-8cd43efc8839"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: 0f6f5418-5f03-45a6-947a-30a53786f288
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816" id="1d8f36cd-922a-4c71-ae37-18e087217816">
+            <actions>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839" id="51fbdd58-be99-4cb2-9ee5-8cd43efc8839"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:56</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '409'
+    correlation-id: cffbdcbd-4bfd-4ada-a72f-0e6e39659385
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 400b5d0c-a148-42c0-95b0-fab4658b5bf6
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/snapshots/6a8f5a7c-78dd-432e-85f8-7b74f74d454b" id="6a8f5a7c-78dd-432e-85f8-7b74f74d454b">
+            <actions>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/snapshots/6a8f5a7c-78dd-432e-85f8-7b74f74d454b/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T11:18:36.556+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 22e6bc76-70fa-46d9-9811-180d3926fa1c
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/diskattachments/b4ba391b-d617-4353-8aef-c2b3f721a0c8" id="b4ba391b-d617-4353-8aef-c2b3f721a0c8">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8" id="b4ba391b-d617-4353-8aef-c2b3f721a0c8"/>
+            <vm href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4" id="4eae23a7-a218-41aa-991c-1f0c07aedfd4"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '307'
+    correlation-id: 7bb33a5a-16d7-42a1-9dbe-e36bb048887e
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8" id="8f5d0853-95d3-4b96-bca3-623d03e378b8">
+            <actions>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4" id="4eae23a7-a218-41aa-991c-1f0c07aedfd4"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:57</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '408'
+    correlation-id: 97832b51-930d-4099-8260-f4f63069f872
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: ad18cbda-3c23-4659-94e8-fe5b621a1797
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/snapshots/cd2a4cd2-60f0-4ff6-89f3-e3ac37b2740f" id="cd2a4cd2-60f0-4ff6-89f3-e3ac37b2740f">
+            <actions>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/snapshots/cd2a4cd2-60f0-4ff6-89f3-e3ac37b2740f/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T11:23:36.479+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '331'
+    correlation-id: bc788e8d-9f2c-4826-98aa-8c2d4077e6e6
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/diskattachments/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9" id="90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9" id="90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9"/>
+            <vm href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5" id="57cf204b-2938-4245-9bb2-a9e416a486b5"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: 93d0c9c6-b9c7-4ebc-964a-1c54527d3f3a
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c" id="1855de95-15d5-4414-a8d0-f621c943ae5c">
+            <actions>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5" id="57cf204b-2938-4245-9bb2-a9e416a486b5"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:58</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '410'
+    correlation-id: b584b2cd-d3fc-405c-8361-a0c06b9d6119
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 024e5573-bbd8-4f63-9a79-780d97115866
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/snapshots/6abcd75e-8e21-4436-b98c-0b4b1710a472" id="6abcd75e-8e21-4436-b98c-0b4b1710a472">
+            <actions>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/snapshots/6abcd75e-8e21-4436-b98c-0b4b1710a472/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T11:40:38.811+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 8158c015-81fe-4273-b5a7-2977a74719cf
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/diskattachments/6537938a-4438-4dec-b65f-61a3403b13b4" id="6537938a-4438-4dec-b65f-61a3403b13b4">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4" id="6537938a-4438-4dec-b65f-61a3403b13b4"/>
+            <vm href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b" id="155ecdc7-c2ed-48ee-a6d0-493c7df9a02b"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: 73d8994e-3f7e-4f30-b57c-39b0ff25b44e
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648" id="ff1704a7-bfd0-4b4b-98f3-1440b3571648">
+            <actions>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b" id="155ecdc7-c2ed-48ee-a6d0-493c7df9a02b"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:59</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '408'
+    correlation-id: 4af2cf3e-0f40-438b-b468-7cf17c7fb2b2
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 0f5fd0e6-a3e9-4721-b100-35e410c8ec85
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/snapshots/8bb1ea64-38f3-4719-b360-1d721c199e8a" id="8bb1ea64-38f3-4719-b360-1d721c199e8a">
+            <actions>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/snapshots/8bb1ea64-38f3-4719-b360-1d721c199e8a/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T11:48:53.899+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 8ff4b3d0-5bd3-49ca-b416-a80f8be55108
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/diskattachments/88c441ca-1a6d-428f-913a-8092947e1f4e" id="88c441ca-1a6d-428f-913a-8092947e1f4e">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e" id="88c441ca-1a6d-428f-913a-8092947e1f4e"/>
+            <vm href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90" id="cf52ed48-3ff0-4c86-b938-eff4acb5fe90"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '308'
+    correlation-id: 55f5d39e-753f-4af3-8d83-6dfd57f9b89a
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc" id="80694cc6-0106-4d5b-af8d-b50e9fafe0bc">
+            <actions>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90" id="cf52ed48-3ff0-4c86-b938-eff4acb5fe90"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5a</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '409'
+    correlation-id: 98d84b85-1f09-4070-b28d-794fbedcfd8b
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 03e1b09a-414a-4775-81a4-d843d54e0757
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/snapshots/dc6e7ff4-d523-49b2-ae88-9a20926f9f8a" id="dc6e7ff4-d523-49b2-ae88-9a20926f9f8a">
+            <actions>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/snapshots/dc6e7ff4-d523-49b2-ae88-9a20926f9f8a/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T13:31:01.439+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '332'
+    correlation-id: fc017273-2317-42be-8dc9-a1ce3c502215
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/diskattachments/0df228b6-2d75-4fc4-b475-8ac0be90f931" id="0df228b6-2d75-4fc4-b475-8ac0be90f931">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931" id="0df228b6-2d75-4fc4-b475-8ac0be90f931"/>
+            <vm href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471" id="2698dfeb-c8ba-468b-8125-f3e082bf8471"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: 4e501a48-851a-48ba-b585-5e9917574fc5
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a" id="550e2e64-d6b9-496a-b793-cf388726c82a">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471" id="2698dfeb-c8ba-468b-8125-f3e082bf8471"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5b</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '410'
+    correlation-id: 4864ac4f-a729-403d-9232-e1715a3f9daa
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: c08bc84c-61ea-4f94-8313-5d57c41072e0
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/snapshots/9699684d-62a6-4bb3-97e7-a951a2c53eae" id="9699684d-62a6-4bb3-97e7-a951a2c53eae">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/snapshots/9699684d-62a6-4bb3-97e7-a951a2c53eae/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T14:20:17.405+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '332'
+    correlation-id: dc264f65-6025-4d79-b13c-0d1fbaa6453e
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/diskattachments/7728e6b1-7544-43cb-9066-8f4732351bd7" id="7728e6b1-7544-43cb-9066-8f4732351bd7">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7" id="7728e6b1-7544-43cb-9066-8f4732351bd7"/>
+            <vm href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52" id="1c59b294-15ab-4630-8715-8850b6e5fd52"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '311'
+    correlation-id: e7c017ad-463c-4e03-9919-4229ec229dae
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac" id="d2d908fa-7490-459d-a665-1cb6a8ed14ac">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52" id="1c59b294-15ab-4630-8715-8850b6e5fd52"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5c</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '411'
+    correlation-id: 5ce23b73-e17c-41cc-8ed4-f3939285a56d
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: ea22d6f8-ec01-4604-9143-51d76b75f41e
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/snapshots/5dd593da-5cb1-4c0b-b8bd-ba6b31271a41" id="5dd593da-5cb1-4c0b-b8bd-ba6b31271a41">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/snapshots/5dd593da-5cb1-4c0b-b8bd-ba6b31271a41/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T14:52:29.533+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 1769d2b1-919d-482c-9629-32aea40dcc8c
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/diskattachments/a38cccb5-9345-4185-9ef3-600285627e38" id="a38cccb5-9345-4185-9ef3-600285627e38">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38" id="a38cccb5-9345-4185-9ef3-600285627e38"/>
+            <vm href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289" id="78e60d40-1fd9-42e7-aa07-4ef4439b5289"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '310'
+    correlation-id: 5d92be37-59c1-4420-a4d5-c91fe8b71d06
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4" id="1243335c-692a-46a1-8723-3ae16355a2f4">
+            <actions>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289" id="78e60d40-1fd9-42e7-aa07-4ef4439b5289"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5d</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '408'
+    correlation-id: 874ac70f-9883-44c5-8c7c-8e8b032c98e8
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: a3ae2f2d-d2dd-4966-8fea-6d927cb513ae
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/snapshots/dac821da-485e-4d5d-96c5-b75a959be55f" id="dac821da-485e-4d5d-96c5-b75a959be55f">
+            <actions>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/snapshots/dac821da-485e-4d5d-96c5-b75a959be55f/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T15:40:21.466+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '332'
+    correlation-id: dd27de16-dd03-42e7-87cb-5d06c6f57d6f
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/diskattachments/af578e0e-b222-4754-aefc-879bf37eacec" id="af578e0e-b222-4754-aefc-879bf37eacec">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <logical_name>/dev/vda</logical_name>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec" id="af578e0e-b222-4754-aefc-879bf37eacec"/>
+            <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '326'
+    correlation-id: 2ba2af35-2a23-4182-8535-867f1735fe06
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93" id="6a538d86-38a2-4ac9-98f5-9d401a596e93">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:51</address>
+            </mac>
+            <plugged>true</plugged>
+            <reported_devices>
+                <reported_device href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/65746830-3030-3a31-613a-34613a31363a" id="65746830-3030-3a31-613a-34613a31363a">
+                    <name>eth0</name>
+                    <description>guest reported data</description>
+                    <ips>
+                        <ip>
+                            <address>10.35.18.141</address>
+                            <version>v4</version>
+                        </ip>
+                        <ip>
+                            <address>fe80::21a:4aff:fe16:151</address>
+                            <version>v6</version>
+                        </ip>
+                        <ip>
+                            <address>2620:52:0:2310:21a:4aff:fe16:151</address>
+                            <version>v6</version>
+                        </ip>
+                    </ips>
+                    <mac>
+                        <address>00:1a:4a:16:01:51</address>
+                    </mac>
+                    <type>network</type>
+                    <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+                </reported_device>
+            </reported_devices>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '603'
+    correlation-id: 709d7825-ef45-409a-ae2a-642930a46ddd
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices>
+        <reported_device href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/65746830-3030-3a31-613a-34613a31363a" id="65746830-3030-3a31-613a-34613a31363a">
+            <name>eth0</name>
+            <description>guest reported data</description>
+            <ips>
+                <ip>
+                    <address>10.35.18.141</address>
+                    <version>v4</version>
+                </ip>
+                <ip>
+                    <address>fe80::21a:4aff:fe16:151</address>
+                    <version>v6</version>
+                </ip>
+                <ip>
+                    <address>2620:52:0:2310:21a:4aff:fe16:151</address>
+                    <version>v6</version>
+                </ip>
+            </ips>
+            <mac>
+                <address>00:1a:4a:16:01:51</address>
+            </mac>
+            <type>network</type>
+            <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+        </reported_device>
+    </reported_devices>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '371'
+    correlation-id: 492d8176-e00a-4252-8a4b-28a8fb183651
+    date: Mon, 07 Aug 2017 12:24:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/6e3e547f-9544-42cf-842d-9104828d8511" id="6e3e547f-9544-42cf-842d-9104828d8511">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/6e3e547f-9544-42cf-842d-9104828d8511/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2016-07-05T13:14:08.116+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+        <snapshot href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510" id="05ff445a-0bfc-44c3-90d1-a338e9095510">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/restore" rel="restore"/>
+            </actions>
+            <description>vm1_snap</description>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/disks" rel="disks"/>
+            <date>2016-12-15T09:51:43.247+02:00</date>
+            <persist_memorystate>true</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>regular</snapshot_type>
+            <vm id="3a9401a0-bf3d-4496-8acf-edd3e903511f">
+                <name>vm1</name>
+                <bios>
+                    <boot_menu>
+                        <enabled>true</enabled>
+                    </boot_menu>
+                </bios>
+                <cpu>
+                    <architecture>x86_64</architecture>
+                    <topology>
+                        <cores>1</cores>
+                        <sockets>4</sockets>
+                        <threads>1</threads>
+                    </topology>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <creation_time>2016-06-28T13:31:17.000+03:00</creation_time>
+                <delete_protected>false</delete_protected>
+                <display>
+                    <address>10.35.17.69</address>
+                    <allow_override>false</allow_override>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <monitors>1</monitors>
+                    <secure_port>5900</secure_port>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <smartcard_enabled>false</smartcard_enabled>
+                    <type>spice</type>
+                </display>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>1</priority>
+                </high_availability>
+                <initialization/>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <large_icon id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+                <memory>2122317824</memory>
+                <memory_policy>
+                    <guaranteed>2122317824</guaranteed>
+                    <max>4398046511104</max>
+                </memory_policy>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <migration_downtime>-1</migration_downtime>
+                <origin>ovirt</origin>
+                <os>
+                    <boot>
+                        <devices>
+                            <device>hd</device>
+                        </devices>
+                    </boot>
+                    <type>other</type>
+                </os>
+                <small_icon id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+                <sso>
+                    <methods>
+                        <method id="guest_agent"/>
+                    </methods>
+                </sso>
+                <start_paused>false</start_paused>
+                <stateless>false</stateless>
+                <time_zone>
+                    <name>Etc/GMT</name>
+                </time_zone>
+                <type>desktop</type>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <cluster id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+                <cpu_profile id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+                <fqdn>vm-18-82.eng.lab.tlv.redhat.com</fqdn>
+                <guest_operating_system>
+                    <architecture>x86_64</architecture>
+                    <codename>Core</codename>
+                    <distribution>CentOS Linux</distribution>
+                    <family>Linux</family>
+                    <kernel>
+                        <version>
+                            <build>0</build>
+                            <full_version>3.10.0-123.el7.x86_64</full_version>
+                            <major>3</major>
+                            <minor>10</minor>
+                            <revision>123</revision>
+                        </version>
+                    </kernel>
+                    <version>
+                        <build>1406</build>
+                        <full_version>7.0.1406</full_version>
+                        <major>7</major>
+                        <minor>0</minor>
+                    </version>
+                </guest_operating_system>
+                <guest_time_zone>
+                    <name>Asia/Jerusalem</name>
+                    <utc_offset>+02:00</utc_offset>
+                </guest_time_zone>
+                <next_run_configuration_exists>false</next_run_configuration_exists>
+                <numa_tune_mode>interleave</numa_tune_mode>
+                <placement_policy>
+                    <affinity>migratable</affinity>
+                </placement_policy>
+                <run_once>false</run_once>
+                <start_time>2017-08-02T09:53:36.148+03:00</start_time>
+                <status>up</status>
+                <stop_time>2017-05-24T11:54:41.708+03:00</stop_time>
+                <host id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+                <original_template id="00000000-0000-0000-0000-000000000000"/>
+                <template id="00000000-0000-0000-0000-000000000000"/>
+            </vm>
+        </snapshot>
+        <snapshot href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30" id="e13fc61c-c566-4264-9a75-0e62fe5d7a30">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30/restore" rel="restore"/>
+            </actions>
+            <description>snap 1</description>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30/disks" rel="disks"/>
+            <date>2017-05-24T12:02:44.698+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>regular</snapshot_type>
+            <vm id="3a9401a0-bf3d-4496-8acf-edd3e903511f">
+                <name>vm1</name>
+                <bios>
+                    <boot_menu>
+                        <enabled>true</enabled>
+                    </boot_menu>
+                </bios>
+                <cpu>
+                    <architecture>x86_64</architecture>
+                    <topology>
+                        <cores>1</cores>
+                        <sockets>4</sockets>
+                        <threads>1</threads>
+                    </topology>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <creation_time>2016-06-28T13:31:17.000+03:00</creation_time>
+                <delete_protected>false</delete_protected>
+                <display>
+                    <address>10.35.17.69</address>
+                    <allow_override>false</allow_override>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <monitors>1</monitors>
+                    <secure_port>5900</secure_port>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <smartcard_enabled>false</smartcard_enabled>
+                    <type>spice</type>
+                </display>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>1</priority>
+                </high_availability>
+                <initialization/>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <large_icon id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+                <memory>2122317824</memory>
+                <memory_policy>
+                    <guaranteed>2122317824</guaranteed>
+                    <max>8489271296</max>
+                </memory_policy>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <migration_downtime>-1</migration_downtime>
+                <origin>ovirt</origin>
+                <os>
+                    <boot>
+                        <devices>
+                            <device>hd</device>
+                        </devices>
+                    </boot>
+                    <type>other</type>
+                </os>
+                <small_icon id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+                <sso>
+                    <methods>
+                        <method id="guest_agent"/>
+                    </methods>
+                </sso>
+                <start_paused>false</start_paused>
+                <stateless>false</stateless>
+                <time_zone>
+                    <name>Etc/GMT</name>
+                </time_zone>
+                <type>desktop</type>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <cluster id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+                <cpu_profile id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+                <fqdn>vm-18-82.eng.lab.tlv.redhat.com</fqdn>
+                <guest_operating_system>
+                    <architecture>x86_64</architecture>
+                    <codename>Core</codename>
+                    <distribution>CentOS Linux</distribution>
+                    <family>Linux</family>
+                    <kernel>
+                        <version>
+                            <build>0</build>
+                            <full_version>3.10.0-123.el7.x86_64</full_version>
+                            <major>3</major>
+                            <minor>10</minor>
+                            <revision>123</revision>
+                        </version>
+                    </kernel>
+                    <version>
+                        <build>1406</build>
+                        <full_version>7.0.1406</full_version>
+                        <major>7</major>
+                        <minor>0</minor>
+                    </version>
+                </guest_operating_system>
+                <guest_time_zone>
+                    <name>Asia/Jerusalem</name>
+                    <utc_offset>+02:00</utc_offset>
+                </guest_time_zone>
+                <next_run_configuration_exists>false</next_run_configuration_exists>
+                <numa_tune_mode>interleave</numa_tune_mode>
+                <placement_policy>
+                    <affinity>migratable</affinity>
+                </placement_policy>
+                <run_once>false</run_once>
+                <start_time>2017-08-02T09:53:36.148+03:00</start_time>
+                <status>up</status>
+                <stop_time>2017-05-24T11:54:41.708+03:00</stop_time>
+                <host id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+                <original_template id="00000000-0000-0000-0000-000000000000"/>
+                <template id="00000000-0000-0000-0000-000000000000"/>
+            </vm>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1895'
+    correlation-id: ed319dfe-eb7e-47d6-a6ff-124e2b7700fb
+    date: Mon, 07 Aug 2017 12:24:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/diskattachments/9a3e866c-4497-46df-801a-d1739c31c69d" id="9a3e866c-4497-46df-801a-d1739c31c69d">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d" id="9a3e866c-4497-46df-801a-d1739c31c69d"/>
+            <vm href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf" id="072093dc-3492-4cb1-b240-dbf88a8f4fbf"/>
+        </disk_attachment>
+        <disk_attachment href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/diskattachments/1f702a46-6a95-46ce-a682-a3ff26dbcee3" id="1f702a46-6a95-46ce-a682-a3ff26dbcee3">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio_scsi</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/1f702a46-6a95-46ce-a682-a3ff26dbcee3" id="1f702a46-6a95-46ce-a682-a3ff26dbcee3"/>
+            <vm href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf" id="072093dc-3492-4cb1-b240-dbf88a8f4fbf"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '361'
+    correlation-id: d47477d3-bba2-4bd5-90f7-f8f9278eb813
+    date: Mon, 07 Aug 2017 12:24:44 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e" id="fdc2d708-01d1-4aa4-8b53-d64177181e2e">
+            <actions>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf" id="072093dc-3492-4cb1-b240-dbf88a8f4fbf"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:52</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '409'
+    correlation-id: c678148f-ebe8-4ee3-ad09-883a1efc2ac2
+    date: Mon, 07 Aug 2017 12:24:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 41603846-db9f-491d-afd7-80242c1f1b26
+    date: Mon, 07 Aug 2017 12:24:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912" id="677a1c40-8112-4e4a-bd03-c430e7505912">
+            <actions>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/restore" rel="restore"/>
+            </actions>
+            <description>22</description>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/disks" rel="disks"/>
+            <date>2016-08-02T14:42:19.378+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>regular</snapshot_type>
+            <vm id="072093dc-3492-4cb1-b240-dbf88a8f4fbf">
+                <name>vm2</name>
+                <bios>
+                    <boot_menu>
+                        <enabled>true</enabled>
+                    </boot_menu>
+                </bios>
+                <cpu>
+                    <architecture>x86_64</architecture>
+                    <topology>
+                        <cores>1</cores>
+                        <sockets>1</sockets>
+                        <threads>1</threads>
+                    </topology>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <creation_time>2016-07-05T14:48:58.000+03:00</creation_time>
+                <delete_protected>false</delete_protected>
+                <display>
+                    <allow_override>false</allow_override>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <monitors>1</monitors>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <smartcard_enabled>false</smartcard_enabled>
+                </display>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>1</priority>
+                </high_availability>
+                <initialization/>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <large_icon id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+                <memory>1073741824</memory>
+                <memory_policy>
+                    <guaranteed>1073741824</guaranteed>
+                    <max>4398046511104</max>
+                </memory_policy>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <migration_downtime>-1</migration_downtime>
+                <origin>ovirt</origin>
+                <os>
+                    <boot>
+                        <devices>
+                            <device>network</device>
+                            <device>hd</device>
+                        </devices>
+                    </boot>
+                    <type>other</type>
+                </os>
+                <small_icon id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+                <sso>
+                    <methods>
+                        <method id="guest_agent"/>
+                    </methods>
+                </sso>
+                <start_paused>false</start_paused>
+                <stateless>false</stateless>
+                <time_zone>
+                    <name>Etc/GMT</name>
+                </time_zone>
+                <type>desktop</type>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <cluster id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+                <cpu_profile id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+                <next_run_configuration_exists>false</next_run_configuration_exists>
+                <numa_tune_mode>interleave</numa_tune_mode>
+                <placement_policy>
+                    <affinity>migratable</affinity>
+                </placement_policy>
+                <status>down</status>
+                <stop_reason></stop_reason>
+                <stop_time>2016-11-17T17:24:40.816+02:00</stop_time>
+                <original_template id="00000000-0000-0000-0000-000000000000"/>
+                <template id="00000000-0000-0000-0000-000000000000"/>
+            </vm>
+        </snapshot>
+        <snapshot href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/ef7b7d35-c7b8-4270-8ec7-b85047a50bdc" id="ef7b7d35-c7b8-4270-8ec7-b85047a50bdc">
+            <actions>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/ef7b7d35-c7b8-4270-8ec7-b85047a50bdc/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2016-11-17T17:24:11.967+02:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1384'
+    correlation-id: 04e29145-8f84-47af-ad57-c008b10b16e6
+    date: Mon, 07 Aug 2017 12:24:46 GMT
+  :message: 

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
@@ -1,0 +1,6376 @@
+---
+https://localhost:8443/ovirt-engine/api/clusters{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <clusters>
+        <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf">
+            <actions>
+                <link href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/resetemulatedmachine" rel="resetemulatedmachine"/>
+            </actions>
+            <name>cc1</name>
+            <link href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/networkfilters" rel="networkfilters"/>
+            <link href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/affinitygroups" rel="affinitygroups"/>
+            <link href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/glusterhooks" rel="glusterhooks"/>
+            <link href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/glustervolumes" rel="glustervolumes"/>
+            <ballooning_enabled>false</ballooning_enabled>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <type>Intel Westmere Family</type>
+            </cpu>
+            <custom_scheduling_policy_properties>
+                <property>
+                    <name>HighUtilization</name>
+                    <value>80</value>
+                </property>
+                <property>
+                    <name>CpuOverCommitDurationMinutes</name>
+                    <value>2</value>
+                </property>
+            </custom_scheduling_policy_properties>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_connectivity_broken>
+                    <enabled>true</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+                <skip_if_gluster_bricks_up>false</skip_if_gluster_bricks_up>
+                <skip_if_gluster_quorum_not_met>false</skip_if_gluster_quorum_not_met>
+                <skip_if_sd_active>
+                    <enabled>true</enabled>
+                </skip_if_sd_active>
+            </fencing_policy>
+            <gluster_service>false</gluster_service>
+            <ha_reservation>false</ha_reservation>
+            <ksm>
+                <enabled>false</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <maintenance_reason_required>false</maintenance_reason_required>
+            <memory_policy>
+                <over_commit>
+                    <percent>100</percent>
+                </over_commit>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <bandwidth>
+                    <assignment_method>auto</assignment_method>
+                </bandwidth>
+                <compressed>inherit</compressed>
+                <policy id="80554327-0569-496b-bdeb-fcbbf52b827b"/>
+            </migration>
+            <optional_reason>false</optional_reason>
+            <required_rng_sources>
+                <required_rng_source>random</required_rng_source>
+            </required_rng_sources>
+            <switch_type>legacy</switch_type>
+            <threads_as_cores>false</threads_as_cores>
+            <trusted_service>false</trusted_service>
+            <tunnel_migration>false</tunnel_migration>
+            <version>
+                <major>3</major>
+                <minor>6</minor>
+            </version>
+            <virt_service>true</virt_service>
+            <data_center href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1" id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            <mac_pool href="/ovirt-engine/api/macpools/0000000d-000d-000d-000d-000000000234" id="0000000d-000d-000d-000d-000000000234"/>
+            <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812"/>
+        </cluster>
+        <cluster href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610" id="13fea00a-05fc-4024-8ed2-216cf20bf610">
+            <actions>
+                <link href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/resetemulatedmachine" rel="resetemulatedmachine"/>
+            </actions>
+            <name>dccc2</name>
+            <link href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/networkfilters" rel="networkfilters"/>
+            <link href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/affinitygroups" rel="affinitygroups"/>
+            <link href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/glusterhooks" rel="glusterhooks"/>
+            <link href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/glustervolumes" rel="glustervolumes"/>
+            <ballooning_enabled>false</ballooning_enabled>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <type>Intel Conroe Family</type>
+            </cpu>
+            <custom_scheduling_policy_properties>
+                <property>
+                    <name>HighUtilization</name>
+                    <value>80</value>
+                </property>
+                <property>
+                    <name>CpuOverCommitDurationMinutes</name>
+                    <value>2</value>
+                </property>
+            </custom_scheduling_policy_properties>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_connectivity_broken>
+                    <enabled>true</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+                <skip_if_gluster_bricks_up>false</skip_if_gluster_bricks_up>
+                <skip_if_gluster_quorum_not_met>false</skip_if_gluster_quorum_not_met>
+                <skip_if_sd_active>
+                    <enabled>true</enabled>
+                </skip_if_sd_active>
+            </fencing_policy>
+            <gluster_service>false</gluster_service>
+            <ha_reservation>false</ha_reservation>
+            <ksm>
+                <enabled>false</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <maintenance_reason_required>false</maintenance_reason_required>
+            <memory_policy>
+                <over_commit>
+                    <percent>100</percent>
+                </over_commit>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <bandwidth>
+                    <assignment_method>auto</assignment_method>
+                </bandwidth>
+                <compressed>inherit</compressed>
+                <policy id="80554327-0569-496b-bdeb-fcbbf52b827b"/>
+            </migration>
+            <optional_reason>false</optional_reason>
+            <required_rng_sources>
+                <required_rng_source>random</required_rng_source>
+            </required_rng_sources>
+            <switch_type>legacy</switch_type>
+            <threads_as_cores>false</threads_as_cores>
+            <trusted_service>false</trusted_service>
+            <tunnel_migration>false</tunnel_migration>
+            <version>
+                <major>3</major>
+                <minor>6</minor>
+            </version>
+            <virt_service>true</virt_service>
+            <data_center href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1" id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            <mac_pool href="/ovirt-engine/api/macpools/0000000d-000d-000d-000d-000000000234" id="0000000d-000d-000d-000d-000000000234"/>
+            <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812"/>
+        </cluster>
+        <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092" id="00000002-0002-0002-0002-000000000092">
+            <actions>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/resetemulatedmachine" rel="resetemulatedmachine"/>
+            </actions>
+            <name>Default</name>
+            <description>The default server cluster</description>
+            <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/networkfilters" rel="networkfilters"/>
+            <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/affinitygroups" rel="affinitygroups"/>
+            <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/glusterhooks" rel="glusterhooks"/>
+            <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/glustervolumes" rel="glustervolumes"/>
+            <ballooning_enabled>false</ballooning_enabled>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <type>Intel Westmere Family</type>
+            </cpu>
+            <custom_scheduling_policy_properties>
+                <property>
+                    <name>HighUtilization</name>
+                    <value>80</value>
+                </property>
+                <property>
+                    <name>CpuOverCommitDurationMinutes</name>
+                    <value>2</value>
+                </property>
+            </custom_scheduling_policy_properties>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_connectivity_broken>
+                    <enabled>false</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+                <skip_if_gluster_bricks_up>false</skip_if_gluster_bricks_up>
+                <skip_if_gluster_quorum_not_met>false</skip_if_gluster_quorum_not_met>
+                <skip_if_sd_active>
+                    <enabled>false</enabled>
+                </skip_if_sd_active>
+            </fencing_policy>
+            <gluster_service>false</gluster_service>
+            <ha_reservation>false</ha_reservation>
+            <ksm>
+                <enabled>true</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <maintenance_reason_required>false</maintenance_reason_required>
+            <memory_policy>
+                <over_commit>
+                    <percent>100</percent>
+                </over_commit>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <bandwidth>
+                    <assignment_method>auto</assignment_method>
+                </bandwidth>
+                <compressed>inherit</compressed>
+            </migration>
+            <optional_reason>false</optional_reason>
+            <required_rng_sources>
+                <required_rng_source>urandom</required_rng_source>
+            </required_rng_sources>
+            <switch_type>legacy</switch_type>
+            <threads_as_cores>false</threads_as_cores>
+            <trusted_service>false</trusted_service>
+            <tunnel_migration>false</tunnel_migration>
+            <version>
+                <major>4</major>
+                <minor>1</minor>
+            </version>
+            <virt_service>true</virt_service>
+            <data_center href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f" id="00000001-0001-0001-0001-00000000009f"/>
+            <mac_pool href="/ovirt-engine/api/macpools/0000000d-000d-000d-000d-000000000234" id="0000000d-000d-000d-000d-000000000234"/>
+            <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812"/>
+        </cluster>
+    </clusters>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1439'
+    correlation-id: ca487bee-7e8f-4c94-b6b9-5d05990b3694
+    date: Thu, 03 Aug 2017 10:38:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>data1</name>
+            <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/diskprofiles" rel="diskprofiles"/>
+            <available>46170898432</available>
+            <committed>151397597184</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <storage>
+                <address>spider.eng.lab.tlv.redhat.com</address>
+                <nfs_version>v3</nfs_version>
+                <path>/vol/vol_bodnopoz/data1</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v3</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>7516192768</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_centers>
+                <data_center id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb" id="4672fe17-c260-4ecc-aab0-b535f4d0dbeb">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>data2</name>
+            <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/diskprofiles" rel="diskprofiles"/>
+            <available>46170898432</available>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <storage>
+                <address>spider.eng.lab.tlv.redhat.com</address>
+                <path>/vol/vol_bodnopoz/data2</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v3</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>7516192768</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_centers>
+                <data_center id="00000001-0001-0001-0001-00000000009f"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1" id="0c55619d-4d88-4bd1-921c-5425275061d1">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>export</name>
+            <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/diskprofiles" rel="diskprofiles"/>
+            <available>46170898432</available>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <storage>
+                <address>spider.eng.lab.tlv.redhat.com</address>
+                <nfs_version>v3</nfs_version>
+                <path>/vol/vol_bodnopoz/export</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>export</type>
+            <used>7516192768</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_centers>
+                <data_center id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0" id="9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>isos</name>
+            <link href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/files" rel="files"/>
+            <link href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/diskprofiles" rel="diskprofiles"/>
+            <available>153545080832</available>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <storage>
+                <address>venus-vdsb.usersys.redhat.com</address>
+                <nfs_version>v3</nfs_version>
+                <path>/home/nfsshare/boris/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>53687091200</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_centers>
+                <data_center id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74" id="072fbaa1-08f3-4a40-9f34-a5ca22dd1d74">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>ovirt-image-repository</name>
+            <link href="/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/images" rel="images"/>
+            <link href="/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/diskprofiles" rel="diskprofiles"/>
+            <committed>0</committed>
+            <critical_space_action_blocker>0</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>unattached</status>
+            <storage>
+                <type>glance</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>image</type>
+            <warning_low_space_indicator>0</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1238'
+    correlation-id: e8d90542-d249-4cf7-9d99-d0f03cda492d
+    date: Thu, 03 Aug 2017 10:38:45 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/hosts{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <hosts>
+        <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a">
+            <actions>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/setupnetworks" rel="setupnetworks"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/enrollcertificate" rel="enrollcertificate"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/approve" rel="approve"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/commitnetconfig" rel="commitnetconfig"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/forceselectspm" rel="forceselectspm"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/iscsidiscover" rel="iscsidiscover"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/iscsilogin" rel="iscsilogin"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/unregisteredstoragedomainsdiscover" rel="unregisteredstoragedomainsdiscover"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/upgradecheck" rel="upgradecheck"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/refresh" rel="refresh"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/fence" rel="fence"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/install" rel="install"/>
+                <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/activate" rel="activate"/>
+            </actions>
+            <name>bodh1</name>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/devices" rel="devices"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/hooks" rel="hooks"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/storage" rel="storage"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/storageconnectionextensions" rel="storageconnectionextensions"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/unmanagednetworks" rel="unmanagednetworks"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/fenceagents" rel="fenceagents"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics" rel="statistics"/>
+            <address>bodh1.usersys.redhat.com</address>
+            <auto_numa_status>disable</auto_numa_status>
+            <certificate>
+                <organization>Test</organization>
+                <subject>O=Test,CN=bodh1.usersys.redhat.com</subject>
+            </certificate>
+            <cpu>
+                <name>Westmere E56xx/L56xx/X56xx (Nehalem-C)</name>
+                <speed>2400</speed>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>2</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <device_passthrough>
+                <enabled>false</enabled>
+            </device_passthrough>
+            <external_status>ok</external_status>
+            <hardware_information>
+                <family>Red Hat Enterprise Linux</family>
+                <manufacturer>Red Hat</manufacturer>
+                <product_name>RHEV Hypervisor</product_name>
+                <serial_number>30353036-3837-4247-3831-303946353239</serial_number>
+                <supported_rng_sources>
+                    <supported_rng_source>random</supported_rng_source>
+                </supported_rng_sources>
+                <uuid>4587CAA0-8F1A-4246-838B-0F5380A7E67E</uuid>
+                <version>7.3-7.el7</version>
+            </hardware_information>
+            <iscsi>
+                <initiator>iqn.1994-05.com.redhat:3a591f887a5</initiator>
+            </iscsi>
+            <kdump_status>disabled</kdump_status>
+            <ksm>
+                <enabled>false</enabled>
+            </ksm>
+            <libvirt_version>
+                <build>17</build>
+                <full_version>libvirt-1.2.17-13.el7_2.5</full_version>
+                <major>1</major>
+                <minor>2</minor>
+                <revision>0</revision>
+            </libvirt_version>
+            <max_scheduling_memory>3568304128</max_scheduling_memory>
+            <memory>3973054464</memory>
+            <numa_supported>false</numa_supported>
+            <os>
+                <custom_kernel_cmdline></custom_kernel_cmdline>
+                <reported_kernel_cmdline>BOOT_IMAGE=/vmlinuz-3.10.0-327.18.2.el7.x86_64 root=/dev/mapper/vg0-lv_root ro rd.lvm.lv=vg0/lv_root vconsole.font=latarcyrheb-sun16 rd.lvm.lv=vg0/lv_swap crashkernel=auto vconsole.keymap=us rhgb quiet LANG=en_US.UTF-8</reported_kernel_cmdline>
+                <type>RHEL</type>
+                <version>
+                    <full_version>7 - 1.1503.el7.centos.2.8</full_version>
+                    <major>7</major>
+                </version>
+            </os>
+            <port>54321</port>
+            <power_management>
+                <automatic_pm_enabled>true</automatic_pm_enabled>
+                <enabled>false</enabled>
+                <kdump_detection>true</kdump_detection>
+                <pm_proxies/>
+            </power_management>
+            <protocol>stomp</protocol>
+            <se_linux>
+                <mode>enforcing</mode>
+            </se_linux>
+            <spm>
+                <priority>5</priority>
+                <status>spm</status>
+            </spm>
+            <ssh>
+                <fingerprint>SHA256:c34s0Cfo9dzBEtKX/P2gNqS6aoacuYJre2B21feC7Xk</fingerprint>
+                <port>22</port>
+            </ssh>
+            <status>up</status>
+            <summary>
+                <active>0</active>
+                <migrating>0</migrating>
+                <total>0</total>
+            </summary>
+            <transparent_hugepages>
+                <enabled>true</enabled>
+            </transparent_hugepages>
+            <type>rhel</type>
+            <update_available>true</update_available>
+            <version>
+                <build>999</build>
+                <full_version>vdsm-4.18.999-156.git7c6905e.el7.centos</full_version>
+                <major>4</major>
+                <minor>18</minor>
+                <revision>0</revision>
+            </version>
+            <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092" id="00000002-0002-0002-0002-000000000092"/>
+        </host>
+        <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747">
+            <actions>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/setupnetworks" rel="setupnetworks"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/enrollcertificate" rel="enrollcertificate"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/approve" rel="approve"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/commitnetconfig" rel="commitnetconfig"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/forceselectspm" rel="forceselectspm"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/iscsidiscover" rel="iscsidiscover"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/iscsilogin" rel="iscsilogin"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/unregisteredstoragedomainsdiscover" rel="unregisteredstoragedomainsdiscover"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/upgradecheck" rel="upgradecheck"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/refresh" rel="refresh"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/fence" rel="fence"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/install" rel="install"/>
+                <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/activate" rel="activate"/>
+            </actions>
+            <name>bodh2</name>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/devices" rel="devices"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/hooks" rel="hooks"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/storage" rel="storage"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/storageconnectionextensions" rel="storageconnectionextensions"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/unmanagednetworks" rel="unmanagednetworks"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/fenceagents" rel="fenceagents"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics" rel="statistics"/>
+            <address>bodh2.usersys.redhat.com</address>
+            <auto_numa_status>disable</auto_numa_status>
+            <certificate>
+                <organization>Test</organization>
+                <subject>O=Test,CN=bodh2.usersys.redhat.com</subject>
+            </certificate>
+            <cpu>
+                <name>Westmere E56xx/L56xx/X56xx (Nehalem-C)</name>
+                <speed>2400</speed>
+                <topology>
+                    <cores>4</cores>
+                    <sockets>2</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <device_passthrough>
+                <enabled>false</enabled>
+            </device_passthrough>
+            <external_status>ok</external_status>
+            <hardware_information>
+                <family>Red Hat Enterprise Linux</family>
+                <manufacturer>Red Hat</manufacturer>
+                <product_name>RHEV Hypervisor</product_name>
+                <serial_number>30353036-3837-4247-3831-303946353239</serial_number>
+                <supported_rng_sources>
+                    <supported_rng_source>random</supported_rng_source>
+                </supported_rng_sources>
+                <uuid>263886E9-5A74-48D4-8839-6FEAFBC380F4</uuid>
+                <version>7.3-7.el7</version>
+            </hardware_information>
+            <iscsi>
+                <initiator>iqn.1994-05.com.redhat:d8ad6f214bf</initiator>
+            </iscsi>
+            <kdump_status>disabled</kdump_status>
+            <ksm>
+                <enabled>false</enabled>
+            </ksm>
+            <libvirt_version>
+                <build>17</build>
+                <full_version>libvirt-1.2.17-13.el7_2.5</full_version>
+                <major>1</major>
+                <minor>2</minor>
+                <revision>0</revision>
+            </libvirt_version>
+            <max_scheduling_memory>14055112704</max_scheduling_memory>
+            <memory>16650338304</memory>
+            <numa_supported>false</numa_supported>
+            <os>
+                <custom_kernel_cmdline></custom_kernel_cmdline>
+                <reported_kernel_cmdline>BOOT_IMAGE=/vmlinuz-3.10.0-327.18.2.el7.x86_64 root=/dev/mapper/vg0-lv_root ro crashkernel=auto rd.lvm.lv=vg0/lv_root rd.lvm.lv=vg0/lv_swap rhgb quiet LANG=en_US.UTF-8</reported_kernel_cmdline>
+                <type>RHEL</type>
+                <version>
+                    <full_version>7.2 - 9.el7</full_version>
+                    <major>7</major>
+                    <minor>2</minor>
+                </version>
+            </os>
+            <port>54321</port>
+            <power_management>
+                <automatic_pm_enabled>true</automatic_pm_enabled>
+                <enabled>false</enabled>
+                <kdump_detection>true</kdump_detection>
+                <pm_proxies/>
+            </power_management>
+            <protocol>stomp</protocol>
+            <se_linux>
+                <mode>enforcing</mode>
+            </se_linux>
+            <spm>
+                <priority>5</priority>
+                <status>spm</status>
+            </spm>
+            <ssh>
+                <fingerprint>SHA256:GHC9k+DeY93GWGRpwbqgluCBmkXxFvz1FK29FCtju4Q</fingerprint>
+                <port>22</port>
+            </ssh>
+            <status>up</status>
+            <summary>
+                <active>1</active>
+                <migrating>0</migrating>
+                <total>1</total>
+            </summary>
+            <transparent_hugepages>
+                <enabled>true</enabled>
+            </transparent_hugepages>
+            <type>rhel</type>
+            <update_available>true</update_available>
+            <version>
+                <build>999</build>
+                <full_version>vdsm-4.18.999-156.git7c6905e.el7.centos</full_version>
+                <major>4</major>
+                <minor>18</minor>
+                <revision>0</revision>
+            </version>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+        </host>
+        <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa">
+            <actions>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/setupnetworks" rel="setupnetworks"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/enrollcertificate" rel="enrollcertificate"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/approve" rel="approve"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/commitnetconfig" rel="commitnetconfig"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/forceselectspm" rel="forceselectspm"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/iscsidiscover" rel="iscsidiscover"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/iscsilogin" rel="iscsilogin"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/unregisteredstoragedomainsdiscover" rel="unregisteredstoragedomainsdiscover"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/upgradecheck" rel="upgradecheck"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/refresh" rel="refresh"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/fence" rel="fence"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/install" rel="install"/>
+                <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/activate" rel="activate"/>
+            </actions>
+            <name>motis</name>
+            <comment></comment>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/devices" rel="devices"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/hooks" rel="hooks"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/storage" rel="storage"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/storageconnectionextensions" rel="storageconnectionextensions"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/unmanagednetworks" rel="unmanagednetworks"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/fenceagents" rel="fenceagents"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics" rel="statistics"/>
+            <address>venus-vdsb.usersys.redhat.com</address>
+            <auto_numa_status>disable</auto_numa_status>
+            <certificate>
+                <organization>Test</organization>
+                <subject>O=Test,CN=venus-vdsb.usersys.redhat.com</subject>
+            </certificate>
+            <cpu>
+                <name>Intel(R) Core(TM)2 Quad CPU    Q8400  @ 2.66GHz</name>
+                <speed>2660</speed>
+                <topology>
+                    <cores>4</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <device_passthrough>
+                <enabled>false</enabled>
+            </device_passthrough>
+            <external_status>ok</external_status>
+            <hardware_information>
+                <manufacturer>Dell Inc.</manufacturer>
+                <product_name>OptiPlex 780</product_name>
+                <serial_number>7BL605J</serial_number>
+                <supported_rng_sources>
+                    <supported_rng_source>random</supported_rng_source>
+                </supported_rng_sources>
+                <uuid>44454c4c-4200-104c-8036-b7c04f30354a</uuid>
+            </hardware_information>
+            <iscsi>
+                <initiator>iqn.1994-05.com.redhat:bodnopoz-vm-2</initiator>
+            </iscsi>
+            <kdump_status>enabled</kdump_status>
+            <ksm>
+                <enabled>false</enabled>
+            </ksm>
+            <libvirt_version>
+                <build>17</build>
+                <full_version>libvirt-1.2.17-13.el7_2.4</full_version>
+                <major>1</major>
+                <minor>2</minor>
+                <revision>0</revision>
+            </libvirt_version>
+            <max_scheduling_memory>3463446528</max_scheduling_memory>
+            <memory>3868196864</memory>
+            <numa_supported>false</numa_supported>
+            <os>
+                <custom_kernel_cmdline></custom_kernel_cmdline>
+                <type>RHEL</type>
+                <version>
+                    <full_version>7 - 1.1503.el7.centos.2.8</full_version>
+                    <major>7</major>
+                </version>
+            </os>
+            <port>54321</port>
+            <power_management>
+                <automatic_pm_enabled>true</automatic_pm_enabled>
+                <enabled>false</enabled>
+                <kdump_detection>true</kdump_detection>
+                <pm_proxies/>
+            </power_management>
+            <protocol>stomp</protocol>
+            <se_linux>
+                <mode>enforcing</mode>
+            </se_linux>
+            <spm>
+                <priority>5</priority>
+                <status>none</status>
+            </spm>
+            <ssh>
+                <fingerprint>SHA256:mm10Fxl4ZSOAYncZ68gWU9T31f8tQFHgLAvV5+2UHZ8</fingerprint>
+                <port>22</port>
+            </ssh>
+            <status>non_responsive</status>
+            <summary>
+                <active>0</active>
+                <migrating>0</migrating>
+                <total>0</total>
+            </summary>
+            <transparent_hugepages>
+                <enabled>true</enabled>
+            </transparent_hugepages>
+            <type>rhel</type>
+            <update_available>false</update_available>
+            <version>
+                <build>32</build>
+                <full_version>vdsm-4.17.32-0.el7.centos</full_version>
+                <major>4</major>
+                <minor>17</minor>
+                <revision>0</revision>
+            </version>
+            <cluster href="/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610" id="13fea00a-05fc-4024-8ed2-216cf20bf610"/>
+        </host>
+    </hosts>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '2786'
+    correlation-id: 4315e24a-e53b-471d-abcd-54957f224f0d
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <host_nics>
+        <host_nic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/nics/01c2d4a8-5d7a-4960-bfc4-ca1b400a9bdd" id="01c2d4a8-5d7a-4960-bfc4-ca1b400a9bdd">
+            <actions/>
+            <name>eth0</name>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/nics/01c2d4a8-5d7a-4960-bfc4-ca1b400a9bdd/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/nics/01c2d4a8-5d7a-4960-bfc4-ca1b400a9bdd/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/nics/01c2d4a8-5d7a-4960-bfc4-ca1b400a9bdd/statistics" rel="statistics"/>
+            <boot_protocol>dhcp</boot_protocol>
+            <bridged>true</bridged>
+            <custom_configuration>false</custom_configuration>
+            <ip>
+                <address>10.35.19.12</address>
+                <gateway>10.35.19.254</gateway>
+                <netmask>255.255.252.0</netmask>
+                <version>v4</version>
+            </ip>
+            <ipv6>
+                <address>2620:52:0:2310:21a:4aff:fe23:128c</address>
+                <gateway>::</gateway>
+                <netmask>64</netmask>
+                <version>v6</version>
+            </ipv6>
+            <ipv6_boot_protocol>dhcp</ipv6_boot_protocol>
+            <mac>
+                <address>00:1a:4a:23:12:8c</address>
+            </mac>
+            <mtu>1500</mtu>
+            <properties/>
+            <status>up</status>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+            <network href="/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
+        </host_nic>
+    </host_nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '536'
+    correlation-id: 9b538fe5-b12c-4046-80da-47533a78c73c
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <statistics>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896" id="7816602b-c05c-3db7-a4da-3769f7ad8896">
+            <name>memory.total</name>
+            <description>Total memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>3973054464</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08" id="b7499508-c1c3-32f0-8174-c1783e57bb08">
+            <name>memory.used</name>
+            <description>Used memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>437035991</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946" id="5a0fba9d-33d7-3cbf-addd-ba462040c946">
+            <name>memory.free</name>
+            <description>Free memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>3536018473</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc" id="ffc0e1fd-fa34-3f85-9862-8a841c1658bc">
+            <name>memory.shared</name>
+            <description>Shared memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f" id="c81c86f0-bc61-3c78-a543-898b8339d03f">
+            <name>memory.buffers</name>
+            <description>IO buffers</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11" id="1b6244ee-8dbd-365d-8762-482ddc05ee11">
+            <name>memory.cached</name>
+            <description>OS caches</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b" id="c43847d7-3bc1-3aaf-b92c-902e64bbdb5b">
+            <name>swap.total</name>
+            <description>Total swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>16776167424</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46" id="1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46">
+            <name>swap.free</name>
+            <description>Free swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>16776167424</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9" id="27686b4e-ba8d-3576-bc70-d68cbd8a2ba9">
+            <name>swap.used</name>
+            <description>Used swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07" id="ea00da15-de2d-3393-a7cb-810c4b19ed07">
+            <name>swap.cached</name>
+            <description>Swap also in memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169" id="f740b9ad-14a7-3f6c-9b80-efff44777169">
+            <name>ksm.cpu.current</name>
+            <description>KSM CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719" id="a1fab379-66e2-3b1d-9914-81a9e79cb719">
+            <name>cpu.current.user</name>
+            <description>User CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>1</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815" id="a98c1e11-078c-3593-a57e-4b12c1ce9815">
+            <name>cpu.current.system</name>
+            <description>System CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac" id="4ae97794-f56d-3f05-a9e7-8798887cd1ac">
+            <name>cpu.current.idle</name>
+            <description>Idle CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>99</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/65860dae-c890-312e-9314-5c01f31225ab" id="65860dae-c890-312e-9314-5c01f31225ab">
+            <name>cpu.load.avg.5m</name>
+            <description>CPU 5 minute load average</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0.030</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/3ceb2072-a5a5-3b21-9bb2-e966471fd81c" id="3ceb2072-a5a5-3b21-9bb2-e966471fd81c">
+            <name>boot.time</name>
+            <description>Boot time of the machine</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>none</unit>
+            <values>
+                <value>
+                    <datum>1501413029</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a" id="5bf6b336-f86d-4551-ac08-d34621ec5f0a"/>
+        </statistic>
+    </statistics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1117'
+    correlation-id: 735550bd-789f-463b-94b3-f54cd7dba33a
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <host_nics>
+        <host_nic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/nics/59646cf3-f01a-4f5f-9633-40c26ea5f938" id="59646cf3-f01a-4f5f-9633-40c26ea5f938">
+            <actions/>
+            <name>eth0</name>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/nics/59646cf3-f01a-4f5f-9633-40c26ea5f938/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/nics/59646cf3-f01a-4f5f-9633-40c26ea5f938/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/nics/59646cf3-f01a-4f5f-9633-40c26ea5f938/statistics" rel="statistics"/>
+            <boot_protocol>dhcp</boot_protocol>
+            <bridged>true</bridged>
+            <custom_configuration>true</custom_configuration>
+            <ip>
+                <address>10.35.17.69</address>
+                <gateway>10.35.19.254</gateway>
+                <netmask>255.255.252.0</netmask>
+                <version>v4</version>
+            </ip>
+            <ipv6>
+                <address>2620:52:0:2310:21a:4aff:fe23:13fe</address>
+                <gateway>::</gateway>
+                <netmask>64</netmask>
+                <version>v6</version>
+            </ipv6>
+            <ipv6_boot_protocol>dhcp</ipv6_boot_protocol>
+            <mac>
+                <address>00:1a:4a:23:13:fe</address>
+            </mac>
+            <mtu>1500</mtu>
+            <properties/>
+            <status>up</status>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+            <network href="/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef" id="6ad90f38-5496-47fb-9882-5aa55e1314ef"/>
+        </host_nic>
+    </host_nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '551'
+    correlation-id: 4c647f1e-fc48-4888-831c-b152be40930e
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <statistics>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896" id="7816602b-c05c-3db7-a4da-3769f7ad8896">
+            <name>memory.total</name>
+            <description>Total memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>16650338304</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08" id="b7499508-c1c3-32f0-8174-c1783e57bb08">
+            <name>memory.used</name>
+            <description>Used memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>1498530447</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946" id="5a0fba9d-33d7-3cbf-addd-ba462040c946">
+            <name>memory.free</name>
+            <description>Free memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>15151807857</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc" id="ffc0e1fd-fa34-3f85-9862-8a841c1658bc">
+            <name>memory.shared</name>
+            <description>Shared memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f" id="c81c86f0-bc61-3c78-a543-898b8339d03f">
+            <name>memory.buffers</name>
+            <description>IO buffers</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11" id="1b6244ee-8dbd-365d-8762-482ddc05ee11">
+            <name>memory.cached</name>
+            <description>OS caches</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b" id="c43847d7-3bc1-3aaf-b92c-902e64bbdb5b">
+            <name>swap.total</name>
+            <description>Total swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>16776167424</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46" id="1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46">
+            <name>swap.free</name>
+            <description>Free swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>16776167424</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9" id="27686b4e-ba8d-3576-bc70-d68cbd8a2ba9">
+            <name>swap.used</name>
+            <description>Used swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07" id="ea00da15-de2d-3393-a7cb-810c4b19ed07">
+            <name>swap.cached</name>
+            <description>Swap also in memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169" id="f740b9ad-14a7-3f6c-9b80-efff44777169">
+            <name>ksm.cpu.current</name>
+            <description>KSM CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719" id="a1fab379-66e2-3b1d-9914-81a9e79cb719">
+            <name>cpu.current.user</name>
+            <description>User CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>1</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815" id="a98c1e11-078c-3593-a57e-4b12c1ce9815">
+            <name>cpu.current.system</name>
+            <description>System CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>1</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac" id="4ae97794-f56d-3f05-a9e7-8798887cd1ac">
+            <name>cpu.current.idle</name>
+            <description>Idle CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>99</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/65860dae-c890-312e-9314-5c01f31225ab" id="65860dae-c890-312e-9314-5c01f31225ab">
+            <name>cpu.load.avg.5m</name>
+            <description>CPU 5 minute load average</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0.020</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/3ceb2072-a5a5-3b21-9bb2-e966471fd81c" id="3ceb2072-a5a5-3b21-9bb2-e966471fd81c">
+            <name>boot.time</name>
+            <description>Boot time of the machine</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>none</unit>
+            <values>
+                <value>
+                    <datum>1501413581</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+        </statistic>
+    </statistics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1115'
+    correlation-id: fc2c8285-a7c5-4d55-871a-d9a39ead020d
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <host_nics>
+        <host_nic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/1e49055d-11e6-4c06-9dd7-0ad1e1e32f43" id="1e49055d-11e6-4c06-9dd7-0ad1e1e32f43">
+            <actions/>
+            <name>enp4s0</name>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/1e49055d-11e6-4c06-9dd7-0ad1e1e32f43/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/1e49055d-11e6-4c06-9dd7-0ad1e1e32f43/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/1e49055d-11e6-4c06-9dd7-0ad1e1e32f43/statistics" rel="statistics"/>
+            <boot_protocol>none</boot_protocol>
+            <bridged>false</bridged>
+            <ip>
+                <address></address>
+                <netmask></netmask>
+                <version>v4</version>
+            </ip>
+            <ipv6_boot_protocol>none</ipv6_boot_protocol>
+            <mac>
+                <address>00:07:e9:11:0d:e5</address>
+            </mac>
+            <mtu>1500</mtu>
+            <status>down</status>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </host_nic>
+        <host_nic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/192e4fce-7237-49bd-8e75-13ac27bd8349" id="192e4fce-7237-49bd-8e75-13ac27bd8349">
+            <actions/>
+            <name>enp0s25</name>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/192e4fce-7237-49bd-8e75-13ac27bd8349/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/192e4fce-7237-49bd-8e75-13ac27bd8349/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/192e4fce-7237-49bd-8e75-13ac27bd8349/statistics" rel="statistics"/>
+            <boot_protocol>dhcp</boot_protocol>
+            <bridged>true</bridged>
+            <custom_configuration>true</custom_configuration>
+            <ip>
+                <address>10.35.0.154</address>
+                <gateway>10.35.1.254</gateway>
+                <netmask>255.255.254.0</netmask>
+                <version>v4</version>
+            </ip>
+            <ipv6>
+                <gateway>::</gateway>
+                <version>v6</version>
+            </ipv6>
+            <ipv6_boot_protocol>none</ipv6_boot_protocol>
+            <mac>
+                <address>84:2b:2b:bf:60:43</address>
+            </mac>
+            <mtu>1500</mtu>
+            <properties/>
+            <speed>100000000</speed>
+            <status>up</status>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+            <network href="/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef" id="6ad90f38-5496-47fb-9882-5aa55e1314ef"/>
+        </host_nic>
+    </host_nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '640'
+    correlation-id: d1341ffc-be13-41f5-8b2f-89f41cc2c022
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <statistics>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896" id="7816602b-c05c-3db7-a4da-3769f7ad8896">
+            <name>memory.total</name>
+            <description>Total memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>3868196864</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08" id="b7499508-c1c3-32f0-8174-c1783e57bb08">
+            <name>memory.used</name>
+            <description>Used memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946" id="5a0fba9d-33d7-3cbf-addd-ba462040c946">
+            <name>memory.free</name>
+            <description>Free memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>3868196864</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc" id="ffc0e1fd-fa34-3f85-9862-8a841c1658bc">
+            <name>memory.shared</name>
+            <description>Shared memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f" id="c81c86f0-bc61-3c78-a543-898b8339d03f">
+            <name>memory.buffers</name>
+            <description>IO buffers</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11" id="1b6244ee-8dbd-365d-8762-482ddc05ee11">
+            <name>memory.cached</name>
+            <description>OS caches</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b" id="c43847d7-3bc1-3aaf-b92c-902e64bbdb5b">
+            <name>swap.total</name>
+            <description>Total swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>16776167424</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46" id="1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46">
+            <name>swap.free</name>
+            <description>Free swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>16776167424</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9" id="27686b4e-ba8d-3576-bc70-d68cbd8a2ba9">
+            <name>swap.used</name>
+            <description>Used swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07" id="ea00da15-de2d-3393-a7cb-810c4b19ed07">
+            <name>swap.cached</name>
+            <description>Swap also in memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169" id="f740b9ad-14a7-3f6c-9b80-efff44777169">
+            <name>ksm.cpu.current</name>
+            <description>KSM CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719" id="a1fab379-66e2-3b1d-9914-81a9e79cb719">
+            <name>cpu.current.user</name>
+            <description>User CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815" id="a98c1e11-078c-3593-a57e-4b12c1ce9815">
+            <name>cpu.current.system</name>
+            <description>System CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac" id="4ae97794-f56d-3f05-a9e7-8798887cd1ac">
+            <name>cpu.current.idle</name>
+            <description>Idle CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/65860dae-c890-312e-9314-5c01f31225ab" id="65860dae-c890-312e-9314-5c01f31225ab">
+            <name>cpu.load.avg.5m</name>
+            <description>CPU 5 minute load average</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/3ceb2072-a5a5-3b21-9bb2-e966471fd81c" id="3ceb2072-a5a5-3b21-9bb2-e966471fd81c">
+            <name>boot.time</name>
+            <description>Boot time of the machine</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>none</unit>
+            <values>
+                <value>
+                    <datum>1464607249</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa" id="2d0f658b-37fe-4692-b0d7-7d18b18eadaa"/>
+        </statistic>
+    </statistics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1093'
+    correlation-id: 6e641fd7-8704-4999-aebf-04c983068078
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vms>
+        <vm href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d" id="1010ec66-5d68-4ae6-b72b-824f5885259d">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/suspend" rel="suspend"/>
+            </actions>
+            <name>iso_t2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-04T16:35:36.956+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:21:26.104+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88" id="2971952a-d2ba-456c-b090-7d2c2299fe88">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/suspend" rel="suspend"/>
+            </actions>
+            <name>iso_t3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-04T16:55:57.168+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-04T16:55:57.171+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8" id="c586d7dc-a7c0-4e92-8db0-b4eadaed87e8">
+            <actions>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/suspend" rel="suspend"/>
+            </actions>
+            <name>iso_test_4</name>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-05T17:39:23.521+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4219469824</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-05T17:39:40.051+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526" id="71bc98a1-0073-405f-bf0a-6ca68a24b526">
+            <actions>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/suspend" rel="suspend"/>
+            </actions>
+            <name>test_gaps_p2</name>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>2</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-23T14:45:38.616+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>2147483648</memory>
+            <memory_policy>
+                <guaranteed>2147483648</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-23T14:45:46.774+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839" id="51fbdd58-be99-4cb2-9ee5-8cd43efc8839">
+            <actions>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_a1</name>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T11:18:36.537+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4219469824</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:18:45.260+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4" id="4eae23a7-a218-41aa-991c-1f0c07aedfd4">
+            <actions>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_a2</name>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T11:23:36.438+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:23:45.828+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5" id="57cf204b-2938-4245-9bb2-a9e416a486b5">
+            <actions>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_b3</name>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T11:40:38.801+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:40:47.698+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b" id="155ecdc7-c2ed-48ee-a6d0-493c7df9a02b">
+            <actions>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_b5</name>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T11:48:53.858+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T11:49:11.673+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90" id="cf52ed48-3ff0-4c86-b938-eff4acb5fe90">
+            <actions>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_b6</name>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T13:31:01.380+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T13:31:10.272+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471" id="2698dfeb-c8ba-468b-8125-f3e082bf8471">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_c1</name>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T14:20:17.342+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4219469824</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T14:20:22.239+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52" id="1c59b294-15ab-4630-8715-8850b6e5fd52">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_f2</name>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T14:52:29.490+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-07T14:52:38.499+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289" id="78e60d40-1fd9-42e7-aa07-4ef4439b5289">
+            <actions>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/suspend" rel="suspend"/>
+            </actions>
+            <name>test_iso_f5</name>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-07T15:40:21.443+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4294967296</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_time>2017-05-23T10:05:37.376+03:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/suspend" rel="suspend"/>
+            </actions>
+            <name>vm1</name>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>true</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2016-06-28T13:31:17.000+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <address>10.35.17.69</address>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <secure_port>5900</secure_port>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>2122317824</memory>
+            <memory_policy>
+                <guaranteed>2122317824</guaranteed>
+                <max>8489271296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <fqdn>vm-18-82.eng.lab.tlv.redhat.com</fqdn>
+            <guest_operating_system>
+                <architecture>x86_64</architecture>
+                <codename>Core</codename>
+                <distribution>CentOS Linux</distribution>
+                <family>Linux</family>
+                <kernel>
+                    <version>
+                        <build>0</build>
+                        <full_version>3.10.0-123.el7.x86_64</full_version>
+                        <major>3</major>
+                        <minor>10</minor>
+                        <revision>123</revision>
+                    </version>
+                </kernel>
+                <version>
+                    <build>1406</build>
+                    <full_version>7.0.1406</full_version>
+                    <major>7</major>
+                    <minor>0</minor>
+                </version>
+            </guest_operating_system>
+            <guest_time_zone>
+                <name>Asia/Jerusalem</name>
+                <utc_offset>+02:00</utc_offset>
+            </guest_time_zone>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <run_once>false</run_once>
+            <start_time>2017-08-02T09:53:36.148+03:00</start_time>
+            <status>up</status>
+            <stop_time>2017-05-24T11:54:41.708+03:00</stop_time>
+            <host href="/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747" id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf" id="072093dc-3492-4cb1-b240-dbf88a8f4fbf">
+            <actions>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/suspend" rel="suspend"/>
+            </actions>
+            <name>vm2</name>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>true</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2016-07-05T14:48:58.000+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>network</device>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <status>down</status>
+            <stop_reason></stop_reason>
+            <stop_time>2016-11-17T17:24:40.816+02:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+    </vms>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '5698'
+    correlation-id: 7021eb53-f343-4f0e-a315-46c37576a4da
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/disks{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disks>
+        <disk href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9" id="29d19082-9406-4a14-992c-3f3bcea305d9">
+            <actions>
+                <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/copy" rel="copy"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/29d19082-9406-4a14-992c-3f3bcea305d9/statistics" rel="statistics"/>
+            <actual_size>134750208</actual_size>
+            <alias>OVF_STORE</alias>
+            <format>raw</format>
+            <image_id>1c1acd15-1753-4dc6-b30e-5fb3b92aef3d</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881" id="a8f6f43e-9fdc-4d9b-9195-90213f8d1881">
+            <actions>
+                <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/copy" rel="copy"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/a8f6f43e-9fdc-4d9b-9195-90213f8d1881/statistics" rel="statistics"/>
+            <actual_size>134750208</actual_size>
+            <alias>OVF_STORE</alias>
+            <format>raw</format>
+            <image_id>fcecce72-af95-4b1d-b08c-10bf6f561525</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8" id="b932057a-3990-49ab-b22e-bed62151f0d8">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/copy" rel="copy"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b932057a-3990-49ab-b22e-bed62151f0d8/statistics" rel="statistics"/>
+            <actual_size>134750208</actual_size>
+            <alias>OVF_STORE</alias>
+            <format>raw</format>
+            <image_id>d7c89f1b-861d-4e99-a6c5-bb474fa80d45</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/b1f0065e-9aef-4eb1-8939-aaad13eee28e" id="b1f0065e-9aef-4eb1-8939-aaad13eee28e"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb" id="4672fe17-c260-4ecc-aab0-b535f4d0dbeb"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182" id="cf96c431-f7bb-4dbb-8409-9a648f6c9182">
+            <actions>
+                <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/copy" rel="copy"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/cf96c431-f7bb-4dbb-8409-9a648f6c9182/statistics" rel="statistics"/>
+            <actual_size>134750208</actual_size>
+            <alias>OVF_STORE</alias>
+            <format>raw</format>
+            <image_id>4fddda2d-516d-40ac-8518-f6fdc397086d</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/b1f0065e-9aef-4eb1-8939-aaad13eee28e" id="b1f0065e-9aef-4eb1-8939-aaad13eee28e"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb" id="4672fe17-c260-4ecc-aab0-b535f4d0dbeb"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf" id="9d010e66-eee5-472c-be88-ad38685e7ebf">
+            <actions>
+                <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/copy" rel="copy"/>
+            </actions>
+            <name>qwue</name>
+            <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/9d010e66-eee5-472c-be88-ad38685e7ebf/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>qwue</alias>
+            <format>cow</format>
+            <image_id>48d46972-fbfe-4766-9e0e-7389cdb79d98</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>53687091200</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>locked</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931" id="0df228b6-2d75-4fc4-b475-8ac0be90f931">
+            <actions>
+                <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>e27dbb5a-73c7-4c37-a3a1-234e0678dab0</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d" id="25bc5579-196f-4558-bf6d-3722b1f25b5d">
+            <actions>
+                <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>ffee8dc4-c0a0-4ebb-ae36-197794d15e69</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4" id="6537938a-4438-4dec-b65f-61a3403b13b4">
+            <actions>
+                <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>06f24728-5fad-44d4-aa42-b30cd4705f5a</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7" id="7728e6b1-7544-43cb-9066-8f4732351bd7">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>1f777566-028d-4613-b7e1-c74aad6b73cd</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6" id="7917730e-39fb-4da4-9256-da652c33e5b6">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/statistics" rel="statistics"/>
+            <actual_size>1838448640</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>raw</format>
+            <image_id>cea4905b-0d4a-4d10-9943-1721ddc454eb</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e" id="88c441ca-1a6d-428f-913a-8092947e1f4e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>1ca72211-c4ea-449a-ab18-6bc2e973f886</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9" id="90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9">
+            <actions>
+                <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>6436e1cc-d49b-4fcd-9b62-e88e8a678ce4</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38" id="a38cccb5-9345-4185-9ef3-600285627e38">
+            <actions>
+                <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38/statistics" rel="statistics"/>
+            <actual_size>113172480</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>1d9485ad-f0d9-41d9-aad3-83e7ad9ed022</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5" id="ab6affb1-cab1-4156-930d-bb6b87edced5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>1eb4e9c1-99cb-4c21-92a1-4f003620900c</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec" id="af578e0e-b222-4754-aefc-879bf37eacec">
+            <actions>
+                <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/statistics" rel="statistics"/>
+            <actual_size>93106176</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>d85f85c7-a266-4c06-888c-fd4d498acc63</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8" id="b4ba391b-d617-4353-8aef-c2b3f721a0c8">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>b7073994-1ea5-43c5-b9ee-624a7c03582a</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1" id="c32ee8fe-8328-4021-891f-633cde5d5ce1">
+            <actions>
+                <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>raw</format>
+            <image_id>9deca41a-bf83-4621-b5b9-9facd2ca2277</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f" id="e0001bb7-3e18-457d-af89-8e5b565cc84f">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>raw</format>
+            <image_id>b0f15001-881c-4564-811c-823ca1659e2f</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <quota id="5852485d-01e5-036f-036e-000000000336"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29" id="e7820fec-15c1-4561-a4c3-63a08f889b29">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/copy" rel="copy"/>
+            </actions>
+            <name>vm1_Disk1</name>
+            <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm1_Disk1</alias>
+            <format>cow</format>
+            <image_id>5957000c-11e3-4f30-9a6a-48ab19d61178</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>6442450944</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486" id="0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d" id="9a3e866c-4497-46df-801a-d1739c31c69d">
+            <actions>
+                <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/copy" rel="copy"/>
+            </actions>
+            <name>vm2_Disk1</name>
+            <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/statistics" rel="statistics"/>
+            <actual_size>204800</actual_size>
+            <alias>vm2_Disk1</alias>
+            <format>cow</format>
+            <image_id>b181984a-e625-48c7-895c-f2cbac41d5db</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>5368709120</provisioned_size>
+            <qcow_version>qcow2_v2</qcow_version>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"/>
+            </storage_domains>
+        </disk>
+    </disks>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '2569'
+    correlation-id: 9cfc4b4c-2e54-4389-b4b4-31b4e81d5d33
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/diskattachments/e0001bb7-3e18-457d-af89-8e5b565cc84f" id="e0001bb7-3e18-457d-af89-8e5b565cc84f">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/e0001bb7-3e18-457d-af89-8e5b565cc84f" id="e0001bb7-3e18-457d-af89-8e5b565cc84f"/>
+            <vm href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d" id="1010ec66-5d68-4ae6-b72b-824f5885259d"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '310'
+    correlation-id: a156e4c5-9bb9-4079-9afb-ddba391c5a49
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853" id="cbcf2311-8577-49d4-9670-4e97f9fec853">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/nics/cbcf2311-8577-49d4-9670-4e97f9fec853/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d" id="1010ec66-5d68-4ae6-b72b-824f5885259d"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:53</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '410'
+    correlation-id: 66c7cf93-8c2e-4ac0-ab60-1c80d6f95675
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: a12b224a-67c0-444a-bb5a-6d6921f0053a
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/snapshots/c4b36a70-faf4-45e9-bd7d-e7d6470d1855" id="c4b36a70-faf4-45e9-bd7d-e7d6470d1855">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d/snapshots/c4b36a70-faf4-45e9-bd7d-e7d6470d1855/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-04T16:35:37.004+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 751d53f9-381d-4015-9ad1-b836e2aa9f63
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/diskattachments/c32ee8fe-8328-4021-891f-633cde5d5ce1" id="c32ee8fe-8328-4021-891f-633cde5d5ce1">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/c32ee8fe-8328-4021-891f-633cde5d5ce1" id="c32ee8fe-8328-4021-891f-633cde5d5ce1"/>
+            <vm href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88" id="2971952a-d2ba-456c-b090-7d2c2299fe88"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: 2732a1fd-1340-4e91-9790-60f8f1538802
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5" id="831c5646-4792-46c6-91c6-fb04475694b5">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/nics/831c5646-4792-46c6-91c6-fb04475694b5/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88" id="2971952a-d2ba-456c-b090-7d2c2299fe88"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:54</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '410'
+    correlation-id: a6ac2118-772d-4f93-9f84-2e84c30b5b17
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: a36e219d-a707-4297-9290-c93f3e187dbc
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/snapshots/4015d7c7-3384-4842-a14d-786d73b488d0" id="4015d7c7-3384-4842-a14d-786d73b488d0">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2971952a-d2ba-456c-b090-7d2c2299fe88/snapshots/4015d7c7-3384-4842-a14d-786d73b488d0/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-04T16:55:57.180+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 46213995-a353-482d-9130-6ed5408b83ab
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/diskattachments/ab6affb1-cab1-4156-930d-bb6b87edced5" id="ab6affb1-cab1-4156-930d-bb6b87edced5">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/ab6affb1-cab1-4156-930d-bb6b87edced5" id="ab6affb1-cab1-4156-930d-bb6b87edced5"/>
+            <vm href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8" id="c586d7dc-a7c0-4e92-8db0-b4eadaed87e8"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '307'
+    correlation-id: 2541ae6a-cbc8-48bc-b929-a4b0106d220d
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1" id="52096e94-0ccb-44ea-af10-a691d58c61d1">
+            <actions>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/nics/52096e94-0ccb-44ea-af10-a691d58c61d1/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8" id="c586d7dc-a7c0-4e92-8db0-b4eadaed87e8"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:55</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '407'
+    correlation-id: 3e2f1c8b-6816-454d-bae4-49abf4c7b5b1
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 724fc4ff-9453-4501-9a13-58361f835b5d
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/snapshots/c487889a-5975-4465-8b2f-d85e2e21ecfb" id="c487889a-5975-4465-8b2f-d85e2e21ecfb">
+            <actions>
+                <link href="/ovirt-engine/api/vms/c586d7dc-a7c0-4e92-8db0-b4eadaed87e8/snapshots/c487889a-5975-4465-8b2f-d85e2e21ecfb/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-05T17:39:23.650+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '331'
+    correlation-id: fc71886b-3012-4f4c-afdc-b66e77d18057
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/diskattachments/25bc5579-196f-4558-bf6d-3722b1f25b5d" id="25bc5579-196f-4558-bf6d-3722b1f25b5d">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/25bc5579-196f-4558-bf6d-3722b1f25b5d" id="25bc5579-196f-4558-bf6d-3722b1f25b5d"/>
+            <vm href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526" id="71bc98a1-0073-405f-bf0a-6ca68a24b526"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '310'
+    correlation-id: 2059e069-8ac3-4962-8e36-243e3e1597eb
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75" id="ab9ae042-3e4d-42f1-a162-7726beab3c75">
+            <actions>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/nics/ab9ae042-3e4d-42f1-a162-7726beab3c75/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526" id="71bc98a1-0073-405f-bf0a-6ca68a24b526"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5e</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '409'
+    correlation-id: f3aaa082-1e99-40c6-a7b0-308293723654
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 4ccd2f10-0c8c-45af-bd11-aab7f7f6ad6f
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/snapshots/2588b2ac-22c7-4557-8a4b-c15293b0aa6b" id="2588b2ac-22c7-4557-8a4b-c15293b0aa6b">
+            <actions>
+                <link href="/ovirt-engine/api/vms/71bc98a1-0073-405f-bf0a-6ca68a24b526/snapshots/2588b2ac-22c7-4557-8a4b-c15293b0aa6b/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-23T14:45:38.704+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: bb2a98fd-e3a5-468b-8a2f-56170495a33a
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/diskattachments/e7820fec-15c1-4561-a4c3-63a08f889b29" id="e7820fec-15c1-4561-a4c3-63a08f889b29">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/e7820fec-15c1-4561-a4c3-63a08f889b29" id="e7820fec-15c1-4561-a4c3-63a08f889b29"/>
+            <vm href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839" id="51fbdd58-be99-4cb2-9ee5-8cd43efc8839"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: dcd434ac-cf4d-4518-99ac-0f9236df25a1
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816" id="1d8f36cd-922a-4c71-ae37-18e087217816">
+            <actions>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/nics/1d8f36cd-922a-4c71-ae37-18e087217816/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839" id="51fbdd58-be99-4cb2-9ee5-8cd43efc8839"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:56</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '409'
+    correlation-id: e4350b91-244c-42c5-976e-69ce38c0ec86
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 85333a92-4cb3-4daa-8bb3-47d55e514599
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/snapshots/6a8f5a7c-78dd-432e-85f8-7b74f74d454b" id="6a8f5a7c-78dd-432e-85f8-7b74f74d454b">
+            <actions>
+                <link href="/ovirt-engine/api/vms/51fbdd58-be99-4cb2-9ee5-8cd43efc8839/snapshots/6a8f5a7c-78dd-432e-85f8-7b74f74d454b/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T11:18:36.556+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: e3b40e24-c354-4e86-83c6-5e063149d68c
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/diskattachments/b4ba391b-d617-4353-8aef-c2b3f721a0c8" id="b4ba391b-d617-4353-8aef-c2b3f721a0c8">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/b4ba391b-d617-4353-8aef-c2b3f721a0c8" id="b4ba391b-d617-4353-8aef-c2b3f721a0c8"/>
+            <vm href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4" id="4eae23a7-a218-41aa-991c-1f0c07aedfd4"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '307'
+    correlation-id: e5f8fca9-cefc-40f4-a641-013bef5b240c
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8" id="8f5d0853-95d3-4b96-bca3-623d03e378b8">
+            <actions>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/nics/8f5d0853-95d3-4b96-bca3-623d03e378b8/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4" id="4eae23a7-a218-41aa-991c-1f0c07aedfd4"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:57</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '408'
+    correlation-id: 80a5438c-c3fd-4043-bcaf-2e057a1a2418
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: e9536fbd-f302-4bf5-96ef-552ffc5f6e4b
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/snapshots/cd2a4cd2-60f0-4ff6-89f3-e3ac37b2740f" id="cd2a4cd2-60f0-4ff6-89f3-e3ac37b2740f">
+            <actions>
+                <link href="/ovirt-engine/api/vms/4eae23a7-a218-41aa-991c-1f0c07aedfd4/snapshots/cd2a4cd2-60f0-4ff6-89f3-e3ac37b2740f/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T11:23:36.479+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '331'
+    correlation-id: a2d96143-fd5c-469b-b844-0daf3821e0c2
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/diskattachments/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9" id="90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9" id="90be86d0-f5a0-4e81-ba5b-ef9cb14e0ff9"/>
+            <vm href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5" id="57cf204b-2938-4245-9bb2-a9e416a486b5"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: 875feca8-3124-49b8-b731-bf445b4a4c5c
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c" id="1855de95-15d5-4414-a8d0-f621c943ae5c">
+            <actions>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/nics/1855de95-15d5-4414-a8d0-f621c943ae5c/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5" id="57cf204b-2938-4245-9bb2-a9e416a486b5"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:58</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '410'
+    correlation-id: 8efc8172-b8a4-4845-a180-097a43e09e7a
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 98d10658-fdcf-41e0-8315-5539d878de42
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/snapshots/6abcd75e-8e21-4436-b98c-0b4b1710a472" id="6abcd75e-8e21-4436-b98c-0b4b1710a472">
+            <actions>
+                <link href="/ovirt-engine/api/vms/57cf204b-2938-4245-9bb2-a9e416a486b5/snapshots/6abcd75e-8e21-4436-b98c-0b4b1710a472/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T11:40:38.811+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 352cb4a3-cdf7-49d4-9f52-f1ad75990ea7
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/diskattachments/6537938a-4438-4dec-b65f-61a3403b13b4" id="6537938a-4438-4dec-b65f-61a3403b13b4">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/6537938a-4438-4dec-b65f-61a3403b13b4" id="6537938a-4438-4dec-b65f-61a3403b13b4"/>
+            <vm href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b" id="155ecdc7-c2ed-48ee-a6d0-493c7df9a02b"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: 431b88aa-54d8-4d42-9a5c-991aacd460d1
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648" id="ff1704a7-bfd0-4b4b-98f3-1440b3571648">
+            <actions>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/nics/ff1704a7-bfd0-4b4b-98f3-1440b3571648/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b" id="155ecdc7-c2ed-48ee-a6d0-493c7df9a02b"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:59</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '408'
+    correlation-id: aacdcc2d-bb4e-45e0-a67e-23e1578720f1
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: fd89afdd-d715-41f9-b24a-cd35124a6052
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/snapshots/8bb1ea64-38f3-4719-b360-1d721c199e8a" id="8bb1ea64-38f3-4719-b360-1d721c199e8a">
+            <actions>
+                <link href="/ovirt-engine/api/vms/155ecdc7-c2ed-48ee-a6d0-493c7df9a02b/snapshots/8bb1ea64-38f3-4719-b360-1d721c199e8a/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T11:48:53.899+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 8a1b0871-7ff2-4809-a638-15a6c392b405
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/diskattachments/88c441ca-1a6d-428f-913a-8092947e1f4e" id="88c441ca-1a6d-428f-913a-8092947e1f4e">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/88c441ca-1a6d-428f-913a-8092947e1f4e" id="88c441ca-1a6d-428f-913a-8092947e1f4e"/>
+            <vm href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90" id="cf52ed48-3ff0-4c86-b938-eff4acb5fe90"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '308'
+    correlation-id: 258f926a-71dc-4f85-b883-bc0769e8dd28
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc" id="80694cc6-0106-4d5b-af8d-b50e9fafe0bc">
+            <actions>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/nics/80694cc6-0106-4d5b-af8d-b50e9fafe0bc/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90" id="cf52ed48-3ff0-4c86-b938-eff4acb5fe90"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5a</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '409'
+    correlation-id: 8ce433ad-4afe-4adc-8157-c18576fdd396
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 1d3dd111-37ce-4939-aa7a-68299b6102dd
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/snapshots/dc6e7ff4-d523-49b2-ae88-9a20926f9f8a" id="dc6e7ff4-d523-49b2-ae88-9a20926f9f8a">
+            <actions>
+                <link href="/ovirt-engine/api/vms/cf52ed48-3ff0-4c86-b938-eff4acb5fe90/snapshots/dc6e7ff4-d523-49b2-ae88-9a20926f9f8a/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T13:31:01.439+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '332'
+    correlation-id: b5e923e7-8ec2-47e4-a4b8-65569303cdab
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/diskattachments/0df228b6-2d75-4fc4-b475-8ac0be90f931" id="0df228b6-2d75-4fc4-b475-8ac0be90f931">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/0df228b6-2d75-4fc4-b475-8ac0be90f931" id="0df228b6-2d75-4fc4-b475-8ac0be90f931"/>
+            <vm href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471" id="2698dfeb-c8ba-468b-8125-f3e082bf8471"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: 3e2cce11-0cd9-4307-b57e-6c32a2d7313b
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a" id="550e2e64-d6b9-496a-b793-cf388726c82a">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/nics/550e2e64-d6b9-496a-b793-cf388726c82a/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471" id="2698dfeb-c8ba-468b-8125-f3e082bf8471"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5b</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '410'
+    correlation-id: 4bfba166-82db-43d4-bc15-b4b6435c6515
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 990c656a-659c-44e0-bd9f-46d338948fd0
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/snapshots/9699684d-62a6-4bb3-97e7-a951a2c53eae" id="9699684d-62a6-4bb3-97e7-a951a2c53eae">
+            <actions>
+                <link href="/ovirt-engine/api/vms/2698dfeb-c8ba-468b-8125-f3e082bf8471/snapshots/9699684d-62a6-4bb3-97e7-a951a2c53eae/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T14:20:17.405+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '332'
+    correlation-id: c5f00abc-6617-4ef7-a381-91ec7196f0b3
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/diskattachments/7728e6b1-7544-43cb-9066-8f4732351bd7" id="7728e6b1-7544-43cb-9066-8f4732351bd7">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/7728e6b1-7544-43cb-9066-8f4732351bd7" id="7728e6b1-7544-43cb-9066-8f4732351bd7"/>
+            <vm href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52" id="1c59b294-15ab-4630-8715-8850b6e5fd52"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '311'
+    correlation-id: a5eba4f3-2ead-46bd-95a5-de54d2eccf9b
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac" id="d2d908fa-7490-459d-a665-1cb6a8ed14ac">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/nics/d2d908fa-7490-459d-a665-1cb6a8ed14ac/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52" id="1c59b294-15ab-4630-8715-8850b6e5fd52"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5c</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '411'
+    correlation-id: a40c9d8b-1155-4387-95fe-4723c689520c
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: b27118f8-e5ce-4fb1-9883-e9a8cbb30ff7
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/snapshots/5dd593da-5cb1-4c0b-b8bd-ba6b31271a41" id="5dd593da-5cb1-4c0b-b8bd-ba6b31271a41">
+            <actions>
+                <link href="/ovirt-engine/api/vms/1c59b294-15ab-4630-8715-8850b6e5fd52/snapshots/5dd593da-5cb1-4c0b-b8bd-ba6b31271a41/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T14:52:29.533+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '333'
+    correlation-id: 3e1b1cd2-0def-4e3a-8ecb-b94ed9324d63
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/diskattachments/a38cccb5-9345-4185-9ef3-600285627e38" id="a38cccb5-9345-4185-9ef3-600285627e38">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/a38cccb5-9345-4185-9ef3-600285627e38" id="a38cccb5-9345-4185-9ef3-600285627e38"/>
+            <vm href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289" id="78e60d40-1fd9-42e7-aa07-4ef4439b5289"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '310'
+    correlation-id: 50187778-9054-43fa-930f-1f6a8d5475a6
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4" id="1243335c-692a-46a1-8723-3ae16355a2f4">
+            <actions>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/nics/1243335c-692a-46a1-8723-3ae16355a2f4/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289" id="78e60d40-1fd9-42e7-aa07-4ef4439b5289"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:5d</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '408'
+    correlation-id: f2d9525e-d981-442f-a122-89c9d261587e
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: c59c3ebe-6cf7-4e04-a02e-05530db72771
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/snapshots/dac821da-485e-4d5d-96c5-b75a959be55f" id="dac821da-485e-4d5d-96c5-b75a959be55f">
+            <actions>
+                <link href="/ovirt-engine/api/vms/78e60d40-1fd9-42e7-aa07-4ef4439b5289/snapshots/dac821da-485e-4d5d-96c5-b75a959be55f/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2017-05-07T15:40:21.466+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '332'
+    correlation-id: 50882b3b-80db-4666-8cfe-3b08948eb27c
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/diskattachments/af578e0e-b222-4754-aefc-879bf37eacec" id="af578e0e-b222-4754-aefc-879bf37eacec">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <logical_name>/dev/vda</logical_name>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec" id="af578e0e-b222-4754-aefc-879bf37eacec"/>
+            <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '326'
+    correlation-id: 6e0de044-869c-4df0-a387-b0e17712271b
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93" id="6a538d86-38a2-4ac9-98f5-9d401a596e93">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:51</address>
+            </mac>
+            <plugged>true</plugged>
+            <reported_devices>
+                <reported_device href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/65746830-3030-3a31-613a-34613a31363a" id="65746830-3030-3a31-613a-34613a31363a">
+                    <name>eth0</name>
+                    <description>guest reported data</description>
+                    <ips>
+                        <ip>
+                            <address>10.35.18.141</address>
+                            <version>v4</version>
+                        </ip>
+                        <ip>
+                            <address>fe80::21a:4aff:fe16:151</address>
+                            <version>v6</version>
+                        </ip>
+                        <ip>
+                            <address>2620:52:0:2310:21a:4aff:fe16:151</address>
+                            <version>v6</version>
+                        </ip>
+                    </ips>
+                    <mac>
+                        <address>00:1a:4a:16:01:51</address>
+                    </mac>
+                    <type>network</type>
+                    <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+                </reported_device>
+            </reported_devices>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '603'
+    correlation-id: 05fdff27-03cb-4911-8cb0-ee6cd9d2f417
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices>
+        <reported_device href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/65746830-3030-3a31-613a-34613a31363a" id="65746830-3030-3a31-613a-34613a31363a">
+            <name>eth0</name>
+            <description>guest reported data</description>
+            <ips>
+                <ip>
+                    <address>10.35.18.141</address>
+                    <version>v4</version>
+                </ip>
+                <ip>
+                    <address>fe80::21a:4aff:fe16:151</address>
+                    <version>v6</version>
+                </ip>
+                <ip>
+                    <address>2620:52:0:2310:21a:4aff:fe16:151</address>
+                    <version>v6</version>
+                </ip>
+            </ips>
+            <mac>
+                <address>00:1a:4a:16:01:51</address>
+            </mac>
+            <type>network</type>
+            <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+        </reported_device>
+    </reported_devices>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '371'
+    correlation-id: 462db5bd-7241-4577-8b49-959903c7823b
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/6e3e547f-9544-42cf-842d-9104828d8511" id="6e3e547f-9544-42cf-842d-9104828d8511">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/6e3e547f-9544-42cf-842d-9104828d8511/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2016-07-05T13:14:08.116+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+        <snapshot href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510" id="05ff445a-0bfc-44c3-90d1-a338e9095510">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/restore" rel="restore"/>
+            </actions>
+            <description>vm1_snap</description>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/disks" rel="disks"/>
+            <date>2016-12-15T09:51:43.247+02:00</date>
+            <persist_memorystate>true</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>regular</snapshot_type>
+            <vm id="3a9401a0-bf3d-4496-8acf-edd3e903511f">
+                <name>vm1</name>
+                <bios>
+                    <boot_menu>
+                        <enabled>true</enabled>
+                    </boot_menu>
+                </bios>
+                <cpu>
+                    <architecture>x86_64</architecture>
+                    <topology>
+                        <cores>1</cores>
+                        <sockets>4</sockets>
+                        <threads>1</threads>
+                    </topology>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <creation_time>2016-06-28T13:31:17.000+03:00</creation_time>
+                <delete_protected>false</delete_protected>
+                <display>
+                    <address>10.35.17.69</address>
+                    <allow_override>false</allow_override>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <monitors>1</monitors>
+                    <secure_port>5900</secure_port>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <smartcard_enabled>false</smartcard_enabled>
+                    <type>spice</type>
+                </display>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>1</priority>
+                </high_availability>
+                <initialization/>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <large_icon id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+                <memory>2122317824</memory>
+                <memory_policy>
+                    <guaranteed>2122317824</guaranteed>
+                    <max>4398046511104</max>
+                </memory_policy>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <migration_downtime>-1</migration_downtime>
+                <origin>ovirt</origin>
+                <os>
+                    <boot>
+                        <devices>
+                            <device>hd</device>
+                        </devices>
+                    </boot>
+                    <type>other</type>
+                </os>
+                <small_icon id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+                <sso>
+                    <methods>
+                        <method id="guest_agent"/>
+                    </methods>
+                </sso>
+                <start_paused>false</start_paused>
+                <stateless>false</stateless>
+                <time_zone>
+                    <name>Etc/GMT</name>
+                </time_zone>
+                <type>desktop</type>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <cluster id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+                <cpu_profile id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+                <fqdn>vm-18-82.eng.lab.tlv.redhat.com</fqdn>
+                <guest_operating_system>
+                    <architecture>x86_64</architecture>
+                    <codename>Core</codename>
+                    <distribution>CentOS Linux</distribution>
+                    <family>Linux</family>
+                    <kernel>
+                        <version>
+                            <build>0</build>
+                            <full_version>3.10.0-123.el7.x86_64</full_version>
+                            <major>3</major>
+                            <minor>10</minor>
+                            <revision>123</revision>
+                        </version>
+                    </kernel>
+                    <version>
+                        <build>1406</build>
+                        <full_version>7.0.1406</full_version>
+                        <major>7</major>
+                        <minor>0</minor>
+                    </version>
+                </guest_operating_system>
+                <guest_time_zone>
+                    <name>Asia/Jerusalem</name>
+                    <utc_offset>+02:00</utc_offset>
+                </guest_time_zone>
+                <next_run_configuration_exists>false</next_run_configuration_exists>
+                <numa_tune_mode>interleave</numa_tune_mode>
+                <placement_policy>
+                    <affinity>migratable</affinity>
+                </placement_policy>
+                <run_once>false</run_once>
+                <start_time>2017-08-02T09:53:36.148+03:00</start_time>
+                <status>up</status>
+                <stop_time>2017-05-24T11:54:41.708+03:00</stop_time>
+                <host id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+                <original_template id="00000000-0000-0000-0000-000000000000"/>
+                <template id="00000000-0000-0000-0000-000000000000"/>
+            </vm>
+        </snapshot>
+        <snapshot href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30" id="e13fc61c-c566-4264-9a75-0e62fe5d7a30">
+            <actions>
+                <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30/restore" rel="restore"/>
+            </actions>
+            <description>snap 1</description>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30/disks" rel="disks"/>
+            <date>2017-05-24T12:02:44.698+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>regular</snapshot_type>
+            <vm id="3a9401a0-bf3d-4496-8acf-edd3e903511f">
+                <name>vm1</name>
+                <bios>
+                    <boot_menu>
+                        <enabled>true</enabled>
+                    </boot_menu>
+                </bios>
+                <cpu>
+                    <architecture>x86_64</architecture>
+                    <topology>
+                        <cores>1</cores>
+                        <sockets>4</sockets>
+                        <threads>1</threads>
+                    </topology>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <creation_time>2016-06-28T13:31:17.000+03:00</creation_time>
+                <delete_protected>false</delete_protected>
+                <display>
+                    <address>10.35.17.69</address>
+                    <allow_override>false</allow_override>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <monitors>1</monitors>
+                    <secure_port>5900</secure_port>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <smartcard_enabled>false</smartcard_enabled>
+                    <type>spice</type>
+                </display>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>1</priority>
+                </high_availability>
+                <initialization/>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <large_icon id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+                <memory>2122317824</memory>
+                <memory_policy>
+                    <guaranteed>2122317824</guaranteed>
+                    <max>8489271296</max>
+                </memory_policy>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <migration_downtime>-1</migration_downtime>
+                <origin>ovirt</origin>
+                <os>
+                    <boot>
+                        <devices>
+                            <device>hd</device>
+                        </devices>
+                    </boot>
+                    <type>other</type>
+                </os>
+                <small_icon id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+                <sso>
+                    <methods>
+                        <method id="guest_agent"/>
+                    </methods>
+                </sso>
+                <start_paused>false</start_paused>
+                <stateless>false</stateless>
+                <time_zone>
+                    <name>Etc/GMT</name>
+                </time_zone>
+                <type>desktop</type>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <cluster id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+                <cpu_profile id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+                <fqdn>vm-18-82.eng.lab.tlv.redhat.com</fqdn>
+                <guest_operating_system>
+                    <architecture>x86_64</architecture>
+                    <codename>Core</codename>
+                    <distribution>CentOS Linux</distribution>
+                    <family>Linux</family>
+                    <kernel>
+                        <version>
+                            <build>0</build>
+                            <full_version>3.10.0-123.el7.x86_64</full_version>
+                            <major>3</major>
+                            <minor>10</minor>
+                            <revision>123</revision>
+                        </version>
+                    </kernel>
+                    <version>
+                        <build>1406</build>
+                        <full_version>7.0.1406</full_version>
+                        <major>7</major>
+                        <minor>0</minor>
+                    </version>
+                </guest_operating_system>
+                <guest_time_zone>
+                    <name>Asia/Jerusalem</name>
+                    <utc_offset>+02:00</utc_offset>
+                </guest_time_zone>
+                <next_run_configuration_exists>false</next_run_configuration_exists>
+                <numa_tune_mode>interleave</numa_tune_mode>
+                <placement_policy>
+                    <affinity>migratable</affinity>
+                </placement_policy>
+                <run_once>false</run_once>
+                <start_time>2017-08-02T09:53:36.148+03:00</start_time>
+                <status>up</status>
+                <stop_time>2017-05-24T11:54:41.708+03:00</stop_time>
+                <host id="69cd8141-a6f5-4968-880d-121de26f3747"/>
+                <original_template id="00000000-0000-0000-0000-000000000000"/>
+                <template id="00000000-0000-0000-0000-000000000000"/>
+            </vm>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1895'
+    correlation-id: b9a9db4c-1e60-4db6-a674-805151159832
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/diskattachments/9a3e866c-4497-46df-801a-d1739c31c69d" id="9a3e866c-4497-46df-801a-d1739c31c69d">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d" id="9a3e866c-4497-46df-801a-d1739c31c69d"/>
+            <vm href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf" id="072093dc-3492-4cb1-b240-dbf88a8f4fbf"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '309'
+    correlation-id: 602d8e11-f25b-4684-86b8-40de9d9c6932
+    date: Thu, 03 Aug 2017 10:38:46 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e" id="fdc2d708-01d1-4aa4-8b53-d64177181e2e">
+            <actions>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf" id="072093dc-3492-4cb1-b240-dbf88a8f4fbf"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>00:1a:4a:16:01:52</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '409'
+    correlation-id: 4ac1f687-01c4-4d6d-9133-7372e874f0ab
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 1492afb1-74af-4096-97c3-92db1eff4981
+    date: Thu, 03 Aug 2017 10:38:47 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912" id="677a1c40-8112-4e4a-bd03-c430e7505912">
+            <actions>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/restore" rel="restore"/>
+            </actions>
+            <description>22</description>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/disks" rel="disks"/>
+            <date>2016-08-02T14:42:19.378+03:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>regular</snapshot_type>
+            <vm id="072093dc-3492-4cb1-b240-dbf88a8f4fbf">
+                <name>vm2</name>
+                <bios>
+                    <boot_menu>
+                        <enabled>true</enabled>
+                    </boot_menu>
+                </bios>
+                <cpu>
+                    <architecture>x86_64</architecture>
+                    <topology>
+                        <cores>1</cores>
+                        <sockets>1</sockets>
+                        <threads>1</threads>
+                    </topology>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <creation_time>2016-07-05T14:48:58.000+03:00</creation_time>
+                <delete_protected>false</delete_protected>
+                <display>
+                    <allow_override>false</allow_override>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <monitors>1</monitors>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <smartcard_enabled>false</smartcard_enabled>
+                </display>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>1</priority>
+                </high_availability>
+                <initialization/>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <large_icon id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+                <memory>1073741824</memory>
+                <memory_policy>
+                    <guaranteed>1073741824</guaranteed>
+                    <max>4398046511104</max>
+                </memory_policy>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <migration_downtime>-1</migration_downtime>
+                <origin>ovirt</origin>
+                <os>
+                    <boot>
+                        <devices>
+                            <device>network</device>
+                            <device>hd</device>
+                        </devices>
+                    </boot>
+                    <type>other</type>
+                </os>
+                <small_icon id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+                <sso>
+                    <methods>
+                        <method id="guest_agent"/>
+                    </methods>
+                </sso>
+                <start_paused>false</start_paused>
+                <stateless>false</stateless>
+                <time_zone>
+                    <name>Etc/GMT</name>
+                </time_zone>
+                <type>desktop</type>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <cluster id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+                <cpu_profile id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+                <next_run_configuration_exists>false</next_run_configuration_exists>
+                <numa_tune_mode>interleave</numa_tune_mode>
+                <placement_policy>
+                    <affinity>migratable</affinity>
+                </placement_policy>
+                <status>down</status>
+                <stop_reason></stop_reason>
+                <stop_time>2016-11-17T17:24:40.816+02:00</stop_time>
+                <original_template id="00000000-0000-0000-0000-000000000000"/>
+                <template id="00000000-0000-0000-0000-000000000000"/>
+            </vm>
+        </snapshot>
+        <snapshot href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/ef7b7d35-c7b8-4270-8ec7-b85047a50bdc" id="ef7b7d35-c7b8-4270-8ec7-b85047a50bdc">
+            <actions>
+                <link href="/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/ef7b7d35-c7b8-4270-8ec7-b85047a50bdc/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2016-11-17T17:24:11.967+02:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1384'
+    correlation-id: 976bf7c3-ac1d-4493-aeb9-b360eb47a9b4
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/templates{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <templates>
+        <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000">
+            <actions>
+                <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/seal" rel="seal"/>
+                <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/export" rel="export"/>
+            </actions>
+            <name>Blank</name>
+            <description>Blank template</description>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/tags" rel="tags"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>undefined</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2008-04-01T00:00:00.000+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>0</priority>
+            </high_availability>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <status>ok</status>
+            <version>
+                <version_name></version_name>
+                <version_number>0</version_number>
+                <base_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            </version>
+        </template>
+        <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79">
+            <actions>
+                <link href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/seal" rel="seal"/>
+                <link href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/export" rel="export"/>
+            </actions>
+            <name>template_cd1</name>
+            <link href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/tags" rel="tags"/>
+            <bios>
+                <boot_menu>
+                    <enabled>true</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2016-07-12T10:57:38.356+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>4219469824</memory>
+            <memory_policy>
+                <guaranteed>4219469824</guaranteed>
+                <max>16877879296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf" id="504ae500-3476-450e-8243-f6df0f7f7acf"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d" id="c34525ea-072c-452d-baa1-0c5efe643e4d"/>
+            <status>ok</status>
+            <version>
+                <version_name>base version</version_name>
+                <version_number>1</version_number>
+                <base_template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            </version>
+        </template>
+        <template href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b" id="187e40e6-dfff-453c-9433-066ac1b14e5b">
+            <actions>
+                <link href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/seal" rel="seal"/>
+                <link href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/export" rel="export"/>
+            </actions>
+            <name>template_ex_default</name>
+            <link href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/tags" rel="tags"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2016-07-12T10:58:45.436+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092" id="00000002-0002-0002-0002-000000000092"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000384" id="0000000e-000e-000e-000e-000000000384"/>
+            <status>ok</status>
+            <version>
+                <version_name>base version</version_name>
+                <version_number>1</version_number>
+                <base_template href="/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b" id="187e40e6-dfff-453c-9433-066ac1b14e5b"/>
+            </version>
+        </template>
+        <template href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6" id="61fb330d-7f11-4f8d-94fb-df75df34b0d6">
+            <actions>
+                <link href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/seal" rel="seal"/>
+                <link href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/export" rel="export"/>
+            </actions>
+            <name>test_template_1</name>
+            <link href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/tags" rel="tags"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2017-05-15T13:46:57.425+03:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1" id="db8d96f8-75cd-475a-b2f5-c37d75a288b1"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <small_icon href="/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0" id="c947ca42-629e-46cf-aeeb-ef949fae52c0"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092" id="00000002-0002-0002-0002-000000000092"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000384" id="0000000e-000e-000e-000e-000000000384"/>
+            <status>ok</status>
+            <version>
+                <version_name>base version</version_name>
+                <version_number>1</version_number>
+                <base_template href="/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6" id="61fb330d-7f11-4f8d-94fb-df75df34b0d6"/>
+            </version>
+        </template>
+    </templates>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '1758'
+    correlation-id: a15340d3-6415-483c-aec7-b5bbd847620e
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 3c94da69-d178-4949-86e9-5dd32856f09e
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/785e845e-baa0-4812-8a8c-467f37ad6c79/diskattachments/7917730e-39fb-4da4-9256-da652c33e5b6" id="7917730e-39fb-4da4-9256-da652c33e5b6">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6" id="7917730e-39fb-4da4-9256-da652c33e5b6"/>
+            <template href="/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+            <vm href="/ovirt-engine/api/vms/785e845e-baa0-4812-8a8c-467f37ad6c79" id="785e845e-baa0-4812-8a8c-467f37ad6c79"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '325'
+    correlation-id: 7c4ae81c-f9db-4251-ba06-3f8c74bcffbc
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 211845ee-7ed0-4bbb-8813-094dd725baaf
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/templates/61fb330d-7f11-4f8d-94fb-df75df34b0d6/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '96'
+    correlation-id: 9578d2f2-afe3-4f40-80c0-0e5eaed0a1ba
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/networks{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <networks>
+        <network href="/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef" id="6ad90f38-5496-47fb-9882-5aa55e1314ef">
+            <name>ovirtmgmt</name>
+            <description>Default Management Network</description>
+            <link href="/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1" id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            <qos href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/qoss/9e1a73ff-2598-4474-b24f-42d683f56d14" id="9e1a73ff-2598-4474-b24f-42d683f56d14"/>
+        </network>
+        <network href="/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009">
+            <name>ovirtmgmt</name>
+            <description>Management Network</description>
+            <link href="/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f" id="00000001-0001-0001-0001-00000000009f"/>
+        </network>
+    </networks>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '443'
+    correlation-id: a42fa1c3-640d-4ac7-a79a-87e1822c7fe5
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/datacenters{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1" id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1">
+            <name>dc1</name>
+            <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/iscsibonds" rel="iscsibonds"/>
+            <local>false</local>
+            <quota_mode>disabled</quota_mode>
+            <status>up</status>
+            <storage_format>v3</storage_format>
+            <supported_versions>
+                <version>
+                    <major>3</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>3</major>
+                <minor>6</minor>
+            </version>
+        </data_center>
+        <data_center href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f" id="00000001-0001-0001-0001-00000000009f">
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/iscsibonds" rel="iscsibonds"/>
+            <local>false</local>
+            <quota_mode>disabled</quota_mode>
+            <status>up</status>
+            <storage_format>v3</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>1</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>1</minor>
+            </version>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '492'
+    correlation-id: d803ec63-b785-416a-b5ab-e52202e425d7
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1" id="0c55619d-4d88-4bd1-921c-5425275061d1">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/activate" rel="activate"/>
+            </actions>
+            <name>export</name>
+            <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/disks" rel="disks"/>
+            <available>46170898432</available>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>spider.eng.lab.tlv.redhat.com</address>
+                <nfs_version>v3</nfs_version>
+                <path>/vol/vol_bodnopoz/export</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>export</type>
+            <used>7516192768</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1" id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            <data_centers>
+                <data_center id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0" id="9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/9164a17f-5dc7-4fd3-acc5-e4c70c6b78a0/activate" rel="activate"/>
+            </actions>
+            <name>isos</name>
+            <available>153545080832</available>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>venus-vdsb.usersys.redhat.com</address>
+                <nfs_version>v3</nfs_version>
+                <path>/home/nfsshare/boris/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>53687091200</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1" id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            <data_centers>
+                <data_center id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02" id="27a3bcce-c4d0-4bce-afe9-1d669d5a9d02">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/activate" rel="activate"/>
+            </actions>
+            <name>data1</name>
+            <link href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/disks" rel="disks"/>
+            <available>46170898432</available>
+            <committed>151397597184</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>spider.eng.lab.tlv.redhat.com</address>
+                <nfs_version>v3</nfs_version>
+                <path>/vol/vol_bodnopoz/data1</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v3</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>7516192768</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1" id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            <data_centers>
+                <data_center id="b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '819'
+    correlation-id: f27ecee5-7d7d-4f14-8d35-e2a169b2a6b0
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 
+https://localhost:8443/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb" id="4672fe17-c260-4ecc-aab0-b535f4d0dbeb">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/activate" rel="activate"/>
+            </actions>
+            <name>data2</name>
+            <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/disks" rel="disks"/>
+            <available>46170898432</available>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>spider.eng.lab.tlv.redhat.com</address>
+                <path>/vol/vol_bodnopoz/data2</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v3</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>7516192768</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f" id="00000001-0001-0001-0001-00000000009f"/>
+            <data_centers>
+                <data_center id="00000001-0001-0001-0001-00000000009f"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '571'
+    correlation-id: 520ea7d8-2e9e-49d8-8526-39251ebfb81e
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message: 


### PR DESCRIPTION
Make full refresh through OvirSDK use asynchronous calls to oVirt to improve performance.

This should make the refresh significantly faster
https://bugzilla.redhat.com/show_bug.cgi?id=1404346