### PR TITLE
Implement 'update_cloud_init' for V4

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -110,17 +110,17 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
     end
 
     def vm_boot_from_cdrom(operation, name)
-      operation.get_provider_destination.boot_from_cdrom(name)
+      operation.with_provider_destination { |d| d.boot_from_cdrom(name) }
     rescue Ovirt::VmNotReadyToBoot
       raise OvirtServices::VmNotReadyToBoot
     end
 
     def detach_floppy(operation)
-      operation.get_provider_destination.detach_floppy
+      operation.with_provider_destination(&:detach_floppy)
     end
 
     def vm_boot_from_network(operation)
-      operation.get_provider_destination.boot_from_network
+      operation.with_provider_destination(&:boot_from_network)
     rescue Ovirt::VmNotReadyToBoot
       raise OvirtServices::VmNotReadyToBoot
     end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision.rb
@@ -9,8 +9,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Provision < MiqProvision
     "Vm"
   end
 
-  def get_provider_destination
-    return nil if destination.nil?
-    destination.with_provider_object { |rhevm_vm| return rhevm_vm }
+  def with_provider_destination
+    return if destination.nil?
+    destination.with_provider_object { |obj| yield obj }
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -7,12 +7,12 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
   def attach_floppy_payload
     return unless content = customization_template_content
     filename = customization_template.default_filename
-    get_provider_destination.attach_floppy(filename => content)
+    with_provider_destination { |d| d.attach_floppy(filename => content) }
   end
 
   def configure_cloud_init
     return unless content = customization_template_content
-    get_provider_destination.update_cloud_init!(content)
+    with_provider_destination { |d| d.update_cloud_init!(content) }
 
     if Gem::Version.new(source.ext_management_system.api_version) >= Gem::Version.new("3.5.5.0")
       phase_context[:boot_with_cloud_init] = true

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
@@ -20,10 +20,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
                                :status      => 'Ok',
                                :options     => {:src_vm_id => template.id})
     allow(@task).to receive_messages(
-      :dest_cluster             => ems_cluster,
-      :get_provider_destination => rhevm_vm,
-      :source                   => template,
+      :dest_cluster => ems_cluster,
+      :source       => template,
     )
+    allow(@task).to receive(:get_provider_destination).and_yield(rhevm_vm)
 
     allow(Ovirt::Service).to receive_messages(:new => ovirt_service)
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration_spec.rb
@@ -10,7 +10,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration do
   let(:template)      { FactoryGirl.create(:template_redhat, :ext_management_system => ems) }
   let(:vm)            { FactoryGirl.create(:vm_redhat, :ext_management_system => ems) }
 
-  before { allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::Provision).to receive(:get_provider_destination).and_return(provider_object) }
+  before { allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::Provision).to receive(:with_provider_destination).and_yield(provider_object) }
   before(:each) { allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive(:supported_api_versions).and_return([3]) }
   context "#attach_floppy_payload" do
     it "should attach floppy if customization template provided" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
@@ -112,7 +112,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
         before do
           allow(@ems).to receive(:resolve_ip_address).with(@ems.hostname).and_return("1.2.3.4")
           rhevm_vm = double(:attributes => {:status => {:state => "down"}})
-          allow(@vm_prov).to receive(:get_provider_destination).and_return(rhevm_vm)
+          allow(@vm_prov).to receive(:with_provider_destination).and_yield(rhevm_vm)
           allow(@vm_prov).to receive(:destination).and_return(destination_vm)
           allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive(:supported_api_versions)
             .and_return([3])
@@ -127,13 +127,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
           end
 
           it "with an imaged_locked destination" do
-            @vm_prov.get_provider_destination.attributes[:status][:state] = "image_locked"
+            @vm_prov.with_provider_destination { |d| d.attributes[:status][:state] = "image_locked" }
 
             expect(@vm_prov.destination_image_locked?).to be_truthy
           end
 
           it "when destination is nil" do
-            allow(@vm_prov).to receive(:get_provider_destination).and_return(nil)
+            allow(@vm_prov).to receive(:with_provider_destination)
             expect(@vm_prov.destination_image_locked?).to be_falsey
           end
         end
@@ -147,7 +147,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
           end
 
           it "when destination_image_locked is true" do
-            @vm_prov.get_provider_destination.attributes[:status][:state] = "image_locked"
+            @vm_prov.with_provider_destination { |d| d.attributes[:status][:state] = "image_locked" }
             expect(@vm_prov).to receive(:requeue_phase)
 
             @vm_prov.customize_destination

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine_spec.rb
@@ -39,7 +39,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
       context "version 3" do
         before do
           @vm_service = double("vm_service")
-          allow(@vm).to receive(:with_provider_object).and_return(@vm_service)
+          allow(@vm).to receive(:with_provider_object).and_yield(@vm_service)
           allow(@ems).to receive(:supported_api_versions).and_return([3])
         end
 


### PR DESCRIPTION
Currently the provisioning of virtual machines from templates using
cloud-init fails when using version 4 of the API. The reason is that the
'update_cloud_init!' method used to set configure cloud-init isn't
implemented for that version of the API. This patch implements it,
preserving the logic used in the implementation done for V3, as we need
to make sure that existing customization scripts will continue working.

This patch is part of the fix for the following bug:

  Cloud-init not working when using api v4
  https://bugzilla.redhat.com/1486340