### PR TITLE
Introducing OVN as oVirt's network provider

### DIFF
--- a/app/models/manageiq/providers/redhat/builder.rb
+++ b/app/models/manageiq/providers/redhat/builder.rb
@@ -1,13 +1,21 @@
 class ManageIQ::Providers::Redhat::Builder
   class << self
     def build_inventory(ems, target)
-      if target.kind_of? ManagerRefresh::TargetCollection
+      if target.kind_of?(ManagerRefresh::TargetCollection)
         inventory(
           ems,
           target,
           ManageIQ::Providers::Redhat::Inventory::Collector::TargetCollection,
           ManageIQ::Providers::Redhat::Inventory::Persister::TargetCollection,
           [parser]
+        )
+      elsif target.kind_of?(ManageIQ::Providers::Redhat::NetworkManager)
+        inventory(
+          ems,
+          target,
+          ManageIQ::Providers::Redhat::Inventory::Collector::NetworkManager,
+          ManageIQ::Providers::Redhat::Inventory::Persister::NetworkManager,
+          [ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager]
         )
       else
         # Fallback to ems refresh or full refresh

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -304,6 +304,10 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       nic && nic[:mac] && nic[:mac][:address]
     end
 
+    def collect_external_network_providers
+      # Return nothing
+    end
+
     private
 
     #

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -515,6 +515,12 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       ManageIQ::Providers::Redhat::InfraManager::EventFetcher.new(ext_management_system)
     end
 
+    def collect_external_network_providers
+      ext_management_system.with_provider_connection(VERSION_HASH) do |connection|
+        connection.system_service.openstack_network_providers_service.list
+      end
+    end
+
     private
 
     #

--- a/app/models/manageiq/providers/redhat/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector/network_manager.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::Redhat::Inventory::Collector::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Collector::NetworkManager
+  def tenants
+    @tenants = manager.openstack_handle.accessible_tenants
+  end
+end

--- a/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
@@ -1,0 +1,18 @@
+class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Parser::NetworkManager
+  def parse
+    cloud_networks
+    network_ports
+    cloud_tenants
+  end
+
+  def cloud_tenants
+    collector.tenants.each do |t|
+      tenant = persister.cloud_tenants.find_or_build(t.id)
+      tenant.name = t.name
+      tenant.description = t.description
+      tenant.enabled = t.enabled
+      tenant.ems_ref = t.id
+      tenant.parent = persister.cloud_tenants.lazy_find(t.try(:parent_id))
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/inventory/persister/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/network_manager.rb
@@ -1,0 +1,14 @@
+class ManageIQ::Providers::Redhat::Inventory::Persister::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Persister::NetworkManager
+  def network
+    ManageIQ::Providers::Redhat::InventoryCollectionDefault::NetworkManager
+  end
+
+  def initialize_inventory_collections
+    super
+    add_inventory_collections(
+      network,
+      %i(cloud_tenants),
+      :builder_params => {:ext_management_system => manager.parent_manager}
+    )
+  end
+end

