### PR TITLE
Fix graph targeted host refresh spec

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_host_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_host_4_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   before(:each) do
     stub_settings_merge(:ems_refresh => { :rhevm => {:inventory_object_refresh => true }})
     _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.1.107", :ipaddress => "192.168.1.107",
+    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
                               :port => 8443)
     @ovirt_service = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
     allow_any_instance_of(@ovirt_service)


### PR DESCRIPTION
The targeted spec would take a very long time because the requests
actually failed.