### PR TITLE
Block migration call

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -196,7 +196,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     end
   end
 
-  def vm_migrate(vm, options = {})
+  def vm_migrate(vm, options = {}, timeout = 30, limit = 100)
     host_id = URI(options[:host]).path.split('/').last
 
     migration_options = {
@@ -205,9 +205,25 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
       }
     }
 
+    started_time = Time.zone.now
     with_version4_vm_service(vm) do |service|
       service.migrate(migration_options)
     end
+
+    finished_event = nil
+    times = 0
+    while finished_event.nil?
+      times += 1
+      sleep timeout
+      finished_event = vm.ems_events.where(:event_type => %w[VM_MIGRATION_FAILED_FROM_TO VM_MIGRATION_DONE])
+                         .find_by(EventStream.arel_table[:timestamp].gt(started_time))
+      if times == limit
+        _log.error("Migration event no received failing the request")
+        raise ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error
+      end
+    end
+
+    raise ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error if finished_event.event_type == "VM_MIGRATION_FAILED_FROM_TO"
   end
 
   def unsupported_migration_options

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -468,4 +468,33 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       expect(ems.supported_catalog_types).to eq(%w(redhat))
     end
   end
+
+  context 'vm_migration' do
+    before do
+      @ems = FactoryGirl.create(:ems_redhat)
+      @vm = FactoryGirl.create(:vm_redhat, :ext_management_system => @ems)
+
+      service = double
+      allow(service).to receive(:migrate).with(:host => {:id => "11089411-53a2-4337-8613-7c1d411e8ae8"})
+      allow(@ems).to receive(:with_version4_vm_service).and_return(service)
+    end
+
+    it "succeeds migration" do
+      ems_event = FactoryGirl.create(:ems_event, :event_type => "VM_MIGRATION_DONE", :message => "migration done", :ext_management_system => @ems, :vm => @vm, :timestamp => Time.zone.now + 1)
+      @vm.ems_events << ems_event
+
+      expect { @ems.vm_migrate(@vm, {:host => "/ovirt-engine/api/hosts/11089411-53a2-4337-8613-7c1d411e8ae8"}, 1) }.to_not raise_error
+    end
+
+    it "fails migration" do
+      ems_event = FactoryGirl.create(:ems_event, :event_type => "VM_MIGRATION_FAILED_FROM_TO", :message => "migration failed", :ext_management_system => @ems, :vm => @vm, :timestamp => Time.zone.now + 1)
+      @vm.ems_events << ems_event
+
+      expect { @ems.vm_migrate(@vm, {:host => "/ovirt-engine/api/hosts/11089411-53a2-4337-8613-7c1d411e8ae8"}, 1) }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error)
+    end
+
+    it "never receives an event" do
+      expect { @ems.vm_migrate(@vm, {:host => "/ovirt-engine/api/hosts/11089411-53a2-4337-8613-7c1d411e8ae8"}, 1, 2) }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error)
+    end
+  end
 end


### PR DESCRIPTION
We need to align migration call semantic with vmware. We want to block
the call and return with success or raise an error.

Fixes https://bugzilla.redhat.com/1448023