### PR TITLE
Try both API versions in `raw_connect`

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
@@ -9,7 +9,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventParser do
       @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
       @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
       allow(@ems).to receive(:supported_api_versions).and_return([3])
-      allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
+      stub_settings_merge(
+        :ems => {
+          :ems_redhat => {
+            :resolve_ip_addresses => false
+          }
+        }
+      )
     end
 
     it "should parse event" do
@@ -153,7 +159,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventParser do
       @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
       @ems.default_endpoint.path = "/ovirt-engine/api"
       allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
-      allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
+      stub_settings_merge(
+        :ems => {
+          :ems_redhat => {
+            :resolve_ip_addresses => false
+          }
+        }
+      )
     end
 
     require 'yaml'

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
@@ -110,7 +110,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       context "with a destination vm" do
         let(:destination_vm) { FactoryGirl.create(:vm_redhat, :ext_management_system => @ems) }
         before do
-          allow(@ems).to receive(:resolve_ip_address).with(@ems.hostname).and_return("1.2.3.4")
+          stub_settings_merge(
+            :ems => {
+              :ems_redhat => {
+                :resolve_ip_addresses => false
+              }
+            }
+          )
           rhevm_vm = double(:attributes => {:status => {:state => "down"}})
           allow(@vm_prov).to receive(:with_provider_destination).and_yield(rhevm_vm)
           allow(@vm_prov).to receive(:destination).and_return(destination_vm)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
@@ -7,7 +7,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems.update_authentication(:default => {:userid => "evm@manageiq.com", :password => "password"})
     allow(@ems).to receive(:supported_api_versions).and_return([3])
     allow(@ems).to receive(:highest_allowed_api_version).and_return('3')
-    allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
+    stub_settings_merge(
+      :ems => {
+        :ems_redhat => {
+          :resolve_ip_addresses => false
+        }
+      }
+    )
   end
 
   it ".ems_type" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_host_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_host_4_spec.rb
@@ -13,8 +13,14 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
     @ems.default_endpoint.path = "/ovirt-engine/api"
     allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
-    allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
-    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
+    stub_settings_merge(
+      :ems => {
+        :ems_redhat => {
+          :use_ovirt_engine_sdk => true,
+          :resolve_ip_addresses => false
+        }
+      }
+    )
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).and_call_original
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).with(kind_of(Hash)) do |opts|
       Spec::Support::OvirtSDK::ConnectionVCR.new(opts, 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_target_host.yml')

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
@@ -46,8 +46,14 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
                                     :name    => "Default")
 
       allow(@ems).to receive(:supported_api_versions).and_return([3])
-      allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
-      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => false } })
+      stub_settings_merge(
+        :ems => {
+          :ems_redhat => {
+            :use_ovirt_engine_sdk => false,
+            :resolve_ip_addresses => false
+          }
+        }
+      )
     end
 
     it "should refresh a vm" do
@@ -120,7 +126,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
                                 :hostname => ip_address, :ipaddress => ip_address, :port => 443)
       @ems.update_authentication(:default => {:userid => "admin@internal", :password => "password"})
       allow(@ems).to receive(:supported_api_versions).and_return(['3'])
-      allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
+      stub_settings_merge(
+        :ems => {
+          :ems_redhat => {
+            :resolve_ip_addresses => false
+          }
+        }
+      )
     end
 
     it 'should save the vms new host' do

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -167,8 +167,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
       ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
       # TODO: (inventory) resvisit this test and write one for V4
       allow(ems).to receive(:supported_api_versions).and_return([3])
-      allow(ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
-
+      stub_settings_merge(
+        :ems => {
+          :ems_redhat => {
+            :resolve_ip_addresses => false
+          }
+        }
+      )
       @storage = FactoryGirl.create(:storage, :ems_ref => "/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0")
       disk = FactoryGirl.create(:disk, :storage => @storage, :filename => "da123bb9-095a-4933-95f2-8032dfa332e1")
       hardware = FactoryGirl.create(:hardware, :disks => [disk])


### PR DESCRIPTION
Currently the `raw_connect` method needs to receive the version of the
API in order to work correctly. If it doesn't receive it it fails
because the method that determines it just doesn't exist (it is an
instance method, but `raw_connect` is a class method). To avoid that
this patch changes the `raw_connect` method so that it tries with both
versions of the API.

This patch fixes partially the following bug:

  Failed validation when adding RHV provider
  https://bugzilla.redhat.com/1509432