### PR TITLE
move provider specific settings over here

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,3 +24,15 @@
 :ems_refresh:
   :rhevm:
     :inventory_object_refresh: false
+:log:
+  :level_rhevm: info
+:workers:
+  :worker_base:
+    :event_catcher:
+      :event_catcher_redhat:
+        :poll: 15.seconds
+    :queue_worker_base:
+      :ems_metrics_collector_worker:
+        :ems_metrics_collector_worker_redhat: {}
+      :ems_refresh_worker:
+        :ems_refresh_worker_redhat: {}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,14 +1,14 @@
 ---
 :ems:
   :ems_redhat:
-      :use_ovirt_engine_sdk: true
-      :resolve_ip_addresses: true
-      :inventory:
-        :read_timeout: 1.hour
-        :open_timeout: 1.minute
-      :service:
-        :read_timeout: 1.hour
-        :open_timeout: 1.minute
+    :use_ovirt_engine_sdk: true
+    :resolve_ip_addresses: true
+    :inventory:
+      :read_timeout: 1.hour
+      :open_timeout: 1.minute
+    :service:
+      :read_timeout: 1.hour
+      :open_timeout: 1.minute
   :ems_ovirt:
     :blacklisted_event_names: []
     :event_handling:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,8 +9,8 @@
     :service:
       :read_timeout: 1.hour
       :open_timeout: 1.minute
-  :ems_ovirt:
     :blacklisted_event_names: []
+  :ems_ovirt:
     :event_handling:
       :event_groups:
     :connection_manager:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@
     :connection_manager:
       :purge_interval: 1.hour
 :http_proxy:
-  :ovirt:
+  :rhevm:
     :host:
     :password:
     :port:


### PR DESCRIPTION
@borod108 @jhernand @pkliczewski please have a look at the individual commits

whats still missing is `event_handling`. This would involve identifying the redhat events in the core settings and moving them here.

```shell
~/src/manageiq-content/content/automate/ManageIQ 
❯ pwd
/Users/hild/src/manageiq-content/content/automate/ManageIQ

~/src/manageiq-content/content/automate/ManageIQ 
❯ ag name System/Event/EmsEvent/RHEVM.class/
```