### PR TITLE
[WIP] Add method to generate UI URL

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -1,3 +1,8 @@
+require 'nokogiri'
+require 'openssl'
+require 'ovirtsdk4'
+require 'uri'
+
 class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
   include_concern 'Operations'
   include_concern 'RemoteConsole'
@@ -101,5 +106,135 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
 
   def self.calculate_power_state(raw_power_state)
     POWER_STATES[raw_power_state] || super
+  end
+
+  #
+  # This method is executed in the UI worker. It adds to the queue a task to retrieve the
+  # URL of the oVirt UI for this virtual machine.
+  #
+  # @return [Integer] The identifier of the task.
+  #
+  def queue_generate_ui_url
+    # Create the task options:
+    task_options = {
+      action: "Generate oVirt UI URL for VM '#{name}'"
+    }
+
+    # Create the queue options:
+    queue_options = {
+      class_name: self.class.name,
+      instance_id: id,
+      method_name: 'generate_ui_url',
+      priority: MiqQueue::HIGH_PRIORITY,
+      role: 'ems_operations',
+      zone: my_zone,
+      args: []
+    }
+
+    # Add the task to the queue and return the identifier:
+    MiqTask.generic_action_with_callback(task_options, queue_options)
+  end
+
+  #
+  # This method is executed in the provider worker. It contacts the calculates oVirt URL using the
+  # credentials of the provider.
+  #
+  # @return [String] The oVirt URL.
+  #
+  def generate_ui_url
+    # Get the reference to the EMS:
+    ems = ext_management_system
+
+    # Calculate the target URL:
+    endpoint = ems.default_endpoint
+    target = URI::HTTPS.build(
+      host: endpoint.hostname,
+      port: endpoint.port,
+      path: '/ovirt-engine/webadmin/',
+    ).to_s
+
+    # Get the credentials of the provider:
+    user = ems.authentication_userid(:default)
+    password = ems.authentication_password(:default)
+
+    # Split the authentication user into user name and profile, assuming that the profile is the
+    # text after the last at sign:
+    at = user.rindex('@')
+    profile = ''
+    unless at.nil?
+      profile = user[(at + 1)..-1]
+      user = user[0..at - 1]
+    end
+
+    # Create the HTTP client:
+    insecure = endpoint.verify_ssl == OpenSSL::SSL::VERIFY_NONE,
+    ca_certs = endpoint.certificate_authority
+    ca_certs = nil if ca_certs.blank?
+    ca_certs = [ca_certs] if ca_certs
+    client = OvirtSDK4::HttpClient.new(
+      insecure: insecure,
+      ca_certs: ca_certs,
+      cookies: true,
+      log: $rhevm_log
+    )
+
+    # Send the initial request, and follow the potentially multiple redirects that the server and the
+    # SSO service will ask us to do:
+    url = target
+    request = nil
+    response = nil
+    loop do
+      request = OvirtSDK4::HttpRequest.new
+      request.method = :GET
+      request.url = url
+      client.send(request)
+      response = client.wait(request)
+      break if response.code != 302
+      url = response.headers['location']
+    end
+
+    # When we finally land in the HTML page that contains the authentication form, we need to parse the
+    # HTML page and extract the action:
+    page = Nokogiri::HTML(response.body)
+    action = page.xpath('//form/@action').first
+
+    # Post the form with the credentials:
+    url = URI(url)
+    url.path = action
+    url = url.to_s
+    request = OvirtSDK4::HttpRequest.new
+    request.method = :POST
+    request.url = url
+    request.headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    }
+    request.body = URI.encode_www_form(
+      username: user,
+      password: password,
+      profile: profile
+    )
+    client.send(request)
+    response = client.wait(request)
+
+    # We need now to follow the potentially multiple redirects that the SSO service will ask to do, till
+    # we are redirected to the URL that we originally requested. When that happens we know that the
+    # previous URL had all the information to automatically log-in to the application.
+    previous = nil
+    loop do
+      previous = url
+      url = response.headers['location']
+      break if url == target
+      request = OvirtSDK4::HttpRequest.new
+      request.method = :GET
+      request.url = url
+      client.send(request)
+      response = client.wait(request)
+    end
+
+    # Close the HTTP client:
+    client.close
+
+    # Return the URL:
+    previous
   end
 end

--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "ovirt", "~>0.18.0"
   s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
-  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.1.9"
+  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.2.0.alpha4"
+  s.add_runtime_dependency "nokogiri", "~>1.8"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This patch adds a `generate_ui_url` method to the virtual machine class
that generates the complete URL needed to access the oVirt UI using the
credentials of the provider.