### PR TITLE
Add admin_ui feature support to InfraManager

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -14,6 +14,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   require_nested  :Vm
   include_concern :ApiIntegration
   include_concern :VmImport
+  include_concern :AdminUI
 
   has_many :cloud_tenants, :foreign_key => :ems_id, :dependent => :destroy
 
@@ -21,6 +22,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
 
   supports :provisioning
   supports :refresh_new_target
+  supports :admin_ui
 
   def ensure_managers
     return unless enabled

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -22,7 +22,11 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
 
   supports :provisioning
   supports :refresh_new_target
-  supports :admin_ui
+
+  def supports_admin_ui?
+    # Link to oVirt Admin UI is supported for Engine version >= 4.2
+    version_higher_than?('4.2')
+  end
 
   def ensure_managers
     return unless enabled

--- a/app/models/manageiq/providers/redhat/infra_manager/admin_ui.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/admin_ui.rb
@@ -1,0 +1,101 @@
+module ManageIQ::Providers::Redhat::InfraManager::AdminUI
+  extend ActiveSupport::Concern
+
+  require 'openssl'
+  require 'ovirtsdk4'
+  require 'uri'
+  require 'json'
+
+  def queue_generate_admin_ui_url
+    task_opts = {
+      :action => 'Generate oVirt Admin UI URL for EMS'
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :instance_id => id,
+      :method_name => 'generate_admin_ui_url',
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def generate_admin_ui_url
+    $rhevm_log.info("Generating oVirt Admin UI URL for EMS with identifier '#{id}'.")
+
+    # Get the credentials of the provider:
+    user = authentication_userid(:default)
+    password = authentication_password(:default)
+
+    # Get the timeouts from the configuration:
+    read_timeout, open_timeout = ems_timeouts(:ems_redhat, options[:service])
+
+    # Create the HTTP client:
+    insecure = default_endpoint.verify_ssl == OpenSSL::SSL::VERIFY_NONE,
+    ca_certs = default_endpoint.certificate_authority
+    ca_certs = nil if ca_certs.blank?
+    ca_certs = [ca_certs] if ca_certs
+    client = OvirtSDK4::HttpClient.new(
+      :insecure        => insecure,
+      :ca_certs        => ca_certs,
+      :log             => $rhevm_log,
+      :timeout         => read_timeout,
+      :connect_timeout => open_timeout
+    )
+
+    # Request new SSO token using the provider credentials:
+    request = OvirtSDK4::HttpRequest.new
+    request.method = :GET
+    request.url = URI::HTTPS.build(
+      :host  => default_endpoint.hostname,
+      :port  => default_endpoint.port,
+      :path  => '/ovirt-engine/sso/oauth/token',
+      :query => URI.encode_www_form(
+        :grant_type => 'password',
+        :username   => user,
+        :password   => password,
+        :scope      => 'ovirt-app-admin ovirt-app-portal'
+      )
+    ).to_s
+    request.headers = {
+      'Accept'     => 'application/json',
+      'User-Agent' => "manageiq-providers-ovirt/#{ManageIQ::Providers::Ovirt::VERSION}"
+    }
+    client.send(request)
+    response = client.wait(request)
+
+    # Close the HTTP client:
+    client.close
+
+    # Extract the SSO token, return nil in case of error:
+    if response.is_a?(OvirtSDK4::Error) || response.code != 200
+      $rhevm_log.warn("Failed to obtain SSO token from oVirt Engine.")
+      $rhevm_log.warn(response.message) unless response.is_a?(OvirtSDK4::Error)
+      return nil
+    end
+    sso_token = JSON.parse(response.body)['access_token']
+
+    # Generate URL to access oVirt Admin UI using the SSO token:
+    app_url = URI::HTTPS.build(
+      :host => default_endpoint.hostname,
+      :port => default_endpoint.port,
+      :path => '/ovirt-engine/webadmin'
+    ).to_s
+    access_url = URI::HTTPS.build(
+      :host  => default_endpoint.hostname,
+      :port  => default_endpoint.port,
+      :path  => '/ovirt-engine/webadmin/sso/login',
+      :query => URI.encode_www_form(
+        :sso_token => sso_token,
+        :app_url   => app_url
+      )
+    ).to_s
+
+    # Return the URL:
+    access_url
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/admin_ui.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/admin_ui.rb
@@ -32,7 +32,7 @@ module ManageIQ::Providers::Redhat::InfraManager::AdminUI
     password = authentication_password(:default)
 
     # Get the timeouts from the configuration:
-    read_timeout, open_timeout = ems_timeouts(:ems_redhat, options[:service])
+    read_timeout, open_timeout = self.class.ems_timeouts(:ems_redhat, "Service")
 
     # Create the HTTP client:
     insecure = default_endpoint.verify_ssl == OpenSSL::SSL::VERIFY_NONE,
@@ -73,9 +73,9 @@ module ManageIQ::Providers::Redhat::InfraManager::AdminUI
     client.close
 
     # Extract the SSO token, return nil in case of error:
-    if response.is_a?(OvirtSDK4::Error) || response.code != 200
+    if response.kind_of?(OvirtSDK4::Error) || response.code != 200
       $rhevm_log.warn("Failed to obtain SSO token from oVirt Engine.")
-      $rhevm_log.warn(response.message) unless response.is_a?(OvirtSDK4::Error)
+      $rhevm_log.warn(response.message) if response.kind_of?(OvirtSDK4::Error)
       return nil
     end
     sso_token = JSON.parse(response.body)['access_token']

--- a/app/models/manageiq/providers/redhat/infra_manager/admin_ui.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/admin_ui.rb
@@ -49,22 +49,23 @@ module ManageIQ::Providers::Redhat::InfraManager::AdminUI
 
     # Request new SSO token using the provider credentials:
     request = OvirtSDK4::HttpRequest.new
-    request.method = :GET
+    request.method = :POST
     request.url = URI::HTTPS.build(
-      :host  => default_endpoint.hostname,
-      :port  => default_endpoint.port,
-      :path  => '/ovirt-engine/sso/oauth/token',
-      :query => URI.encode_www_form(
-        :grant_type => 'password',
-        :username   => user,
-        :password   => password,
-        :scope      => 'ovirt-app-admin ovirt-app-portal'
-      )
+      :host => default_endpoint.hostname,
+      :port => default_endpoint.port,
+      :path => '/ovirt-engine/sso/oauth/token'
     ).to_s
     request.headers = {
-      'Accept'     => 'application/json',
-      'User-Agent' => "manageiq-providers-ovirt/#{ManageIQ::Providers::Ovirt::VERSION}"
+      'Accept'       => 'application/json',
+      'Content-Type' => 'application/x-www-form-urlencoded',
+      'User-Agent'   => "manageiq-providers-ovirt/#{ManageIQ::Providers::Ovirt::VERSION}"
     }
+    request.body = URI.encode_www_form(
+      :grant_type => 'password',
+      :username   => user,
+      :password   => password,
+      :scope      => 'ovirt-app-admin ovirt-app-portal'
+    )
     client.send(request)
     response = client.wait(request)
 


### PR DESCRIPTION
This PR is part of the following series:
- [Add ems_infra_admin_ui feature](https://github.com/ManageIQ/manageiq/pull/16403) (manageiq)
- [Add ems_infra_admin_ui feature support](https://github.com/ManageIQ/manageiq-ui-classic/pull/2644) (manageiq-ui-classic)
- **[Add admin_ui feature support to InfraManager](https://github.com/ManageIQ/manageiq-providers-ovirt/pull/133) (manageiq-providers-ovirt)**

Utilize `admin_ui` feature in `InfraManager`, using `AdminUI` concern to contain the URL generation logic.

URL to access oVirt WebAdmin is generated in two steps:
1. obtain new SSO token from oVirt Engine, using the credentials of the provider
2. construct URL to access WebAdmin, using the SSO token obtained in the previous step

This PR currently relies on Ravi's [Engine patch](https://gerrit.ovirt.org/#/c/82997/) that simplifies WebAdmin access URL construction.

Inspired by @jhernand (see original PR [here](https://github.com/ManageIQ/manageiq-providers-ovirt/pull/112)).