### PR TITLE
Propagate user validation errors

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -86,7 +86,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     probe_results.map(&:version) if probe_results
   rescue => error
     _log.error("Error while probing supported api versions #{error}")
-    []
+    raise
   end
 
   def supports_the_api_version?(version)


### PR DESCRIPTION
We need to make sure that any errors during ovirt credentials validation are properly
propagated to the user.