### PR TITLE
v2v: Extend 'VM Transform' dialog to select VMs by tag

### DIFF
--- a/content/service_dialogs/transform-vm.yml
+++ b/content/service_dialogs/transform-vm.yml
@@ -19,7 +19,7 @@
       position: 0
       dialog_fields:
       - name: tag_category
-        description: Tag category.
+        description: Tag category
         data_type: string
         notes:
         notes_display:
@@ -57,7 +57,7 @@
           ae_message:
           ae_attributes: {}
       - name: tag_name
-        description: Tag name.
+        description: Tag name
         data_type: string
         notes:
         notes_display:

--- a/content/service_dialogs/transform-vm.yml
+++ b/content/service_dialogs/transform-vm.yml
@@ -18,6 +18,82 @@
       display_method_options:
       position: 0
       dialog_fields:
+      - name: tag_category
+        description: Tag category.
+        data_type: string
+        notes:
+        notes_display:
+        display: edit
+        display_method:
+        display_method_options: {}
+        required: false
+        required_method:
+        required_method_options: {}
+        default_value: ''
+        values: []
+        values_method:
+        values_method_options: {}
+        options:
+          :sort_by: :value
+        label: Tag Category
+        position: 0
+        validator_type:
+        validator_rule:
+        reconfigurable:
+        dynamic: true
+        show_refresh_button:
+        load_values_on_init:
+        read_only:
+        auto_refresh:
+        trigger_auto_refresh: true
+        visible: true
+        type: DialogFieldDropDownList
+        resource_action:
+          action:
+          resource_type: DialogField
+          ae_namespace: Infrastructure/VM/Transform
+          ae_class: Import
+          ae_instance: list_tag_categories
+          ae_message:
+          ae_attributes: {}
+      - name: tag_name
+        description: Tag name.
+        data_type: string
+        notes:
+        notes_display:
+        display: edit
+        display_method:
+        display_method_options: {}
+        required: false
+        required_method:
+        required_method_options: {}
+        default_value: ''
+        values: []
+        values_method:
+        values_method_options: {}
+        options:
+          :sort_by: :value
+        label: Tag Name
+        position: 1
+        validator_type:
+        validator_rule:
+        reconfigurable:
+        dynamic: true
+        show_refresh_button:
+        load_values_on_init:
+        read_only:
+        auto_refresh: true
+        trigger_auto_refresh: false
+        visible: true
+        type: DialogFieldDropDownList
+        resource_action:
+          action:
+          resource_type: DialogField
+          ae_namespace: Infrastructure/VM/Transform
+          ae_class: Import
+          ae_instance: list_tag_names
+          ae_message:
+          ae_attributes: {}
       - name: name
         description: Name of the newly created virtual machine
         data_type:
@@ -26,7 +102,7 @@
         display: edit
         display_method:
         display_method_options: {}
-        required: true
+        required: false
         required_method:
         required_method_options: {}
         default_value: ''
@@ -36,11 +112,11 @@
         options:
           :protected: false
         label: Name
-        position: 0
+        position: 2
         validator_type:
         validator_rule:
         reconfigurable:
-        dynamic: false
+        dynamic: true
         show_refresh_button:
         load_values_on_init:
         read_only:
@@ -51,9 +127,9 @@
         resource_action:
           action:
           resource_type: DialogField
-          ae_namespace:
-          ae_class:
-          ae_instance:
+          ae_namespace: Infrastructure/VM/Transform
+          ae_class: Import
+          ae_instance: show_name
           ae_message:
           ae_attributes: {}
       - name: provider
@@ -75,7 +151,7 @@
         options:
           :sort_by: :value
         label: Provider
-        position: 1
+        position: 3
         validator_type:
         validator_rule:
         reconfigurable:
@@ -113,7 +189,7 @@
         options:
           :sort_by: :value
         label: Cluster
-        position: 2
+        position: 4
         validator_type:
         validator_rule:
         reconfigurable: false
@@ -151,7 +227,7 @@
         options:
           :sort_by: :value
         label: Storage
-        position: 3
+        position: 5
         validator_type:
         validator_rule:
         reconfigurable:
@@ -188,7 +264,7 @@
         values_method_options: {}
         options: {}
         label: Thin provisioning
-        position: 4
+        position: 6
         validator_type:
         validator_rule:
         reconfigurable:
@@ -225,7 +301,7 @@
         values_method_options: {}
         options: {}
         label: Install Windows Drivers
-        position: 5
+        position: 7
         validator_type:
         validator_rule:
         reconfigurable:
@@ -264,7 +340,7 @@
           :force_multi_value: false
           :sort_by: :description
         label: Drivers
-        position: 6
+        position: 8
         validator_type:
         validator_rule:
         reconfigurable:


### PR DESCRIPTION
Added tag category and tag name fields to the 'VM Transform' dialog to
be able to select VMs for V2V by tag. Hide these fields if the dialog is
open from VM details view. Hide VM name input field if the dialog is
open from VM list view.

Depends on https://github.com/ManageIQ/manageiq-content/pull/200
Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/2501

![Menu item](https://user-images.githubusercontent.com/1369041/31956974-ca84fd52-b8f5-11e7-83a9-2badbb2ab280.png)

![Dialog](https://user-images.githubusercontent.com/1369041/31957198-aa952836-b8f6-11e7-9df0-306be17727c4.png)
