### PR TITLE
Support publish VM

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -253,7 +253,8 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
         :migrate,
         :quick_stats,
         :reconfigure_disks,
-        :snapshots
+        :snapshots,
+        :publish
       ]
     end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
@@ -10,19 +10,49 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Cloning
   end
 
   def find_destination_in_vmdb(ems_ref)
-    ManageIQ::Providers::Redhat::InfraManager::Vm.find_by(:name => dest_name, :ems_ref => ems_ref)
+    if source.template?
+      ManageIQ::Providers::Redhat::InfraManager::Vm.find_by(:name => dest_name, :ems_ref => ems_ref)
+    else
+      ManageIQ::Providers::Redhat::InfraManager::Template.find_by(:name => dest_name, :ems_ref => ems_ref)
+    end
   end
 
   def prepare_for_clone_task
     raise MiqException::MiqProvisionError, "Provision Request's Destination VM Name=[#{dest_name}] cannot be blank" if dest_name.blank?
     raise MiqException::MiqProvisionError, "A VM with name: [#{dest_name}] already exists" if source.ext_management_system.vms.where(:name => dest_name).any?
 
+    prepare_clone_options
+  end
+
+  def prepare_clone_options
+    if source.template?
+      # return the options for creating a vm from the template
+      vm_clone_options
+    else
+      # return the options for creating a template from the vm
+      template_clone_options
+    end
+  end
+
+  def vm_clone_options
     clone_options = {
       :name       => dest_name,
       :cluster    => dest_cluster.ems_ref,
       :clone_type => get_option(:linked_clone) ? :linked : :full,
       :sparse     => sparse_disk_value
     }
+    clone_options[:storage] = dest_datastore.ems_ref unless dest_datastore.nil?
+    clone_options
+  end
+
+  def template_clone_options
+    clone_options = {
+      :name        => dest_name,
+      :cluster     => dest_cluster.ems_ref,
+      :description => get_option(:vm_description),
+      :seal        => get_option(:seal)
+    }
+
     clone_options[:storage] = dest_datastore.ems_ref unless dest_datastore.nil?
     clone_options
   end
@@ -42,13 +72,20 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Cloning
     _log.info("Destination VM Name:        [#{clone_options[:name]}]")
     _log.info("Destination Cluster:        [#{dest_cluster.name} (#{dest_cluster.ems_ref})]")
     _log.info("Destination Datastore:      [#{dest_datastore.name} (#{dest_datastore.ems_ref})]") unless dest_datastore.nil?
+    _log.info("Seal:                       [#{clone_options[:seal]}]") unless source.template?
 
     dump_obj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
     dump_obj(options, "#{_log.prefix} Prov Options:  ", $log, :info, :protected => {:path => workflow_class.encrypted_options_field_regs})
   end
 
   def start_clone(clone_options)
-    ems.ovirt_services.start_clone(source, clone_options, phase_context)
+    if source.template?
+      # create a vm from the template
+      ems.ovirt_services.start_clone(source, clone_options, phase_context)
+    else
+      # create a template from the vm
+      ems.ovirt_services.make_template(source, clone_options, phase_context)
+    end
   end
 
   def ems

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -33,15 +33,19 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
   end
 
   def customize_destination
-    if destination_image_locked?
-      _log.info("Destination image locked; re-queuing")
-      requeue_phase
+    if source.template?
+      if destination_image_locked?
+        _log.info("Destination image locked; re-queuing")
+        requeue_phase
+      else
+        message = "Starting New #{destination_type} Customization"
+        _log.info("#{message} #{for_destination}")
+        update_and_notify_parent(:message => message)
+        configure_container
+        signal :configure_disks
+      end
     else
-      message = "Starting New #{destination_type} Customization"
-      _log.info("#{message} #{for_destination}")
-      update_and_notify_parent(:message => message)
-      configure_container
-      signal :configure_disks
+      signal :post_provision
     end
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -135,4 +135,13 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
       _("%{description} VM Memory is larger than Memory Limit") % {:description => required_description(dlg, fld)}
     end
   end
