### PR TITLE
ovn: introducing ovn as ovirt's netwrok provider

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -296,6 +296,10 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       nic && nic[:mac] && nic[:mac][:address]
     end
 
+    def collect_external_network_providers
+      # Return nothing
+    end
+
     private
 
     #

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -378,6 +378,12 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       ManageIQ::Providers::Redhat::InfraManager::EventFetcher.new(ext_management_system)
     end
 
+    def collect_external_network_providers
+      ext_management_system.with_provider_connection(VERSION_HASH) do |connection|
+        connection.system_service.openstack_network_providers_service.list
+      end
+    end
+
     private
 
     #

--- a/app/models/manageiq/providers/redhat/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector/network_manager.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::Redhat::Inventory::Collector::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Collector::NetworkManager
+  def tenants
+    @tenants ||= manager.openstack_handle.accessible_tenants
+  end
+end

--- a/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
@@ -1,0 +1,21 @@
+class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Parser::NetworkManager
+  def parse
+    cloud_networks
+    # floating_ips
+    network_ports
+    # network_routers
+    # security_groups
+    cloud_tenants
+  end
+
+  def cloud_tenants
+    collector.tenants.each do |t|
+      tenant = persister.cloud_tenants.find_or_build(t.id)
+      tenant.name = t.name
+      tenant.description = t.description
+      tenant.enabled = t.enabled
+      tenant.ems_ref = t.id
+      tenant.parent = persister.cloud_tenants.lazy_find(t.try(:parent_id))
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/inventory/persister/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/network_manager.rb
@@ -1,0 +1,16 @@
+class ManageIQ::Providers::Redhat::Inventory::Persister::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Persister::NetworkManager
+  def network
+    ManageIQ::Providers::Redhat::InventoryCollectionDefault::NetworkManager
+  end
+
+  def initialize_inventory_collections
+    super
+    add_inventory_collections(
+        network,
+        %i(
+        cloud_tenants
+      ),
+        :builder_params => {:ext_management_system => manager.parent_manager}
+    )
+  end
+end

