### PR TITLE
Make graph refresh enabled by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,7 +55,7 @@
     :user:
 :ems_refresh:
   :rhevm:
-    :inventory_object_refresh: false
+    :inventory_object_refresh: true
     :pipeline: 40
     :connections: 10
   :redhat_network:

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresh_after_publish_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresh_after_publish_vm_spec.rb
@@ -10,6 +10,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
     allow(@ems).to(receive(:supported_api_versions).and_return(%w(3 4)))
     stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
+    stub_settings_merge(:ems_refresh => { :rhevm => {:inventory_object_refresh => false }})
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).and_call_original
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).with(kind_of(Hash)) do |opts|
       Spec::Support::OvirtSDK::ConnectionVCR.new(opts,

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -11,6 +11,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
     @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
     allow(@ems).to(receive(:supported_api_versions).and_return(%w(3 4)))
+    stub_settings_merge(:ems_refresh => { :rhevm => {:inventory_object_refresh => false }})
     stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).and_call_original
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).with(kind_of(Hash)) do |opts|

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
@@ -85,6 +85,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   end
 
   it "should refresh a vm" do
+    stub_settings_merge(:ems_refresh => { :rhevm => {:inventory_object_refresh => false }})
     allow_any_instance_of(@inventory_wrapper_class)
       .to receive(:collect_clusters).and_return(load_response_mock_for('clusters'))
     allow_any_instance_of(@inventory_wrapper_class)


### PR DESCRIPTION
Graph refresh is now used for both full and targeted refresh.