### PR TITLE
Honour `open_timeout` when using V4

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -251,8 +251,8 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     def raw_connect_v4(options = {})
       require 'ovirtsdk4'
 
-      # Get the timeout from the configuration:
-      timeout, = ems_timeouts(:ems_redhat, options[:service])
+      # Get the timeouts from the configuration:
+      read_timeout, open_timeout = ems_timeouts(:ems_redhat, options[:service])
 
       # The constructor of the SDK expects a list of certificates, but that list can't be empty, or contain only 'nil'
       # values, so we need to check the value passed and make a list only if it won't be empty. If it will be empty then
@@ -270,15 +270,16 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
 
       ManageIQ::Providers::Redhat::ConnectionManager.instance.get(
         options[:id],
-        :url      => url.to_s,
-        :username => options[:username],
-        :password => options[:password],
-        :timeout  => timeout,
-        :insecure => options[:verify_ssl] == OpenSSL::SSL::VERIFY_NONE,
-        :ca_certs => ca_certs,
-        :log      => $rhevm_log,
-        :connections => options[:connections] || ::Settings.ems.ems_redhat.connections,
-        :pipeline    => options[:pipeline] || ::Settings.ems.ems_redhat.pipeline
+        :url             => url.to_s,
+        :username        => options[:username],
+        :password        => options[:password],
+        :timeout         => read_timeout,
+        :connect_timeout => open_timeout,
+        :insecure        => options[:verify_ssl] == OpenSSL::SSL::VERIFY_NONE,
+        :ca_certs        => ca_certs,
+        :log             => $rhevm_log,
+        :connections     => options[:connections] || ::Settings.ems.ems_redhat.connections,
+        :pipeline        => options[:pipeline] || ::Settings.ems.ems_redhat.pipeline
       )
     end
 

--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "ovirt", "~>0.18.0"
   s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
-  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.1.9"
+  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.1.10"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The provider has two configuration settings that control timeouts:

  read_timeout - Max time to wait for a response.
  open_timeout - Max time to wait for a connection.

Both parameters are honoured when using version 3 of the API, but only
the first one is honoured when using version 4 of the API. The result is
that trying to connect to a wrong IP address doesn't fail after
`open_timeout`, but after the default used by the SDK for this, which is
300 seconds (that is the default used by the underlying library).

To avoid that this patch changes the provider so that it uses the
version of the SDK that supports the new `connect_timeout` parameter
(version 4.1.10) and so that it copies the `open_timeout` configuration
setting into the `connect_timeout` parameter of the SDK.

This patch addresses the following bug:

  Add RHV provider using a bad hostname do not fail the validation in UI.
  https://bugzilla.redhat.com/1448065