### PR TITLE
Avoid NoMethod error in TemplatePreloadedAttributesDecorator.new

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
@@ -316,9 +316,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
 
     class TemplatePreloadedAttributesDecorator < SimpleDelegator
       attr_reader :disks
-      def initialize(template, connection, preloaded_disks = nil, future_disk_attachments = nil)
+      def initialize(template, connection, preloaded_disks = nil)
         @obj = template
-        @disks = AttachedDisksFetcher.get_attached_disks_from_futures(template, connection, preloaded_disks, future_disk_attachments[template.id])
+        @disks = AttachedDisksFetcher.get_attached_disks_from_futures(template, connection, preloaded_disks, nil)
         super(template)
       end
     end


### PR DESCRIPTION
Currently the constructor of the `TemplatePreloadedAttributesDecorator`
class receives a parameter that defaults to 'nil', and that it is
actually never used. But the implementation of the constructor tries
call methods on it, `NoMethodError`. The net result is that refresh
fails. To avoid that this patch removes that unused parameter.

This patch addresses the following issue:

  RHV Refresh worker throwing error in evm.log
  https://bugzilla.redhat.com/1501162