### PR TITLE
Fix ConnectionVcr recording

### DIFF
--- a/spec/support/ovirt_sdk/connection_vcr.rb
+++ b/spec/support/ovirt_sdk/connection_vcr.rb
@@ -17,8 +17,10 @@ module Spec::Support::OvirtSDK
     def wait(request)
       req_key = "#{request.url}#{request.query}#{request.method}#{request.body}"
       @all_req_hash[req_key] ||= []
-      res = @all_req_hash[req_key].shift
-      return http_response_hash_to_obj(res) if res
+      unless @is_recording
+        res = @all_req_hash[req_key].shift
+        return http_response_hash_to_obj(res) if res
+      end
       res = super(request)
       @all_req_hash[req_key] << http_response_to_hash(res)
       File.write(path_to_recording, @all_req_hash.to_yaml)


### PR DESCRIPTION
The ConnectionVCR did not save multiple results for the same request,
it saved only the result of the last one which did not allow to record
several refreshes.

This fixes the bug so now several refreshes can be recorder and played
back.