### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -243,4 +243,8 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     ems_version = api_version[/\d+\.\d+\.?\d*/x]
     Gem::Version.new(ems_version) >= Gem::Version.new(version)
   end
+
+  def self.display_name(number = 1)
+    n_('Infrastructure Provider (Red Hat)', 'Infrastructure Providers (Red Hat)', number)
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/host.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/host.rb
@@ -54,4 +54,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Host < ::Host
   def exit_maint_mode
     ext_management_system.ovirt_services.host_activate(self)
   end
+
+  def self.display_name(number = 1)
+    n_('Host (Redhat)', 'Hosts (Redhat)', number)
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -102,4 +102,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
   def self.calculate_power_state(raw_power_state)
     POWER_STATES[raw_power_state] || super
   end
+
+  def self.display_name(number = 1)
+    n_('Virtual Machine (Red Hat)', 'Virtual Machines (Red Hat)', number)
+  end
 end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836