### PR TITLE
Move detecting the api versions to database query

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/supported_apis_mixin.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/supported_apis_mixin.rb
@@ -1,0 +1,62 @@
+module ManageIQ::Providers::Redhat::InfraManager::SupportedApisMixin
+  def supported_api_versions
+    return supported_api_versions_from_sdk(probe_args) if api_version.blank?
+    supported_api_versions_from_db
+  end
+
+  def highest_supported_api_version
+    supported_api_versions.sort.last || '3'
+  end
+
+  def highest_allowed_api_version
+    return '3' unless use_ovirt_sdk?
+    highest_supported_api_version
+  end
+
+  # This method is a result of api_version in the db not actually being the api_version
+  # it is actually the product version based on which we infer the api version.
+  # In the future I hope there will be a separate field created.
+  def supported_api_versions_from_db
+    key = product_version_to_api_version_regexps.keys.detect { |k| api_version =~ Regexp.new(k.to_s, Regexp::EXTENDED) }
+    product_version_to_api_version_regexps[key] || []
+  end
+
+  def product_version_to_api_version_regexps
+    return @parsed_regex_settings if @parsed_regex_settings
+    @parsed_regex_settings = {}
+    version_regex_settings = Settings::ems::ems_redhat.product_version_to_api_version_regexps
+    version_regex_settings.keys.each do |k|
+      @parsed_regex_settings[k] = version_regex_settings[k].to_s.split(' ').collect(&:to_s)
+    end
+    @parsed_regex_settings
+  end
+
+  def supports_the_api_version?(version)
+    if supported_api_versions.empty?
+      raise MiqException::MiqUnreachableError, "Not able to connect to the server."
+    end
+    supported_api_versions.map(&:to_s).include?(version.to_s)
+  end
+
+  def supported_api_versions_from_sdk(args)
+    probe_args = { :host => args[:hostname], :port => args[:port], :username => args[:username], :password => args[:password], :insecure => true }
+    probe_results = OvirtSDK4::Probe.probe(probe_args)
+    probe_results&.map(&:version)
+  rescue => error
+    # Note that errors when trying to find the supported API versions are perfectly normal, in particular authorization
+    # errors are expected, as in many situations, for example during discovery, the user name and the password aren't
+    # yet known. In these situations we *must* return an empty array, to indicate to the caller that it wasn't possible
+    # to determine the supported API versions.
+    _log.info("Can't determine the API versions supported by the server: #{error}")
+    []
+  end
+
+  def probe_args
+    {
+      :username => authentication_userid(:basic),
+      :password => authentication_password(:basic),
+      :hostname => hostname,
+      :port     => port
+    }
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,9 @@
 ---
 :ems:
   :ems_redhat:
+    :product_version_to_api_version_regexps:
+      :'^3\..*$': 3
+      :'^4\..*$': 3 4
     :use_ovirt_engine_sdk: true
     :resolve_ip_addresses: true
     :inventory:

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -191,16 +191,64 @@ describe ManageIQ::Providers::Redhat::InfraManager do
 
   context "api versions" do
     require 'ovirtsdk4'
+
     let(:ems) { FactoryGirl.create(:ems_redhat_with_authentication) }
-    subject(:supported_api_versions) { ems.supported_api_versions }
-    context "#supported_api_versions" do
-      before(:each) do
-        Rails.cache.delete(ems.cache_key)
-        Rails.cache.write(ems.cache_key, cached_api_versions)
+    context 'when parsing database api_version' do
+      let(:ems) { FactoryGirl.create(:ems_redhat, :api_version => api_version) }
+      subject(:supported_api_versions) { ems.supported_api_versions }
+      context "version 4.2" do
+        let(:api_version) { "4.2.0" }
+        it 'returns versions 3 and 4' do
+          expect(supported_api_versions).to match_array(%w(3 4))
+        end
       end
 
-      context "when no cached supported_api_versions" do
-        let(:cached_api_versions) { nil }
+      context "version 3.6.1" do
+        let(:api_version) { "3.6.1" }
+        it 'returns versions 3' do
+          expect(supported_api_versions).to match_array(%w(3))
+        end
+      end
+
+      context "version 4.2.0-0.0.master.20170917124606.gita804ef7.el7.centos" do
+        let(:api_version) { "4.2.0-0.0.master.20170917124606.gita804ef7.el7.centos" }
+        it 'returns versions 3 and 4' do
+          expect(supported_api_versions).to match_array(%w(3 4))
+        end
+      end
+
+      context "version 4.2.1.3" do
+        let(:api_version) { "4.2.1.3" }
+        it 'returns versions 3 and 4' do
+          expect(supported_api_versions).to match_array(%w(3 4))
+        end
+      end
+
+      context "version 4.2.1a" do
+        let(:api_version) { "4.2.1a" }
+        it 'returns versions 3 and 4' do
+          expect(supported_api_versions).to match_array(%w(3 4))
+        end
+      end
+
+      context "version 4.3" do
+        let(:api_version) { "4.3" }
+        it 'returns versions 3 and 4' do
+          expect(supported_api_versions).to match_array(%w(3 4))
+        end
+      end
+
+      context "version 5.5" do
+        let(:api_version) { "5.5" }
+        it 'returns empty array' do
+          expect(supported_api_versions).to match_array([])
+        end
+      end
+    end
+
+    context 'when probing provider directly' do
+      subject(:supported_api_versions) { ems.supported_api_versions }
+      context "#supported_api_versions" do
         it 'calls the OvirtSDK4::Probe.probe' do
           expect(OvirtSDK4::Probe).to receive(:probe).and_return([])
           supported_api_versions
@@ -211,57 +259,6 @@ describe ManageIQ::Providers::Redhat::InfraManager do
             .and_return([OvirtSDK4::ProbeResult.new(:version => '3'),
                          OvirtSDK4::ProbeResult.new(:version => '4')])
           expect(supported_api_versions).to match_array(%w(3 4))
-        end
-      end
-
-      context "when cache of supported_api_versions is stale" do
-        let(:cached_api_versions) do
-          {
-            :created_at => Time.now.utc,
-            :value      => [3]
-          }
-        end
-
-        before(:each) do
-          allow(ems).to receive(:last_refresh_date)
-            .and_return(cached_api_versions[:created_at] + 1.day)
-        end
-
-        it 'calls the OvirtSDK4::Probe.probe' do
-          expect(OvirtSDK4::Probe).to receive(:probe).and_return([])
-          supported_api_versions
-        end
-      end
-
-      context "when cache of supported_api_versions available" do
-        let(:cached_api_versions) do
-          {
-            :created_at => Time.now.utc,
-            :value      => [3]
-          }
-        end
-
-        before(:each) do
-          allow(ems).to receive(:last_refresh_date)
-            .and_return(cached_api_versions[:created_at] - 1.day)
-        end
-
-        it 'returns from cache' do
-          expect(supported_api_versions).to match_array([3])
-        end
-
-        context "when the stored value is empty" do
-          let(:cached_api_versions) do
-            {
-              :created_at => Time.now.utc,
-              :value      => []
-            }
-          end
-
-          it "fetches new values by calling the probe" do
-            expect(OvirtSDK4::Probe).to receive(:probe).and_return([])
-            supported_api_versions
-          end
         end
       end
     end


### PR DESCRIPTION
The probing for api versions was done by connecting to the provider directly
which causes problems when done from a UI applience which has no access to the
provider.

We now use the "api_version" (which actually contains the product version)
to infer the api version supported. When the feild is not available we try probing.