### PR TITLE
Profiles

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -117,6 +117,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       end
 
       vlans['<Empty>'] = _('<No Profile>')
+      vlans['<Template>'] = _('<Use template nics>')
     end
 
     def filter_allowed_hosts(_workflow, all_hosts)

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/network.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/network.rb
@@ -35,7 +35,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Netw
 
   def configure_dialog_nic
     vlan = get_option(:vlan)
-    return if vlan.blank?
+    return if vlan.blank? || vlan == '<Template>'
     options[:networks] ||= []
     options[:networks][0] ||= begin
       _log.info("vlan: #{vlan.inspect}")

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
@@ -233,21 +233,21 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
         allow(vnic_profiles_service).to receive(:list).and_return([])
 
         workflow.load_allowed_vlans(ems, @vlans)
-        expect(@vlans).to eq("<Empty>" => "<No Profile>")
+        expect(@vlans).to eq("<Empty>" => "<No Profile>", "<Template>" => "<Use template nics>")
       end
       it "contains one profile" do
         allow(networks_service).to receive(:list).and_return([network])
         allow(vnic_profiles_service).to receive(:list).and_return([network_profile])
 
         workflow.load_allowed_vlans(ems, @vlans)
-        expect(@vlans).to eq("network_profile-id" => "network_profile (network)", "<Empty>" => "<No Profile>")
+        expect(@vlans).to eq("network_profile-id" => "network_profile (network)", "<Empty>" => "<No Profile>", "<Template>" => "<Use template nics>")
       end
       it "contains two profiles on the same network" do
         allow(networks_service).to receive(:list).and_return([network])
         allow(vnic_profiles_service).to receive(:list).and_return([network_profile, network_profile2])
 
         workflow.load_allowed_vlans(ems, @vlans)
-        expect(@vlans).to eq("network_profile-id" => "network_profile (network)", "network_profile-id2" => "network_profile2 (network)", "<Empty>" => "<No Profile>")
+        expect(@vlans).to eq("network_profile-id" => "network_profile (network)", "network_profile-id2" => "network_profile2 (network)", "<Empty>" => "<No Profile>", "<Template>" => "<Use template nics>")
       end
     end
   end


### PR DESCRIPTION
Set 'Use template nics' as the default vnic profile option

depends on ManageIQ/manageiq#16504