### PR TITLE
Running 'ensure_network provider' as a separate job

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -22,7 +22,16 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   supports :provisioning
   supports :refresh_new_target
 
-  before_save :ensure_managers
+  def ensure_managers
+    return unless enabled
+    ensure_network_manager
+    if network_manager
+      network_manager.name = "#{name} Network Manager"
+      network_manager.zone_id = zone_id
+      network_manager.provider_region = provider_region
+      network_manager.save!
+    end
+  end
 
   def ensure_network_manager
     providers = ovirt_services.collect_external_network_providers

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
@@ -37,6 +37,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
         [target, data]
       end
 
+      ems.ensure_managers
+
       targets_with_data
     end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -1,14 +1,13 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   before(:each) do
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.build(:ems_redhat_with_ensure_managers, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
+    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
                               :port => 8443)
     @ovirt_service = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
     allow_any_instance_of(@ovirt_service)
       .to receive(:collect_external_network_providers).and_return(load_response_mock_for('external_network_providers'))
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
     allow(@ems).to receive(:supported_api_versions).and_return(%w(3 4))
-    @ems.save
     stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
@@ -159,7 +158,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
     expect(Relationship.count).to eq(32)
 
-    expect(MiqQueue.count).to eq(13)
+    expect(MiqQueue.count).to eq(14)
   end
 
   def assert_ems

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -1,7 +1,7 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   before(:each) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.build(:ems_redhat_with_ensure_managers, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
+    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
                               :port => 8443)
     @ovirt_service = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
     allow_any_instance_of(@ovirt_service)
@@ -9,7 +9,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
     @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
     allow(@ems).to(receive(:supported_api_versions).and_return(%w(3 4)))
-    @ems.save
     stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).and_call_original
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).with(kind_of(Hash)) do |opts|
@@ -76,7 +75,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(45)
-    expect(MiqQueue.count).to eq(20)
+    expect(MiqQueue.count).to eq(21)
   end
 
   def assert_ems

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
@@ -3,7 +3,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
   before(:each) do
     _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.build(:ems_redhat_with_ensure_managers, :zone => zone, :hostname => "192.168.1.105", :ipaddress => "192.168.1.105",
+    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.1.105", :ipaddress => "192.168.1.105",
                               :port => 8443)
     @ovirt_service = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
     allow_any_instance_of(@ovirt_service)
@@ -12,7 +12,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
     @ems.default_endpoint.path = "/ovirt-engine/api"
     allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
-    @ems.save
     allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
     stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
@@ -168,7 +167,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(Datacenter.count).to eq(1)
 
     expect(Relationship.count).to eq(9)
-    expect(MiqQueue.count).to eq(4)
+    expect(MiqQueue.count).to eq(5)
   end
 
   def assert_vm(vm, storage)

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -414,12 +414,11 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     let(:api_version) { "4.2" }
 
     before do
-      @ems = FactoryGirl.build(:ems_redhat_with_ensure_managers, :api_version => api_version)
+      @ems = FactoryGirl.create(:ems_redhat, :api_version => api_version)
       @provider = double(:authentication_url => 'https://hostname.usersys.redhat.com:35357/v2.0')
       @providers = double("providers", :sort_by => [@provider], :first => @provider)
       allow(@ems).to receive(:ovirt_services).and_return(double(:collect_external_network_providers => @providers))
-
-      @ems.save
+      @ems.ensure_managers
     end
 
     it "does not create orphaned network_manager" do
@@ -431,7 +430,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       expect(ExtManagementSystem.count).to eq(0)
 
       same_ems.hostname = "dummy-mandatory"
-      same_ems.save!
+      same_ems.ensure_managers
       expect(ExtManagementSystem.count).to eq(0)
     end
 


### PR DESCRIPTION
'ensure_network' has an api call to ovirt, therefore, it should be run
as a separate jobs to avoid calling it directly from the ui.

All the tests that had to be fixed because of this api call were reverted.