### PR TITLE
Fix wrong call to 'orchestrate_destroy' with no parameters

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
         populate_network_manager_connectivity(auth_url)
       end
     elsif network_manager
-      network_manager.orchestrate_destroy
+      network_manager.destroy_queue
     end
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -459,6 +459,22 @@ describe ManageIQ::Providers::Redhat::InfraManager do
         expect(@ems.network_manager.security_protocol).to eq("ssl")
       end
     end
+
+    it "removes network manager" do
+      allow(@ems).to receive(:ovirt_services).and_return(double(:collect_external_network_providers => {}))
+      allow(Zone).to receive_messages(:determine_queue_zone => "defaultzone")
+      expect(ExtManagementSystem.count).to eq(2)
+      @ems.ensure_managers
+      deliver_queue_messages
+      expect(ExtManagementSystem.count).to eq(1)
+    end
+
+    def deliver_queue_messages
+      MiqQueue.order(:id).each do |queue_message|
+        status, message, result = queue_message.deliver
+        queue_message.delivered(status, message, result)
+      end
+    end
   end
 
   context 'catalog types' do


### PR DESCRIPTION
 Fix wrong call to 'orchestrate_destroy' with no parameters

'orchestrate_destroy' was changed recently to take parameters, the change
caused the removal of network provider flow to get an exception.

