### PR TITLE
Fix Seal option of publish VM

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -479,7 +479,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
                                             :description => options[:description],
                                             :cluster     => cluster,
                                             :storage     => storage)
-        templates_service.add(template)
+        templates_service.add(template, :seal => options[:seal])
       end
 
       def build_template_from_hash(args)

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Cloning
       :name        => dest_name,
       :cluster     => dest_cluster.ems_ref,
       :description => get_option(:vm_description),
-      :seal        => get_option(:seal)
+      :seal        => get_option(:seal_template)
     }
 
     clone_options[:storage] = dest_datastore.ems_ref unless dest_datastore.nil?

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -152,7 +152,7 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
   end
 
   def validate_seal_template(_field, values, _dlg, _fld, _value)
-    seal = get_value(values[:seal])
+    seal = get_value(values[:seal_template])
     return nil unless seal
 
     if get_source_vm.platform == 'windows'


### PR DESCRIPTION
Due to latest rename of property name in publish vm yaml file from :seal
to :seal_template, sealing option wasn't processed properly.

In addition, the property should be send as part of the request header,
therefore should be specified in the second parameter of the
`templates_service.add(template, :seal => options[:seal])` method.

https://bugzilla.redhat.com/show_bug.cgi?id=1514895