### PR TITLE
Save host 'maintenance' value

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -138,6 +138,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
         :vmm_buildnumber  => (host_os_version[:build] if host_os_version),
         :connection_state => connection_state,
         :power_state      => power_state,
+        :maintenance      => power_state == 'maintenance',
 
         :operating_system => host_inv_to_os_hash(host_inv, hostname),
 

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
@@ -68,6 +68,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
           :vmm_buildnumber  => (host_os_version.build if host_os_version),
           :connection_state => connection_state,
           :power_state      => power_state,
+          :maintenance      => power_state == 'maintenance',
           :operating_system => host_inv_to_os_hash(host_inv, hostname),
           :ems_cluster      => cluster_uids[host_inv.dig(:cluster, :id)],
           :hardware         => hardware,

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -151,6 +151,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :vmm_buildnumber  => (host_os_version.build if host_os_version),
         :connection_state => connection_state,
         :power_state      => power_state,
+        :maintenance      => power_state == 'maintenance',
         :ems_cluster      => persister.ems_clusters.lazy_find(ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(cluster.href)),
         :ipmi_address     => ipmi_address,
       )

--- a/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
@@ -328,7 +328,8 @@ class ManageIQ::Providers::Redhat::InventoryCollectionDefault::InfraManager < Ma
           :connection_state,
           :power_state,
           :ems_cluster,
-          :ipmi_address
+          :ipmi_address,
+          :maintenance
         ]
       }
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
@@ -185,6 +185,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :vmm_product      => "rhel",
       :vmm_buildnumber  => nil,
       :power_state      => "on",
+      :maintenance      => false,
       :connection_state => "connected"
     )
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -193,6 +193,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :vmm_product      => "rhel",
         :vmm_buildnumber  => nil,
         :power_state      => "on",
+        :maintenance      => false,
         :connection_state => "connected"
       )
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -192,6 +192,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :vmm_product      => "rhel",
         :vmm_buildnumber  => nil,
         :power_state      => "on",
+        :maintenance      => false,
         :connection_state => "connected"
       )
 


### PR DESCRIPTION
The host 'maintenance' attribute was added to provision vm dialog
by https://github.com/ManageIQ/manageiq/pull/16464 and tracked by https://github.com/ManageIQ/manageiq-providers-ovirt/issues/141

RHV should store this information which is already available during host
refresh.

https://bugzilla.redhat.com/show_bug.cgi?id=1513413
