### PR TITLE
Require Ovirt in ApiIntegration

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
   extend ActiveSupport::Concern
 
   require 'ovirtsdk4'
+  require 'ovirt'
 
   included do
     process_api_features_support


### PR DESCRIPTION
Resolves uninitialized constant error described in https://github.com/ManageIQ/manageiq-providers-ovirt/pull/67

@miq-bot assign @borod108 
@miq-bot add_label bug 