### PR TITLE
Handle partial vm entity during creation

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector/target_collection.rb
@@ -172,9 +172,13 @@ class ManageIQ::Providers::Redhat::Inventory::Collector::TargetCollection < Mana
     changed_vms = manager.vms.where(:ems_ref => references(:vms))
 
     changed_vms.each do |vm|
-      add_simple_target!(:ems_clusters, vm.ems_cluster.ems_ref)
+      unless vm.ems_cluster.nil?
+        # when we target new vm
+        add_simple_target!(:ems_clusters, vm.ems_cluster.ems_ref)
+        add_simple_target!(:datacenters, vm.parent_datacenter.ems_ref)
+      end
+
       vm.storages.collect(&:ems_ref).compact.each { |ems_ref| add_simple_target!(:storagedomains, ems_ref) } unless vm.storages.nil?
-      add_simple_target!(:datacenters, vm.parent_datacenter.ems_ref)
       add_simple_target!(:templates, vm.ems_ref)
     end
   end


### PR DESCRIPTION
When a vm is newly created there are only few attributes so graph targeted refresh
need to handle this use case.

Bug-Url:
https://bugzilla.redhat.com/1508465