### PR TITLE
Raise error during test if response is missing

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector/target_collection.rb
@@ -80,20 +80,15 @@ class ManageIQ::Providers::Redhat::Inventory::Collector::TargetCollection < Mana
   end
 
   def hosts
-    h = []
-    return h if references(:hosts).blank?
-
-    manager.with_provider_connection(VERSION_HASH) do |connection|
-      references(:hosts).each do |ems_ref|
+    @hosts ||= manager.with_provider_connection(VERSION_HASH) do |connection|
+      references(:hosts).map do |ems_ref|
         begin
-          h << connection.system_service.hosts_service.host_service(uuid_from_ems_ref(ems_ref)).get
+          connection.system_service.hosts_service.host_service(uuid_from_ems_ref(ems_ref)).get
         rescue OvirtSDK4::Error # when 404
           nil
         end
-      end
+      end.compact
     end
-
-    h
   end
 
   def vms

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_host_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_host_4_spec.rb
@@ -36,7 +36,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       .and_return(OpenStruct.new(:version_string => '4.2.0_master.')))
 
     @cluster = FactoryGirl.create(:ems_cluster,
-                                  :ems_ref               => "/ovirt-engine/api/clusters/11acc1a0-66c7-4aba-a00f-fa2648c9b51f",
+                                  :ems_ref               => "/ovirt-engine/api/clusters/59c8cd2d-01d6-0367-037e-0000000002f7",
                                   :uid_ems               => "11acc1a0-66c7-4aba-a00f-fa2648c9b51f",
                                   :ext_management_system => @ems,
                                   :name                  => "Default")


### PR DESCRIPTION
The connection_vcr will now raise an error if it is not in recording
mode and a response is missing.

This will make tests fail faster, on a clearer error and not rewrite a
recording in cases when it has a request missing.