--- a/app/models/manageiq/providers/redhat/inventory_collection_default/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory_collection_default/network_manager.rb
@@ -1,0 +1,19 @@
+class ManageIQ::Providers::Redhat::InventoryCollectionDefault::NetworkManager < ManageIQ::Providers::Openstack::InventoryCollectionDefault::NetworkManager
+  class << self
+    def cloud_tenants(extra_attributes = {})
+      attributes = {
+          :model_class                 => ManageIQ::Providers::Openstack::CloudManager::CloudTenant,
+          :association                 => :cloud_tenants,
+          :inventory_object_attributes => [
+              :type,
+              :name,
+              :description,
+              :enabled,
+              :parent,
+              :ems_ref
+          ]
+      }
+      attributes.merge!(extra_attributes)
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -1,0 +1,202 @@
+class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::NetworkManager
+  require_nested :CloudNetwork
+  require_nested :CloudSubnet
+  require_nested :EventCatcher
+  require_nested :EventParser
+  require_nested :FloatingIp
+  require_nested :MetricsCapture
+  require_nested :MetricsCollectorWorker
+  require_nested :NetworkPort
+  require_nested :NetworkRouter
+  require_nested :RefreshParser
+  require_nested :RefreshWorker
+  require_nested :Refresher
+  require_nested :SecurityGroup
+
+  include ManageIQ::Providers::Openstack::ManagerMixin
+  include SupportsFeatureMixin
+
+  supports :create
+
+  has_many :public_networks,  :foreign_key => :ems_id, :dependent => :destroy,
+           :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public"
+  has_many :private_networks, :foreign_key => :ems_id, :dependent => :destroy,
+           :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private"
+
+  # Auth and endpoints delegations, editing of this type of manager must be disabled
+  delegate :zone,
+           :authentication_check, # Alona - fix it, auth shouldn't be taken from parent?
+           :authentication_status,
+           :authentication_status_ok?,
+           :authentications,
+           :authentication_for_summary,
+           # :openstack_handle,
+           #:connect,
+           #:verify_credentials,
+           #:with_provider_connection,
+           #:address,
+           #:ip_address,
+           # :hostname,
+           # :default_endpoint,
+           # :endpoints,
+           :to        => :parent_manager,
+           :allow_nil => true
+
+  def self.hostname_required?
+    false
+  end
+
+  def self.ems_type
+    @ems_type ||= "redhat_network".freeze
+  end
+
+  def self.description
+    @description ||= "Redhat Network".freeze
+  end
+
+  def self.default_blacklisted_event_names
+    %w(
+      scheduler.run_instance.start
+      scheduler.run_instance.scheduled
+      scheduler.run_instance.end
+    )
+  end
+
+  def supports_port?
+    true
+  end
+
+  def supports_api_version?
+    true
+  end
+
+  def supports_security_protocol?
+    true
+  end
+
+  def supported_auth_types
+    %w(default amqp)
+  end
+
+  def supports_provider_id?
+    true
+  end
+
+  def supports_authentication?(authtype)
+    supported_auth_types.include?(authtype.to_s)
+  end
+
+  def self.event_monitor_class
+    ManageIQ::Providers::Redhat::NetworkManager::EventCatcher
+  end
+
+  def create_cloud_network(options)
+    CloudNetwork.raw_create_cloud_network(self, options)
+  end
+
+  def create_cloud_network_queue(userid, options = {})
+    task_opts = {
+        :action => "creating Cloud Network for user #{userid}",
+        :userid => userid
+    }
+    queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_cloud_network',
+        :instance_id => id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => my_zone,
+        :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def create_cloud_subnet(options)
+    CloudSubnet.raw_create_cloud_subnet(self, options)
+  end
+
+  def create_cloud_subnet_queue(userid, options = {})
+    task_opts = {
+        :action => "creating Cloud Subnet for user #{userid}",
+        :userid => userid
+    }
+    queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_cloud_subnet',
+        :instance_id => id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => my_zone,
+        :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def create_network_router(options)
+    NetworkRouter.raw_create_network_router(self, options)
+  end
+
+  def create_network_router_queue(userid, options = {})
+    task_opts = {
+        :action => "creating Network Router for user #{userid}",
+        :userid => userid
+    }
+    queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_network_router',
+        :instance_id => id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => my_zone,
+        :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def create_floating_ip(options)
+    FloatingIp.raw_create_floating_ip(self, options)
+  end
+
+  def create_floating_ip_queue(userid, options = {})
+    task_opts = {
+        :action => "creating Floating IP for user #{userid}",
+        :userid => userid
+    }
+    queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_floating_ip',
+        :instance_id => id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => my_zone,
+        :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def create_security_group(options)
+    SecurityGroup.raw_create_security_group(self, options)
+  end
+
+  def create_security_group_queue(userid, options = {})
+    task_opts = {
+        :action => "creating Security Group for user #{userid}",
+        :userid => userid
+    }
+    queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_security_group',
+        :instance_id => id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => my_zone,
+        :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def tenants
+    @tenants ||= openstack_handle.accessible_tenants
+  end
+end
+

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_network.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork
+end

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_network/private.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_network/private.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Private < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private
+end

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_network/public.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_network/public.rb
@@ -1,0 +1,3 @@
+# require 'manageiq/providers/openstack/network_manager/cloud_network/public'
+class ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Public < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public
+end

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_subnet.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::CloudSubnet < ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet
+end

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_tenant.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::CloudTenant < ManageIQ::Providers::Openstack::CloudManager::CloudTenant
+end

--- a/app/models/manageiq/providers/redhat/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/event_catcher.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Redhat::NetworkManager::EventCatcher < ::MiqEventCatcher
+  require_nested :Runner
+
+  def self.ems_class
+    ManageIQ::Providers::Redhat::NetworkManager
+  end
+
+  def self.settings_name
+    :event_catcher_redhat_network
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/event_catcher/runner.rb
@@ -1,0 +1,6 @@
+class ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner < ManageIQ::Providers::Openstack::NetworkManager::EventCatcher::Runner
+  def add_openstack_queue(event)
+    event_hash = ManageIQ::Providers::Redhat::NetworkManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/event_parser.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/event_parser.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::Redhat::NetworkManager::EventParser
+  include ManageIQ::Providers::Openstack::NetworkManager::EventParser
+end

--- a/app/models/manageiq/providers/redhat/network_manager/floating_ip.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/floating_ip.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::FloatingIp < ManageIQ::Providers::Openstack::NetworkManager::FloatingIp
+end

