### PR TITLE
Update ems version during graph refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
@@ -15,6 +15,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
         # TODO: make sure not to use with api v3
         if refresher_options.try(:[], :inventory_object_refresh)
           data = ManageIQ::Providers::Redhat::Builder.build_inventory(ems, target)
+
+          # TODO: remove when graph refresh supports ems updates
+          ems.api_version = inventory.service.version_string
+          ems.save
         else
           case target
           when Host

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -79,11 +79,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   end
 
   def assert_ems
-    # TODO: We can't use graph refresh in production until this is fixed.
-    # expect(@ems).to have_attributes(
-    # :api_version => "4.2.0_master.",
-    # :uid_ems     => nil
-    # )
+    expect(@ems).to have_attributes(
+      :api_version => "4.2.0_master.",
+      :uid_ems     => nil
+    )
 
     expect(@ems.ems_folders.size).to eq(7)
     expect(@ems.ems_clusters.size).to eq(3)


### PR DESCRIPTION
At the moment it is not possible to update ems during graph refresh
so we need to introduce this hack to enable version based functionality.

Bug-Url:
https://bugzilla.redhat.com/1517865