### PR TITLE
Reload provider when api_version available

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/supported_apis_mixin.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/supported_apis_mixin.rb
@@ -1,7 +1,12 @@
 module ManageIQ::Providers::Redhat::InfraManager::SupportedApisMixin
   def supported_api_versions
+    reload_if_api_version_available_in_db if api_version.blank?
     return supported_api_versions_from_sdk(probe_args) if api_version.blank?
     supported_api_versions_from_db
+  end
+
+  def reload_if_api_version_available_in_db
+    reload if ExtManagementSystem.where(:id => id).select(:api_version).take&.api_version
   end
 
   def highest_supported_api_version


### PR DESCRIPTION
Before, when an instance of the ext_management_system was memoized before api_version is set would probe the provider again and again to get list of available versions.

Now it checks if api_version is available in db and reloads it if so.
This fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1512490