+
+  def validate_seal_template(_field, values, _dlg, _fld, _value)
+    seal = get_value(values[:seal])
+    return nil unless seal
+
+    if get_source_vm.platform == 'windows'
+      _("Template sealing is supported only for non-Windows OS.")
+    end
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -22,8 +22,18 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
     end
   end
 
-  supports_not :publish
   supports_not :reset
+  supports :publish do
+    if blank? || orphaned? || archived?
+      unsupported_reason_add(:publish, _('Publish operation in not supported'))
+    elsif ext_management_system.blank?
+      unsupported_reason_add(:publish, _('The virtual machine is not associated with a provider'))
+    elsif !ext_management_system.supports_publish?
+      unsupported_reason_add(:publish, _('This feature is not supported by the api version of the provider'))
+    elsif power_state != "off"
+      unsupported_reason_add(:publish, _('The virtual machine must be down'))
+    end
+  end
 
   POWER_STATES = {
     'up'        => 'on',

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -115,6 +115,50 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
     end
   end
 
+  describe "#supports_publish?" do
+    context "when vm has no storage" do
+      let(:vm) { FactoryGirl.create(:vm_redhat, :storage => nil, :ext_management_system => nil) }
+
+      it "does not support publish" do
+        expect(vm.supports_publish?).to be_falsey
+      end
+    end
+
+    context "when vm has no ems" do
+      let(:storage) { FactoryGirl.create(:storage_nfs, :ems_ref => "http://example.com/storages/XYZ") }
+      let(:vm) { FactoryGirl.create(:vm_redhat, :storage => storage, :ext_management_system => nil) }
+
+      it "does not support publish" do
+        expect(vm.supports_publish?).to be_falsey
+      end
+    end
+
+    context "when vm is not in down state" do
+      let(:storage) { FactoryGirl.create(:storage_nfs, :ems_ref => "http://example.com/storages/XYZ") }
+      let(:ems) { FactoryGirl.create(:ems_redhat_with_authentication) }
+      let(:vm) { FactoryGirl.create(:vm_redhat, :ext_management_system => ems, :storage => storage) }
+
+      it "does not support publish" do
+        allow(vm).to receive(:power_state).and_return("on")
+
+        expect(vm.supports_publish?).to be_falsey
+      end
+    end
+
+    context "when vm is down" do
+      let(:storage) { FactoryGirl.create(:storage_nfs, :ems_ref => "http://example.com/storages/XYZ") }
+      let(:ems) { FactoryGirl.create(:ems_redhat_with_authentication) }
+      let(:vm) { FactoryGirl.create(:vm_redhat, :ext_management_system => ems, :storage => storage) }
+
+      it "does support publish" do
+        allow(ems).to receive(:supported_api_versions).and_return([4])
+        allow(vm).to receive(:power_state).and_return("off")
+
+        expect(vm.supports_publish?).to be_truthy
+      end
+    end
+  end
+
   describe "#disconnect_storage" do
     before(:each) do
       _, _, zone = EvmSpecHelper.create_guid_miq_server_zone


### PR DESCRIPTION
Creating a template from a VM is supported by RHV since forever.
The PR introduces a new dialog to allow the creation of a template from
a VM, including the ability to seal a template (for non-windows vms).

https://bugzilla.redhat.com/show_bug.cgi?id=1373076

**Screenshots of the new dialog:**
Request tab:
![publish_vm_request_tab](https://user-images.githubusercontent.com/316242/30428314-ca806080-995b-11e7-9731-41c9e0362095.png)

Catalog tab:
![publish_vm_catalog_tab](https://user-images.githubusercontent.com/316242/30428313-ca7f8034-995b-11e7-9480-764606a009cf.png)

Environment tab:
![publish_vm_environment_tab](https://user-images.githubusercontent.com/316242/30875111-186690fa-a2fb-11e7-8f4f-cebab0f333b2.png)

Schedule tab:
![publish_vm_schedule_tab](https://user-images.githubusercontent.com/316242/30428311-ca7e3fc6-995b-11e7-84f8-3dda1fbf61da.png)

Due to a limitation of RHV, when specifying a storage domain, all of the template's disks will be created on the specified storage domain (while on RHV the user can specify storage domain per disk)
