### PR TITLE
Use correct refresh for older providers

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -18,6 +18,11 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     @supported_features ||= supported_api_versions.collect { |version| self.class.api_features[version.to_s] }.flatten.uniq
   end
 
+  def use_graph_refresh?
+    Settings.ems_refresh.rhevm.try(:[], :inventory_object_refresh) &&
+      use_ovirt_sdk? && supported_api_versions.include?('4')
+  end
+
   def connect(options = {})
     raise "no credentials defined" if missing_credentials?(options[:auth_type])
     version = options[:version] || highest_allowed_api_version

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
@@ -20,6 +20,24 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(described_class.ems_type).to eq(:rhevm)
   end
 
+  it 'works correctly even if graph refresh is turned on' do
+    stub_settings_merge(:ems_refresh => { :rhevm => {:inventory_object_refresh => true }})
+    VCR.use_cassette("#{described_class.name.underscore}_3_1") do
+      EmsRefresh.refresh(@ems)
+    end
+    @ems.reload
+
+    assert_table_counts
+    assert_ems
+    assert_specific_cluster
+    assert_specific_storage
+    assert_specific_host
+    assert_specific_vm_powered_on
+    assert_specific_vm_powered_off
+    assert_specific_template
+    assert_relationship_tree
+  end
+
   it "will perform a full refresh on v3.1" do
     VCR.use_cassette("#{described_class.name.underscore}_3_1") do
       EmsRefresh.refresh(@ems)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_host_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_host_4_spec.rb
@@ -12,7 +12,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       .to receive(:collect_external_network_providers).and_return(load_response_mock_for('external_network_providers'))
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
     @ems.default_endpoint.path = "/ovirt-engine/api"
-    allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
+    allow(@ems).to receive(:supported_api_versions).and_return(%w(3 4))
     stub_settings_merge(
       :ems => {
         :ems_redhat => {

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       .to receive(:collect_external_network_providers).and_return(load_response_mock_for('external_network_providers'))
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
     @ems.default_endpoint.path = "/ovirt-engine/api"
-    allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
+    allow(@ems).to receive(:supported_api_versions).and_return(%w(3 4))
     allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
     stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end


### PR DESCRIPTION
When refresh is set to use graph strategy we should still use old
refresh in case the provider does not support version 4 of the api.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1540475