### PR TITLE
Use the new ovirt_sdk by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 ---
 :ems:
   :ems_redhat:
-      :use_ovirt_engine_sdk: false
+      :use_ovirt_engine_sdk: true
       :resolve_ip_addresses: true
       :inventory:
         :read_timeout: 1.hour

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
@@ -119,7 +119,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       @ems = FactoryGirl.create(:ems_redhat, :zone => zone,
                                 :hostname => ip_address, :ipaddress => ip_address, :port => 443)
       @ems.update_authentication(:default => {:userid => "admin@internal", :password => "password"})
-      allow(@ems).to receive(:supported_api_versions).and_return([3])
+      allow(@ems).to receive(:supported_api_versions).and_return(['3'])
       allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
     end
 


### PR DESCRIPTION
use_ovirt_engine_sdk will now be set to true by default.
https://bugzilla.redhat.com/show_bug.cgi?id=1490091