### PR TITLE
Rename version_higher_than to version_at_least

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -206,7 +206,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     vms.map(&:ems_cluster).uniq.compact.size == 1
   end
 
-  def version_higher_than?(version)
+  def version_at_least?(version)
     return false if api_version.nil?
 
     ems_version = api_version[/\d+\.\d+\.?\d*/x]

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -141,7 +141,7 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
       return _("Memory Limit is supported only when using ovirt-engine-sdk (To enable, set: ':use_ovirt_engine_sdk: true' in settings.yml).")
     end
 
-    unless ems.version_higher_than?("4.1")
+    unless ems.version_at_least?("4.1")
       return _("Memory Limit is supported for RHV 4.1 and above. Current provider version is #{ems.api_version}.")
     end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
@@ -60,7 +60,7 @@ module ManageIQ::Providers::Redhat::InfraManager::VmImport
 
   def validate_import_vm
     # The version of the RHV needs to be at least 4.1.5 due to https://bugzilla.redhat.com/1477375
-    version_higher_than?('4.1.5')
+    version_at_least?('4.1.5')
   end
 
   def submit_configure_imported_vm_networks(userid, vm_id)

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -322,47 +322,47 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     end
   end
 
-  context "#version_higher_than?" do
+  context "#version_at_least?" do
     let(:api_version) { "4.2" }
     let(:ems) { FactoryGirl.create(:ems_redhat, :api_version => api_version) }
 
     context "api version is higher or equal than checked version" do
       it 'supports the right features' do
-        expect(ems.version_higher_than?("4.1")).to be_truthy
+        expect(ems.version_at_least?("4.1")).to be_truthy
 
         ems.api_version = "4.1.3.2-0.1.el7"
-        expect(ems.version_higher_than?("4.1")).to be_truthy
+        expect(ems.version_at_least?("4.1")).to be_truthy
 
         ems.api_version = "4.2.0_master"
-        expect(ems.version_higher_than?("4.1")).to be_truthy
+        expect(ems.version_at_least?("4.1")).to be_truthy
 
         ems.api_version = "4.2.1_master"
-        expect(ems.version_higher_than?("4.2.0")).to be_truthy
+        expect(ems.version_at_least?("4.2.0")).to be_truthy
       end
     end
 
     context "api version is lowergit  than checked version" do
       let(:api_version) { "4.0" }
       it 'supports the right features' do
-        expect(ems.version_higher_than?("4.1")).to be_falsey
+        expect(ems.version_at_least?("4.1")).to be_falsey
 
         ems.api_version = "4.0.3.2-0.1.el7"
-        expect(ems.version_higher_than?("4.1")).to be_falsey
+        expect(ems.version_at_least?("4.1")).to be_falsey
 
         ems.api_version = "4.0.0_master"
-        expect(ems.version_higher_than?("4.1")).to be_falsey
+        expect(ems.version_at_least?("4.1")).to be_falsey
 
         ems.api_version = "4.0.1_master"
-        expect(ems.version_higher_than?("4.0.2")).to be_falsey
+        expect(ems.version_at_least?("4.0.2")).to be_falsey
       end
     end
 
     context "api version not set" do
       let(:api_version) { nil }
       it 'always return false' do
-        expect(ems.version_higher_than?("10.1")).to be_falsey
+        expect(ems.version_at_least?("10.1")).to be_falsey
 
-        expect(ems.version_higher_than?("0")).to be_falsey
+        expect(ems.version_at_least?("0")).to be_falsey
       end
     end
   end


### PR DESCRIPTION
`ManageIQ::Providers::Redhat::InfraManager#version_higher_than` method performs >= comparison, this PR renames it to `version_at_least`.