### PR TITLE
Fix credential validation if no metrics given

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -327,7 +327,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       database = opts[:metrics_database] || default_history_database_name
 
       # Metrics are optional, so we should only check the details if the server has been specified:
-      return true unless server
+      return true if server.blank?
 
       # Decrypt the password:
       password = MiqPassword.try_decrypt(password)


### PR DESCRIPTION
If no metrics credentials are given the metrics_server is "" not nil.
This was causing it to continue past the `return true unless server`
line and fail later on.

This checks if the metrics_server is `.blank?` which will catch nil as
well as "".

Introduced by https://github.com/ManageIQ/manageiq-providers-ovirt/pull/134