### PR TITLE
Support Unregister VM

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -505,6 +505,10 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       def destroy
         remove
       end
+
+      def unregister
+        remove(:detach_only => true)
+      end
     end
 
     class TemplateProxyDecorator < SimpleDelegator

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations.rb
@@ -8,4 +8,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations
   def raw_destroy
     with_provider_object(&:destroy)
   end
+
+  def raw_unregister
+    with_provider_object(&:unregister)
+  end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -199,4 +199,24 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
       end
     end
   end
+
+  describe "#unregister" do
+    before do
+      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      @ems  = FactoryGirl.create(:ems_redhat_with_authentication, :zone => zone)
+      @vm   = FactoryGirl.create(:vm_redhat, :ext_management_system => @ems)
+      @vm_proxy = double("OvirtSDK4::Vm.new")
+      @vm_service = double("OvirtSDK4::Vm")
+    end
+
+    context "v4" do
+      it "unregisters a vm via v4 api" do
+        allow(@ems).to receive(:highest_supported_api_version).and_return(4)
+        allow(@vm).to receive(:with_provider_object).and_yield(@vm_service)
+        allow(@vm_service).to receive(:unregister).and_return(nil)
+
+        @vm.raw_unregister
+      end
+    end
+  end
 end


### PR DESCRIPTION
Unregister VM allows the user to remove the VM without deleting its
disks.
For that purpose, the request to remove VM to ovirt-engine includes the
'detach_only=true' parameter as specified in the [API](http://ovirt.github.io/ovirt-engine-api-model/master/#services/vm/methods/remove)

This action will succeed if the VM isn't originated from a template, or
if the VM has no snapshots.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536628