### PR TITLE
Parse the serial number during refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
@@ -194,6 +194,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
       unless hw_info.blank?
         result[:manufacturer] = hw_info.manufacturer
         result[:model] = hw_info.product_name
+        result[:serial_number] = hw_info.serial_number
       end
 
       result[:number_of_nics] = inv.nics.count

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -204,6 +204,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       :cpu_total_cores      => cpu_sockets * cpu_cores,
       :manufacturer         => hw_info.manufacturer,
       :model                => hw_info.product_name,
+      :serial_number        => hw_info.serial_number,
       :number_of_nics       => nics.count
     )
 

--- a/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
@@ -479,7 +479,8 @@ class ManageIQ::Providers::Redhat::InventoryCollectionDefault::InfraManager < Ma
           :memory_mb,
           :model,
           :networks,
-          :number_of_nics
+          :number_of_nics,
+          :serial_number
         ]
       }
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -334,7 +334,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :guest_os_full_name   => nil,
       :vmotion_enabled      => nil,
       :cpu_usage            => nil,
-      :memory_usage         => nil
+      :memory_usage         => nil,
+      :serial_number        => "30353036-3837-4247-3831-303946353235"
     )
 
     expect(@host.hardware.networks.size).to eq(1)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -253,7 +253,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :guest_os_full_name   => nil,
         :vmotion_enabled      => nil,
         :cpu_usage            => nil,
-        :memory_usage         => nil
+        :memory_usage         => nil,
+        :serial_number        => "30353036-3837-4247-3831-303946353239"
       )
 
       expect(@host.hardware.networks.size).to eq(1)


### PR DESCRIPTION
Parse the serial number of host during refresh.
This is required for:
https://bugzilla.redhat.com/show_bug.cgi?id=1410183

Required for:
https://github.com/ManageIQ/manageiq/pull/15992