### PR TITLE
Move oVirt settings to the oVirt provider repository

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,14 @@
 ---
 :ems:
+  :ems_redhat:
+      :use_ovirt_engine_sdk: false
+      :resolve_ip_addresses: true
+      :inventory:
+        :read_timeout: 1.hour
+        :open_timeout: 1.minute
+      :service:
+        :read_timeout: 1.hour
+        :open_timeout: 1.minute
   :ems_ovirt:
     :blacklisted_event_names: []
     :event_handling:


### PR DESCRIPTION
These settings will be removed from the core repo in a separate PR.
The settings in the provider repo override the once in the core repo
in case a setting is defined in both.