### PR TITLE
Update to version 4.2.1 of the oVirt Ruby SDK

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "ovirt", "~>0.18.0"
   s.add_runtime_dependency "parallel", "~>1.9" # For ManageIQ::Providers::Ovirt::Legacy::Inventory
-  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.2.0"
+  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.2.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The more relevant changes in this new version of the SDK are the
following:

* Fix handling of the `all_content` parameter
  https://bugzilla.redhat.com/1525555[#1525555].

* Limit the number of requests sent to `libcurl`
  https://bugzilla.redhat.com/1525302[#1525302].

Fixes https://bugzilla.redhat.com/1513528