### PR TITLE
Fix version check in supports_admin_ui method

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -28,9 +28,9 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def supports_admin_ui?
-    # Link to oVirt Admin UI is supported for Engine version >= 4.1.8
+    # Link to oVirt Admin UI is supported for Engine version 4.1.8 or better.
     # See https://bugzilla.redhat.com/1512989 for details.
-    version_higher_than?('4.1.8')
+    version_at_least?('4.1.8')
   end
 
   def ensure_managers


### PR DESCRIPTION
`version_higher_than` was renamed to `version_at_least` via [another PR](https://github.com/ManageIQ/manageiq-providers-ovirt/pull/143) and I forgot to sync with code that implements the `admin_ui` feature 😞