### PR TITLE
Force smart state analysis to use V3

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -78,8 +78,10 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     @rhevm_service ||= connect(:service => "Service")
   end
 
-  def rhevm_inventory
-    @rhevm_inventory ||= connect(:service => "Inventory")
+  def rhevm_inventory(opts = {})
+    connect_options = { :service => "Inventory" }
+    connect_options[:version] = 3 if opts[:force_v3]
+    @rhevm_inventory ||= connect(connect_options)
   end
 
   def ovirt_services(args = {})

--- a/app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared/scanning.rb
@@ -151,7 +151,7 @@ module ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared::Scanning
     $log.info "#{log_header}: Connecting to [#{ems_display_text}] for VM:[#{@vm_cfg_file}]"
 
     begin
-      ost.miqRhevm = ext_management_system.rhevm_inventory
+      ost.miqRhevm = ext_management_system.rhevm_inventory(:force_v3 => true)
       $log.info "Connection to [#{ems_display_text}] completed for VM:[#{@vm_cfg_file}] in [#{Time.now - st}] seconds"
     rescue Timeout::Error => err
       msg = "#{log_header}: Connection to [#{ems_display_text}] timed out for VM:[#{@vm_cfg_file}] with error [#{err}] after [#{Time.now - st}] seconds"


### PR DESCRIPTION
Currently the SSA tries to use v4 when working with providers that support
v4.
The code in ssa was not changed to work with v4 which causes a bug.
A future PR will allow it to work with v4 but currently we will force it
to work with v3.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1534502