### PR TITLE
Use version 4.1.13 of the oVirt Ruby SDK

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "ovirt", "~>0.18.0"
   s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
-  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.1.10"
+  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.1.13"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The more relevant changes in this version of the oVirt Ruby SDK are the
following:

* Virtual machine remove fails due to spelling mistake
  https://bugzilla.redhat.com/1509020[#1509020].

* Improve error message for empty response body
  https://bugzilla.redhat.com/1509020[#1509020].

* Don't send `Expect: 100-continue`
  https://bugzilla.redhat.com/1509910[#1509910].

* Don't include sensible data in the result of `inspect` and `to_s`
  https://bugzilla.redhat.com/1513620[#1513620].

This change addresses the following issue:

  Evm.log contains passwords
  https://bugzilla.redhat.com/1512977