--- a/app/models/manageiq/providers/redhat/network_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/metrics_capture.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::MetricsCapture < ManageIQ::Providers::Openstack::NetworkManager::MetricsCapture
+end

--- a/app/models/manageiq/providers/redhat/network_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/metrics_collector_worker.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::Redhat::NetworkManager::MetricsCollectorWorker < ::MiqEmsMetricsCollectorWorker
+  require_nested :Runner
+
+  self.default_queue_name = "redhat_network"
+
+  def friendly_name
+    @friendly_name ||= "C&U Metrics Collector for Redhat Network"
+  end
+
+  def self.ems_class
+    ManageIQ::Providers::Redhat::NetworkManager
+  end
+
+  def self.settings_name
+    :ems_metrics_collector_worker_redhat_network
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/metrics_collector_worker/runner.rb
@@ -1,0 +1,3 @@
+# require 'manageiq/providers/openstack/network_manager/metrics_collector_worker/runner'
+class ManageIQ::Providers::Redhat::NetworkManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::Openstack::NetworkManager::MetricsCollectorWorker::Runner
+end

--- a/app/models/manageiq/providers/redhat/network_manager/network_port.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/network_port.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::NetworkPort < ManageIQ::Providers::Openstack::NetworkManager::NetworkPort
+end

--- a/app/models/manageiq/providers/redhat/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/network_router.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::NetworkRouter < ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter
+end

--- a/app/models/manageiq/providers/redhat/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresh_parser.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers
+  class Redhat::NetworkManager::RefreshParser < Openstack::NetworkManager::RefreshParser
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresh_worker.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
+  require_nested :Runner
+
+  def self.ems_class
+    ManageIQ::Providers::Redhat::NetworkManager
+  end
+
+  def self.settings_name
+    :ems_refresh_worker_redhat_network
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresh_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker::Runner < ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker::Runner
+end

--- a/app/models/manageiq/providers/redhat/network_manager/refresher.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresher.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers
+  class Redhat::NetworkManager::Refresher < Openstack::NetworkManager::Refresher
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/security_group.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::SecurityGroup < ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,29 @@
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
+        :network:
+                  :critical:
+                  - floatingip.create.end
+                  - floatingip.delete.end
+                  - floatingip.update.end
+                  - network.create.end
+                  - network.delete.end
+                  - network.floating_ip.allocate
+                  - network.floating_ip.deallocate
+                  - network.floating_ip.associate
+                  - network.floating_ip.disassociate
+                  - network.update.end
+                  - router.create.end
+                  - router.delete.end
+                  - router.interface.create
+                  - router.interface.delete
+                  - router.update.end
+                  - security_group.create.end
+                  - security_group.delete.end
+                  - security_group.update.end
+                  - subnet.create.end
+                  - subnet.delete.end
+                  - subnet.update.end
 :http_proxy:
   :ovirt:
     :host:
@@ -13,3 +36,22 @@
 :ems_refresh:
   :rhevm:
     :inventory_object_refresh: false
+:workers:
+  :worker_base:
+    :event_catcher:
+      :event_catcher_redhat_network:
+        :poll: 15.seconds
+        :topics:
+          :neutron: "notifications.*"
+        :duration: 10.seconds
+        :capacity: 50
+        :amqp_port: 5672
+        :amqp_heartbeat: 30
+        :amqp_recovery_attempts: 4
+        :ceilometer:
+          :event_types_regex: '\A(firewall|floatingip|gateway|net|port|router|subnet|security_group|vpn)'
+    :queue_worker_base:
+      :ems_metrics_collector_worker:
+        :ems_metrics_collector_worker_redhat_network: {}
+      :ems_refresh_worker:
+        :ems_refresh_worker_redhat_network: {}


### PR DESCRIPTION
Introducing OVN as oVirt's netwrok provider

Discovering OVN as the network provider of oVirt and supporting showing
ports and CRUD actions for networks and subnets.
Manageiq will communicate directly with ovirt-provider-ovn.
Since ovirt-provider-ovn has neutron like api as much as possible
openstack's network provider code was reused.

Feature page -
https://github.com/oVirt/ovirt-site/pull/1068
