### PR TITLE
ID's shouldn't be in the service dialog YML

### DIFF
--- a/content/service_dialogs/transform-vm.yml
+++ b/content/service_dialogs/transform-vm.yml
@@ -2,7 +2,6 @@
 - description: Transform VM
   buttons: submit,cancel
   label: Transform VM
-  blueprint_id:
   dialog_tabs:
   - description:
     display: edit


### PR DESCRIPTION
This column was recently removed, but this shouldn't have been here anyway

$ rake db:seed
** ManageIQ master; Database: adapter=postgresql, name=vmdb_development, host=
** Using session_store: ActionDispatch::Session::MemCacheStore
rake aborted!
ActiveModel::UnknownAttributeError: unknown attribute 'blueprint_id' for Dialog.
/home/bdunne/.gem/ruby/2.3.3/gems/activemodel-5.0.6/lib/active_model/attribute_assignment.rb:48:in `_assign_attribute'
/home/bdunne/.gem/ruby/2.3.3/gems/activemodel-5.0.6/lib/active_model/attribute_assignment.rb:40:in `block in _assign_attributes'
/home/bdunne/.gem/ruby/2.3.3/gems/activemodel-5.0.6/lib/active_model/attribute_assignment.rb:39:in `each'
/home/bdunne/.gem/ruby/2.3.3/gems/activemodel-5.0.6/lib/active_model/attribute_assignment.rb:39:in `_assign_attributes'
/home/bdunne/.gem/ruby/2.3.3/gems/activerecord-5.0.6/lib/active_record/attribute_assignment.rb:26:in `_assign_attributes'
/home/bdunne/.gem/ruby/2.3.3/gems/activemodel-5.0.6/lib/active_model/attribute_assignment.rb:33:in `assign_attributes'
/home/bdunne/.gem/ruby/2.3.3/gems/activerecord-5.0.6/lib/active_record/persistence.rb:274:in `block in update'
/home/bdunne/.gem/ruby/2.3.3/gems/activerecord-5.0.6/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
/home/bdunne/.gem/ruby/2.3.3/gems/activerecord-5.0.6/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
/home/bdunne/.gem/ruby/2.3.3/gems/activerecord-5.0.6/lib/active_record/transactions.rb:211:in `transaction'
/home/bdunne/.gem/ruby/2.3.3/gems/activerecord-5.0.6/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
/home/bdunne/.gem/ruby/2.3.3/gems/activerecord-5.0.6/lib/active_record/persistence.rb:273:in `update'
/home/bdunne/projects/redhat/manageiq/lib/services/dialog_import_service.rb:123:in `block in import_from_dialogs'
/home/bdunne/projects/redhat/manageiq/lib/services/dialog_import_service.rb:119:in `each'
/home/bdunne/projects/redhat/manageiq/lib/services/dialog_import_service.rb:119:in `import_from_dialogs'
/home/bdunne/projects/redhat/manageiq/lib/services/dialog_import_service.rb:38:in `import_all_service_dialogs_from_yaml_file'
/home/bdunne/projects/redhat/manageiq/app/models/dialog.rb:27:in `block (2 levels) in seed'
/home/bdunne/projects/redhat/manageiq/app/models/dialog.rb:25:in `each'
/home/bdunne/projects/redhat/manageiq/app/models/dialog.rb:25:in `block in seed'
/home/bdunne/projects/redhat/manageiq/app/models/dialog.rb:24:in `each'
/home/bdunne/projects/redhat/manageiq/app/models/dialog.rb:24:in `seed'
/home/bdunne/projects/redhat/manageiq/lib/evm_database.rb:80:in `block (2 levels) in seed'
/home/bdunne/projects/redhat/manageiq/lib/evm_database.rb:69:in `each'
/home/bdunne/projects/redhat/manageiq/lib/evm_database.rb:69:in `block in seed'