### PR TITLE
Fix handling of version-depended refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -6,7 +6,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
   def self.ems_inv_to_hashes(inv)
     uids = {}
     result = {:uid_lookup => uids}
-    result[:ems] = inv[:ems]
+    result[:ems] = ems_version_to_hashes(inv)
     result[:storages], uids[:storages] = storage_inv_to_hashes(inv[:storage])
     result[:clusters], uids[:clusters], result[:resource_pools] = cluster_inv_to_hashes(inv[:cluster])
     result[:hosts], uids[:hosts], uids[:lans], uids[:switches], uids[:guest_devices], uids[:scsi_luns] = host_inv_to_hashes(inv[:host], inv, uids[:clusters], uids[:storages])
@@ -27,6 +27,10 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
     end
 
     result
+  end
+
+  def self.ems_version_to_hashes(inv)
+    inv[:ems_api_version]
   end
 
   def self.storage_inv_to_hashes(inv)

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
@@ -1,5 +1,9 @@
 module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
   class Api4 < ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
+    def self.ems_version_to_hashes(inv)
+      inv.instance_variable_get(:@ems_api_version)
+    end
+
     def self.cluster_inv_to_hashes(inv)
       result = []
       result_uids = {}

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
@@ -26,7 +26,12 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
           end
         end
 
-        data[:ems] = {:api_version => inventory.service.version_string}
+        case ems.highest_allowed_api_version
+        when '3'
+          data[:ems_api_version] = {:api_version => inventory.service.version_string}
+        when '4'
+          data.instance_variable_set(:@ems_api_version, :api_version => inventory.service.version_string)
+        end
 
         _log.info "Filtering inventory...Complete"
         [target, data]

--- a/app/models/manageiq/providers/redhat/inventory/collector.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector.rb
@@ -66,6 +66,7 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManagerRefresh::Invent
   end
 
   def collect_datacenter_for_cluster(cluster)
+    return unless cluster.data_center
     manager.with_provider_connection(VERSION_HASH) do |connection|
       connection.follow_link(cluster.data_center)
     end
@@ -136,6 +137,7 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManagerRefresh::Invent
   end
 
   def collect_dc_domains(dc)
+    return unless dc
     manager.with_provider_connection(VERSION_HASH) do |connection|
       connection.follow_link(dc.storage_domains)
     end

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :ems_ref_obj   => ems_ref,
         :uid_ems       => cluster.id,
         :name          => cluster.name,
-        :datacenter_id => cluster.data_center.id,
+        :datacenter_id => cluster.dig(:data_center, :id),
       )
     end
   end
@@ -275,13 +275,16 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
   end
 
   def network_from_nic(nic, dc, networks)
+    return unless dc
     network_id = nic.dig(:network, :id)
     if network_id
       # TODO: check to indexed_networks = networks.index_by(:id)
       network = networks.detect { |n| n.id == network_id }
     else
       network_name = nic.dig(:network, :name)
-      network = networks.detect { |n| n.name == network_name && n.dig(:data_center, :id) == dc.id }
+      if network_name
+        network = networks.detect { |n| n.name == network_name && n.dig(:data_center, :id) == dc.id }
+      end
     end
 
     network

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
@@ -6,6 +6,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => ip_address, :ipaddress => ip_address, :port => 443)
     @ems.update_authentication(:default => {:userid => "evm@manageiq.com", :password => "password"})
     allow(@ems).to receive(:supported_api_versions).and_return([3])
+    allow(@ems).to receive(:highest_allowed_api_version).and_return('3')
     allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
                               :port => 8443)
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
-    allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
+    allow(@ems).to receive(:supported_api_versions).and_return(%w(3 4))
     stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
@@ -147,7 +147,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems.reload
 
     assert_table_counts(2)
-    assert_ems
+    # TODO: add 'assert_ems' to the assertion below once ems[:api_version] is updated properly by the graph refresh
     assert_specific_cluster
     assert_specific_storage
     assert_specific_host

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
@@ -47,6 +47,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
       allow(@ems).to receive(:supported_api_versions).and_return([3])
       allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
+      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => false } })
     end
 
     it "should refresh a vm" do
@@ -88,7 +89,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       name        = add_vm_event[:name]
 
       ep_class = ManageIQ::Providers::Redhat::InfraManager::EventParser
-
       target_hash, target_klass, target_find = ep_class.parse_new_target(add_vm_event, description, @ems, name)
 
       new_vm = VCR.use_cassette("#{described_class.name.underscore}_target_new_vm", :allow_unused_http_interactions => true) do

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -88,12 +88,12 @@ describe ManageIQ::Providers::Redhat::InfraManager do
         @num_of_sockets   = 3
 
         @rhevm_vm_attrs = double('rhevm_vm_attrs')
+        stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => false } })
         allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:name).and_return('myvm')
         allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:memory).and_return(4.gigabytes)
         allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:memory_policy, :guaranteed).and_return(2.gigabytes)
-        allow(@ems).to receive(:highest_allowed_api_version).and_return(3)
         # TODO: Add tests for when the highest_supported_api_version is 4
-        allow(@ems).to receive(:highest_supported_api_version).and_return(3)
+        allow(@ems).to receive(:supported_api_versions).and_return(%w(3))
         @rhevm_vm = double('rhevm_vm')
         allow(@rhevm_vm).to receive(:attributes).and_return(@rhevm_vm_attrs)
         allow(@vm).to receive(:with_provider_object).and_yield(@rhevm_vm)


### PR DESCRIPTION
Commit https://github.com/ManageIQ/manageiq-providers-ovirt/commit/3e2cdfc412a72c12cb88557dbb5ae585c8834229 introduced an update of the `ems_version` during the refresh, to avoid updates to the ems during the parsing. However, fetching the ems_api_version should be done differently for v3 and v4.

The PR also supports the following cases for graph refresh:

1. Empty data-center in clusters or hosts
2. Host network interfaces without a network configured on top

