### PR TITLE
Implement template targeted refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
@@ -24,7 +24,11 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
           when Host
             data,  = Benchmark.realtime_block(:fetch_host_data) { host_targeted_refresh(inventory, target) }
           when VmOrTemplate
-            data,  = Benchmark.realtime_block(:fetch_vm_data) { vm_targeted_refresh(inventory, target) }
+            if target.template
+              data,  = Benchmark.realtime_block(:fetch_template_data) { template_targeted_refresh(inventory, target) }
+            else
+              data,  = Benchmark.realtime_block(:fetch_vm_data) { vm_targeted_refresh(inventory, target) }
+            end
           else
             data,  = Benchmark.realtime_block(:fetch_all) { inventory.refresh }
           end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
@@ -39,5 +39,22 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
       }
       inventory.targeted_refresh(methods)
     end
+
+    def template_targeted_refresh(inventory, target)
+      require 'uri'
+
+      methods = {
+        :primary   => {
+          :cluster    => {:clusters => "cluster"},
+          :datacenter => {:datacenters => "data_center"},
+          :template   => target.ems_ref,
+          :storage    => target.storages.empty? ? {:storagedomains => "storage_domain"} : target.storages.map(&:ems_ref)
+        },
+        :secondary => {
+          :template => [:disks]
+        }
+      }
+      inventory.targeted_refresh(methods)
+    end
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api4.rb
@@ -14,6 +14,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
       inventory.vm_targeted_refresh(target)
     end
 
+    def template_targeted_refresh(inventory, target)
+      inventory.template_targeted_refresh(target)
+    end
+
     require 'uri'
 
     def inventory_from_ovirt(ems)


### PR DESCRIPTION
Since we can create template from MIQ side on RHV, templates should be
fully refreshed once the creation is completed.
In addition, when a template is being created on RHV side, not all of
its fields are being updated.
Therefore, there is a need to support also template target refresh
(unrelated to graph refresh in this context).

Fixes bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1517852