### PR TITLE
Fix adding vm_location to vm event hash

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/event_parsing/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_parsing/strategies/v4.rb
@@ -37,8 +37,10 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParsing::Strategies
 
       uid_ems = ManageIQ::Providers::Redhat::InfraManager.extract_ems_ref_id(vm_ref)
       location = "#{uid_ems}.ovf"
-      return location if dc.blank?
-
+      if dc.blank?
+        hash[:vm_location] = location
+        return hash
+      end
       dc_ref = ems_ref_from_object_in_event(dc)
       dc_uid = ManageIQ::Providers::Redhat::InfraManager.extract_ems_ref_id(dc_ref)
 


### PR DESCRIPTION
We were not adding vm_location correctly to the event hash when
the dc in the event was blank.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1537139