### PR TITLE
Move refresh settings for the Network Manager

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager/refresher.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresher.rb
@@ -6,7 +6,7 @@ module ManageIQ::Providers
 
         _log.info("Filtering inventory for #{target.class} [#{target_name}] id: [#{target.id}]...")
 
-        if ::Settings.ems.ems_ovirt.ems_network.try(:refresh).try(:inventory_object_refresh)
+        if ::Settings.ems_refresh.redhat_network.try(:inventory_object_refresh)
           inventory = ManageIQ::Providers::Redhat::Builder.build_inventory(ems, target)
         end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,9 +14,6 @@
       :open_timeout: 1.minute
     :blacklisted_event_names: []
   :ems_ovirt:
-    :ems_network:
-      :refresh:
-        :inventory_object_refresh: true
     :event_handling:
       :event_groups:
         :console:
@@ -61,6 +58,9 @@
     :inventory_object_refresh: false
     :pipeline: 40
     :connections: 10
+  :redhat_network:
+    :is_admin: false
+    :inventory_object_refresh: true
 :log:
   :level_rhevm: info
 :workers:


### PR DESCRIPTION
This PR puts the refresh settings for the Network Manager in the correct
spot.
Necessary to support -
https://github.com/ManageIQ/manageiq/pull/16182