### PR TITLE
Highest allowed API version

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -4,6 +4,8 @@ require 'resolv'
 module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
   extend ActiveSupport::Concern
 
+  HIGHEST_ALLOWED_API_VERSION = 4
+
   require 'ovirtsdk4'
 
   included do
@@ -278,7 +280,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     end
 
     def raw_connect(options)
-      version = options[:version] || highest_allowed_api_version
+      version = options[:version] || HIGHEST_ALLOWED_API_VERSION
       options[:password] = MiqPassword.try_decrypt(options[:password])
       connect_method = "raw_connect_v#{version}".to_sym
 

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -394,6 +394,12 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       described_class.raw_connect(options.merge(:version => '3'))
     end
 
+    it "calls the default version" do
+      expect(described_class).to receive(:raw_connect_v4).and_return(connection)
+
+      described_class.raw_connect(options.except(:version))
+    end
+
     it "always closes the connection" do
       expect(described_class).to receive(:raw_connect_v4).and_return(connection)
       expect(connection).to receive(:disconnect)


### PR DESCRIPTION
the `raw_connect` method was using `highest_allowed_api_version`, an instance method. I attempted to make it into a class method and include it as an instance method, however, the `cache_key` method requires an id, which does not work for the instance method.

It appears that the highest allowed API version is 4, since there are only two `raw_connect` methods (v3 and v4). My thought was to store this in a constant for the use of `raw_connect` to simplify and not require the use of the `cache_key`, but I am open to other suggestions.