### PR TITLE
Fix vm removal for apiv4

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -464,6 +464,10 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
                  }
         ))
       end
+
+      def destroy
+        remove
+      end
     end
 
     class TemplateProxyDecorator < SimpleDelegator


### PR DESCRIPTION
It seems like vm removal never worked for apiv4.

Bug-Url:
https://bugzilla.redhat.com/1509020