### PR TITLE
Add missing probe test

### DIFF
--- a/app/models/manageiq/providers/redhat/discovery.rb
+++ b/app/models/manageiq/providers/redhat/discovery.rb
@@ -6,10 +6,10 @@ module ManageIQ
     module Redhat
       class Discovery
         def self.probe(ost)
-          Ovirt.logger = $rhevm_log if $rhevm_log
+          ::Ovirt.logger = $rhevm_log if $rhevm_log
 
-          if ManageIQ::NetworkDiscovery::Port.open?(ost, Ovirt::Service::DEFAULT_PORT) &&
-             Ovirt::Service.ovirt?(:server => ost.ipaddr, :verify_ssl => false)
+          if ManageIQ::NetworkDiscovery::Port.open?(ost, ::Ovirt::Service::DEFAULT_PORT) &&
+             ::Ovirt::Service.ovirt?(:server => ost.ipaddr, :verify_ssl => false)
             ost.hypervisor << :rhevm
           end
         end

--- a/spec/models/manageiq/providers/redhat/discovery_spec.rb
+++ b/spec/models/manageiq/providers/redhat/discovery_spec.rb
@@ -1,0 +1,10 @@
+describe ManageIQ::Providers::Redhat::Discovery do
+  it ".probe" do
+    require 'ostruct'
+    allow(ManageIQ::NetworkDiscovery::Port).to receive(:open?).and_return(true)
+    allow(::Ovirt::Service).to receive(:ovirt?).and_return(true)
+    ost = OpenStruct.new(:ipaddr => "172.168.0.1", :hypervisor => [])
+    described_class.probe(ost)
+    expect(ost.hypervisor).to eq [:rhevm]
+  end
+end


### PR DESCRIPTION
Note, Ovirt namespace exists in the client gem and also in the
ManageIQ::Providers namespace so we need to clarify which Ovirt we want,
namely, the ovirt gem's one.

We had a regression and tests didn't detect it:
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/208
https://github.com/ManageIQ/manageiq/pull/16994