### PR TITLE
Fix location of `pipeline` and `connections` settings

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -400,8 +400,8 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
         :insecure        => options[:verify_ssl] == OpenSSL::SSL::VERIFY_NONE,
         :ca_certs        => ca_certs,
         :log             => $rhevm_log,
-        :connections     => options[:connections] || ::Settings.ems.ems_redhat.connections,
-        :pipeline        => options[:pipeline] || ::Settings.ems.ems_redhat.pipeline
+        :connections     => options[:connections] || ::Settings.ems_refresh.rhevm.connections,
+        :pipeline        => options[:pipeline] || ::Settings.ems_refresh.rhevm.pipeline
       )
     end
 


### PR DESCRIPTION
The `pipeline` and `connections` settings are in the following path:

```
  :ems_refresh:
    :rhevm:
      :pipeline: 40
      :connections: 10
```

But the part of the code that creates the SDK connection gets them from
a different place. As a result the parameters arent really applied, and
the number of connections is unlimited. When combined with the settings
used by the asynchronous refresh code, this results in the creation of
hundreds of connections. When there are more than 256 connections open
the oVirt server will start rejecting them, and the refresh fails.

This patch fixes the location of the parameters in the code that creates
the SDK connection.

Fixes https://bugzilla.redhat.com/1513528