--- a/app/models/manageiq/providers/redhat/inventory_collection_default/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory_collection_default/network_manager.rb
@@ -1,0 +1,19 @@
+class ManageIQ::Providers::Redhat::InventoryCollectionDefault::NetworkManager < ManageIQ::Providers::Openstack::InventoryCollectionDefault::NetworkManager
+  class << self
+    def cloud_tenants(extra_attributes = {})
+      attributes = {
+        :model_class                 => ManageIQ::Providers::Openstack::CloudManager::CloudTenant,
+        :association                 => :cloud_tenants,
+        :inventory_object_attributes => [
+          :type,
+          :name,
+          :description,
+          :enabled,
+          :parent,
+          :ems_ref
+        ]
+      }
+      attributes.merge!(extra_attributes)
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -1,0 +1,125 @@
+class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::NetworkManager
+  require_nested :CloudNetwork
+  require_nested :CloudSubnet
+  require_nested :EventCatcher
+  require_nested :EventParser
+  require_nested :MetricsCapture
+  require_nested :MetricsCollectorWorker
+  require_nested :NetworkPort
+  require_nested :RefreshParser
+  require_nested :RefreshWorker
+  require_nested :Refresher
+
+  include ManageIQ::Providers::Openstack::ManagerMixin
+  include SupportsFeatureMixin
+
+  supports :create
+
+  has_many :public_networks,  :foreign_key => :ems_id, :dependent => :destroy,
+           :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public"
+  has_many :private_networks, :foreign_key => :ems_id, :dependent => :destroy,
+           :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private"
+
+  delegate :zone,
+           :authentication_check, # TODO: fix it, auth shouldn't be done via the parent
+           :authentication_status,
+           :authentication_status_ok?,
+           :authentications,
+           :authentication_for_summary,
+           :to        => :parent_manager,
+           :allow_nil => true
+
+  def self.hostname_required?
+    false
+  end
+
+  def self.ems_type
+    @ems_type ||= "redhat_network".freeze
+  end
+
+  def self.description
+    @description ||= "Redhat Network".freeze
+  end
+
+  def self.default_blacklisted_event_names
+    %w(
+      scheduler.run_instance.start
+      scheduler.run_instance.scheduled
+      scheduler.run_instance.end
+    )
+  end
+
+  def supports_port?
+    true
+  end
+
+  def supports_api_version?
+    true
+  end
+
+  def supports_security_protocol?
+    true
+  end
+
+  def supported_auth_types
+    %w(default amqp)
+  end
+
+  def supports_provider_id?
+    true
+  end
+
+  def supports_authentication?(authtype)
+    supported_auth_types.include?(authtype.to_s)
+  end
+
+  def self.event_monitor_class
+    ManageIQ::Providers::Redhat::NetworkManager::EventCatcher
+  end
+
+  def create_cloud_network(options)
+    CloudNetwork.raw_create_cloud_network(self, options)
+  end
+
+  def create_cloud_network_queue(userid, options = {})
+    task_opts = {
+      :action => "creating Cloud Network for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'create_cloud_network',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def create_cloud_subnet(options)
+    CloudSubnet.raw_create_cloud_subnet(self, options)
+  end
+
+  def create_cloud_subnet_queue(userid, options = {})
+    task_opts = {
+      :action => "creating Cloud Subnet for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'create_cloud_subnet',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def tenants
+    @tenants ||= openstack_handle.accessible_tenants
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_network.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork
+end

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_subnet.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::CloudSubnet < ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet
+end

--- a/app/models/manageiq/providers/redhat/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/event_catcher.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Redhat::NetworkManager::EventCatcher < ::MiqEventCatcher
+  require_nested :Runner
+
+  def self.ems_class
+    ManageIQ::Providers::Redhat::NetworkManager
+  end
+
+  def self.settings_name
+    :event_catcher_redhat_network
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/event_catcher/runner.rb
@@ -1,0 +1,6 @@
+class ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner < ManageIQ::Providers::Openstack::NetworkManager::EventCatcher::Runner
+  def add_openstack_queue(event)
+    event_hash = ManageIQ::Providers::Redhat::NetworkManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/event_parser.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/event_parser.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::Redhat::NetworkManager::EventParser
+  include ManageIQ::Providers::Openstack::NetworkManager::EventParser
+end

--- a/app/models/manageiq/providers/redhat/network_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/metrics_capture.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::MetricsCapture < ManageIQ::Providers::Openstack::NetworkManager::MetricsCapture
+end

--- a/app/models/manageiq/providers/redhat/network_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/metrics_collector_worker.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::Redhat::NetworkManager::MetricsCollectorWorker < ::MiqEmsMetricsCollectorWorker
+  require_nested :Runner
+
+  self.default_queue_name = "redhat_network"
+
+  def friendly_name
+    @friendly_name ||= "C&U Metrics Collector for Redhat Network"
+  end
+
+  def self.ems_class
+    ManageIQ::Providers::Redhat::NetworkManager
+  end
+
+  def self.settings_name
+    :ems_metrics_collector_worker_redhat_network
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/metrics_collector_worker/runner.rb
@@ -1,0 +1,3 @@
+# require 'manageiq/providers/openstack/network_manager/metrics_collector_worker/runner'
+class ManageIQ::Providers::Redhat::NetworkManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::Openstack::NetworkManager::MetricsCollectorWorker::Runner
+end

--- a/app/models/manageiq/providers/redhat/network_manager/network_port.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/network_port.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::NetworkPort < ManageIQ::Providers::Openstack::NetworkManager::NetworkPort
+end

--- a/app/models/manageiq/providers/redhat/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresh_parser.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers
+  class Redhat::NetworkManager::RefreshParser < Openstack::NetworkManager::RefreshParser
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresh_worker.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
+  require_nested :Runner
+
+  def self.ems_class
+    ManageIQ::Providers::Redhat::NetworkManager
+  end
+
+  def self.settings_name
+    :ems_refresh_worker_redhat_network
+  end
+end

--- a/app/models/manageiq/providers/redhat/network_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresh_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker::Runner < ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker::Runner
+end

--- a/app/models/manageiq/providers/redhat/network_manager/refresher.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresher.rb
@@ -1,0 +1,20 @@
+module ManageIQ::Providers
+  class Redhat::NetworkManager::Refresher < Openstack::NetworkManager::Refresher
+    def collect_inventory_for_targets(ems, targets)
+      targets_with_data = targets.collect do |target|
+        target_name = target.try(:name) || target.try(:event_type)
+
+        _log.info("Filtering inventory for #{target.class} [#{target_name}] id: [#{target.id}]...")
+
+        if ::Settings.ems.ems_ovirt.ems_network.try(:refresh).try(:inventory_object_refresh)
+          inventory = ManageIQ::Providers::Redhat::Builder.build_inventory(ems, target)
+        end
+
+        _log.info("Filtering inventory...Complete")
+        [target, inventory]
+      end
+
+      targets_with_data
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,8 +11,19 @@
       :open_timeout: 1.minute
     :blacklisted_event_names: []
   :ems_ovirt:
+    :ems_network:
+      :refresh:
+        :inventory_object_refresh: true
     :event_handling:
       :event_groups:
+        :network:
+          :critical:
+          - network.create.end
+          - network.delete.end
+          - network.update.end
+          - subnet.create.end
+          - subnet.delete.end
+          - subnet.update.end
     :connection_manager:
       :purge_interval: 1.hour
 :http_proxy:
@@ -33,8 +44,21 @@
     :event_catcher:
       :event_catcher_redhat:
         :poll: 15.seconds
+      :event_catcher_redhat_network:
+        :poll: 15.seconds
+        :topics:
+          :neutron: "notifications.*"
+        :duration: 10.seconds
+        :capacity: 50
+        :amqp_port: 5672
+        :amqp_heartbeat: 30
+        :amqp_recovery_attempts: 4
+        :ceilometer:
+          :event_types_regex: '\A(firewall|floatingip|gateway|net|port|router|subnet|security_group|vpn)'
     :queue_worker_base:
       :ems_metrics_collector_worker:
         :ems_metrics_collector_worker_redhat: {}
+        :ems_metrics_collector_worker_redhat_network: {}
       :ems_refresh_worker:
         :ems_refresh_worker_redhat: {}
+        :ems_refresh_worker_redhat_network: {}

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/external_network_providers.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/external_network_providers.yml
@@ -1,0 +1,30 @@
+--- !ruby/array:OvirtSDK4::List
+internal:
+- !ruby/object:OvirtSDK4::OpenStackNetworkProvider
+  href: "/ovirt-engine/api/openstacknetworkproviders/6e452166-e772-4355-b050-24705a32c15c"
+  comment: 
+  description: 
+  id: 6e452166-e772-4355-b050-24705a32c15c
+  name: ovn
+  authentication_url: http://localhost:35357/v2.0/
+  password: 
+  properties: 
+  requires_authentication: true
+  url: http://localhost:9696
+  username: admin@internal
+  tenant_name: 
+  agent_configuration: 
+  certificates: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/openstacknetworkproviders/6e452166-e772-4355-b050-24705a32c15c/certificates"
+  networks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/openstacknetworkproviders/6e452166-e772-4355-b050-24705a32c15c/networks"
+  plugin_type: open_vswitch
+  read_only: 
+  subnets: 
+  type: external
+ivars:
+  :@href: 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/external_network_providers.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/external_network_providers.yml
@@ -1,0 +1,30 @@
+--- !ruby/array:OvirtSDK4::List
+internal:
+- !ruby/object:OvirtSDK4::OpenStackNetworkProvider
+  href: "/ovirt-engine/api/openstacknetworkproviders/6e452166-e772-4355-b050-24705a32c15c"
+  comment: 
+  description: 
+  id: 6e452166-e772-4355-b050-24705a32c15c
+  name: ovn
+  authentication_url: http://localhost:35357/v2.0/
+  password: 
+  properties: 
+  requires_authentication: true
+  url: http://localhost:9696
+  username: admin@internal
+  tenant_name: 
+  agent_configuration: 
+  certificates: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/openstacknetworkproviders/6e452166-e772-4355-b050-24705a32c15c/certificates"
+  networks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/openstacknetworkproviders/6e452166-e772-4355-b050-24705a32c15c/networks"
+  plugin_type: open_vswitch
+  read_only: 
+  subnets: 
+  type: external
+ivars:
+  :@href: 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -1,10 +1,14 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   before(:each) do
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
+    @ems = FactoryGirl.build(:ems_redhat_with_ensure_managers, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
                               :port => 8443)
+    @ovirt_service = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
+    allow_any_instance_of(@ovirt_service)
+      .to receive(:collect_external_network_providers).and_return(load_response_mock_for('external_network_providers'))
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
     allow(@ems).to receive(:supported_api_versions).and_return(%w(3 4))
+    @ems.save
     stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
@@ -116,6 +120,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
     assert_table_counts(2)
     # TODO: add 'assert_ems' to the assertion below once ems[:api_version] is updated properly by the graph refresh
+    assert_network_manager
     assert_specific_cluster
     assert_specific_storage
     assert_specific_host
@@ -126,7 +131,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   end
 
   def assert_table_counts(lan_number)
-    expect(ExtManagementSystem.count).to eq(1)
+    expect(ExtManagementSystem.count).to eq(2)
     expect(EmsFolder.count).to eq(7)
     expect(EmsCluster.count).to eq(3)
     expect(Host.count).to eq(3)
@@ -153,6 +158,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(32)
+
     expect(MiqQueue.count).to eq(13)
   end
 
@@ -172,6 +178,18 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(@ems.miq_templates.size).to eq(2)
 
     expect(@ems.customization_specs.size).to eq(0)
+  end
+
+  def assert_network_manager
+    @network_manager = ExtManagementSystem.find_by(:type => 'ManageIQ::Providers::Redhat::NetworkManager')
+    expect(@network_manager).to have_attributes(
+      :name              => @ems.name + " Network Manager",
+      :hostname          => "localhost",
+      :port              => 35357,
+      :api_version       => "v2",
+      :security_protocol => "non-ssl",
+      :zone_id           => @ems.zone_id
+    )
   end
 
   def assert_specific_cluster


### PR DESCRIPTION
Discovering OVN as the network provider of oVirt and supporting showing
ports and CRUD actions for networks and subnets.
Manageiq will communicate directly with ovirt-provider-ovn.
Since ovirt-provider-ovn has neutron like api as much as possible
openstack's network provider code was reused.

Feature page -
https://github.com/oVirt/ovirt-site/pull/1068