### PR TITLE
Require oVirt Ruby SDK 4.1.9 or newer

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "ovirt", "~>0.18.0"
   s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
+  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.1.9"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This patch changes the provider so that it directly requires version
4.1.9 or newer of the oVirt Ruby SDK.

The new version of the SDK addresses a problem when using the same
connection from multiple threads, described in the following bug:

  Access to RHV using the oVirt SDK may crash the events worker
  https://bugzilla.redhat.com/1496848