### PR TITLE
Set default tag category in 'Transform VM' dialog

### DIFF
--- a/content/service_dialogs/transform-vm.yml
+++ b/content/service_dialogs/transform-vm.yml
@@ -28,7 +28,7 @@
         required: false
         required_method:
         required_method_options: {}
-        default_value: ''
+        default_value: 'migration_group'
         values: []
         values_method:
         values_method_options: {}


### PR DESCRIPTION
Set tag category in 'Transform VM' dialog to 'Migration Groups' by
default.

Depends-on: https://github.com/ManageIQ/manageiq/pull/16402