### PR TITLE
Added supported_catalog_types

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -144,6 +144,10 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     end
   end
 
+  def supported_catalog_types
+    %w(redhat)
+  end
+
   def vm_reconfigure(vm, options = {})
     ovirt_services_for_reconfigure = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Builder.new(self)
       .build(:use_highest_supported_version => true).new(:ems => self)

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -460,4 +460,12 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       end
     end
   end
+
+  context 'catalog types' do
+    let(:ems) { FactoryGirl.create(:ems_redhat) }
+
+    it "#supported_catalog_types" do
+      expect(ems.supported_catalog_types).to eq(%w(redhat))
+    end
+  end
 end


### PR DESCRIPTION
Each service catalog now requires the provider to provide a list of supported catalog types.

This is part of PR https://github.com/ManageIQ/manageiq/pull/16559