### PR TITLE
Fix updating catalog item when provider missing

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -137,6 +137,7 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
     return nil if limited.nil? || limited.zero?
 
     ems = source_ems
+    return nil if ems.blank?
     unless ems.use_ovirt_sdk?
       return _("Memory Limit is supported only when using ovirt-engine-sdk (To enable, set: ':use_ovirt_engine_sdk: true' in settings.yml).")
     end


### PR DESCRIPTION
When the provider is removed updating the catalog item would fail
because we validate if provider supports setting memory limits.

We now by default decide we do not support it if the provider is was
removed. A more elaborate fix will be discussed on the core
level.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1540592