### PR TITLE
Don't close connection explicitly

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -190,8 +190,6 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     connection = connect(:version => 4)
     service = connection.system_service.vms_service.vm_service(vm.uid_ems)
     yield service
-  ensure
-    connection.close
   end
 
   def use_ovirt_sdk?

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
@@ -75,28 +75,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
   end
 
   def with_snapshots_service(vm_uid_ems)
-    closeable_service = closeable_snapshots_service(ext_management_system, vm_uid_ems)
-    yield closeable_service
-  ensure
-    closeable_service.close if closeable_service
-  end
-
-  def closeable_snapshots_service(ems, vm_uid_ems, options = {})
-    version = options[:version] || 4
-    connection = ems.connect(:version => version)
+    connection = ext_management_system.connect(:version => 4)
     service = connection.system_service.vms_service.vm_service(vm_uid_ems).snapshots_service
-    CloseableService.new(service) { connection.close }
-  end
-
-  class CloseableService < SimpleDelegator
-    attr_reader :closing_block
-    def initialize(service, &closing_block)
-      @closing_block = closing_block
-      super service
-    end
-
-    def close
-      closing_block.call
-    end
+    yield service
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/operations/snapshot_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/operations/snapshot_spec.rb
@@ -4,11 +4,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot do
     let!(:snapshot) { double("snapshot", :id => 1, :uid_ems => 'ems_id_111') }
     before(:each) do
       @snapshot_service = double('snapshot_service')
-      @closeable_snapshots_service = double('snapshots_service')
-      allow(@closeable_snapshots_service).to receive(:close).and_return(nil)
-      allow(@closeable_snapshots_service).to receive(:snapshot_service)
+      @snapshots_service = double('snapshots_service')
+      allow(@snapshots_service).to receive(:snapshot_service)
         .with(snapshot.uid_ems) { @snapshot_service }
-      allow(vm).to receive(:closeable_snapshots_service).with(any_args).and_return(@closeable_snapshots_service)
+      allow(vm).to receive(:with_snapshots_service).with(any_args).and_yield(@snapshots_service)
       allow(vm).to receive(:snapshots).and_return(double(:find_by => snapshot))
     end
 
@@ -23,7 +22,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot do
     end
 
     it 'calls revert on the snapshot service' do
-      expect(@closeable_snapshots_service).to receive(:add)
+      expect(@snapshots_service).to receive(:add)
         .with(:description => "snap_desc", :persist_memorystate => true)
       vm.raw_create_snapshot(nil, "snap_desc", true)
     end


### PR DESCRIPTION
The management of the connectios to the oVirt server is the exclusive
reponsibility of the `ConnectionManager` class. Nothing else should
create or close connections, otherwise callers may end up receiving
closed connections.

This patch changes two places in the provider that are explicitly
closing connections.