### PR TITLE
Properly fetch snapshot current state

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
@@ -260,8 +260,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
       return result if inv.nil?
 
       parent_id = nil
-      inv.each_with_index do |snapshot, idx|
-        result << snapshot_inv_to_snapshot_hashes(snapshot, idx == inv.length - 1, parent_id)
+      inv.each do |snapshot|
+        current = snapshot.snapshot_type == "active"
+        result << snapshot_inv_to_snapshot_hashes(snapshot, current, parent_id)
         parent_id = snapshot.id
       end
       result
@@ -274,7 +275,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
       name = description = inv.description
       name = "Active Image" if name[0, 13] == '_ActiveImage_'
 
-      result = {
+      {
         :uid_ems     => inv.id,
         :uid         => inv.id,
         :parent_uid  => parent_uid,
@@ -283,8 +284,6 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         :create_time => create_time,
         :current     => current,
       }
-
-      result
     end
 
     def vm_inv_to_custom_attribute_hashes(inv)

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -502,7 +502,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
     snapshots = snapshots.sort_by(&:date).reverse
 
     parent_id = nil
-    snapshots.each_with_index do |snapshot, idx|
+    snapshots.each do |snapshot|
       name = description = snapshot.description
       name = "Active Image" if name[0, 13] == '_ActiveImage_'
 
@@ -513,8 +513,8 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :name           => name,
         :description    => description,
         :create_time    => snapshot.date.getutc,
-        :current        => idx == snapshots.length - 1,
-        :vm_or_template => persister_vm
+        :current        => snapshot.snapshot_type == "active",
+        :vm_or_template => persister_vm,
       )
       parent_id = snapshot.id
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -483,19 +483,20 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       expect(v.snapshots.size).to eq(3)
 
       # TODO: Fix this boolean column
-      snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
+      snapshot = v.snapshots.detect { |s| s.name = "Active VM" } # TODO: Fix this boolean column
       expect(snapshot).to have_attributes(
         :uid         => "6e3e547f-9544-42cf-842d-9104828d8511",
         :parent_uid  => "05ff445a-0bfc-44c3-90d1-a338e9095510",
         :uid_ems     => "6e3e547f-9544-42cf-842d-9104828d8511",
         :name        => "Active VM",
         :description => "Active VM",
-        :current     => 1,
+        :current     => 0,
         :total_size  => nil,
         :filename    => nil
       )
       snapshot_parent = ::Snapshot.find_by(:name => "vm1_snap")
       expect(snapshot.parent).to eq(snapshot_parent)
+      expect(snapshot_parent.current).to eq(1)
 
       expect(v.hardware).to have_attributes(
         :guest_os             => "other",

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -447,20 +447,20 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
       expect(v.snapshots.size).to eq(3)
 
-      # TODO: Fix this boolean column
-      snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
+      snapshot = v.snapshots.detect { |s| s.name == "Active VM" } # TODO: Fix this boolean column
       expect(snapshot).to have_attributes(
         :uid         => "6e3e547f-9544-42cf-842d-9104828d8511",
         :parent_uid  => "05ff445a-0bfc-44c3-90d1-a338e9095510",
         :uid_ems     => "6e3e547f-9544-42cf-842d-9104828d8511",
         :name        => "Active VM",
         :description => "Active VM",
-        :current     => 1,
+        :current     => 0,
         :total_size  => nil,
         :filename    => nil
       )
       snapshot_parent = ::Snapshot.find_by(:name => "vm1_snap")
       expect(snapshot.parent).to eq(snapshot_parent)
+      expect(snapshot_parent.current).to eq(1)
 
       expect(v.hardware).to have_attributes(
         :guest_os             => "other",

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
@@ -5223,7 +5223,7 @@ https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f
             <date>2016-07-05T13:14:08.116+03:00</date>
             <persist_memorystate>false</persist_memorystate>
             <snapshot_status>ok</snapshot_status>
-            <snapshot_type>active</snapshot_type>
+            <snapshot_type>regular</snapshot_type>
         </snapshot>
         <snapshot href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510" id="05ff445a-0bfc-44c3-90d1-a338e9095510">
             <actions>
@@ -5236,7 +5236,7 @@ https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f
             <date>2016-12-15T09:51:43.247+02:00</date>
             <persist_memorystate>true</persist_memorystate>
             <snapshot_status>ok</snapshot_status>
-            <snapshot_type>regular</snapshot_type>
+            <snapshot_type>active</snapshot_type>
             <vm id="3a9401a0-bf3d-4496-8acf-edd3e903511f">
                 <name>vm1</name>
                 <bios>


### PR DESCRIPTION
We will now fetch the snapshot current state from the snapshot_type returned
form the oVirt api, the previous calculation we used for this attribute did not
always work.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1552732