### PR TITLE
Fix provider discovery

### DIFF
--- a/app/models/manageiq/providers/redhat/discovery.rb
+++ b/app/models/manageiq/providers/redhat/discovery.rb
@@ -6,10 +6,10 @@ module ManageIQ
     module Redhat
       class Discovery
         def self.probe(ost)
-          Ovirt.logger = $rhevm_log if $rhevm_log
+          ::Ovirt.logger = $rhevm_log if $rhevm_log
 
-          if ManageIQ::NetworkDiscovery::Port.open?(ost, Ovirt::Service::DEFAULT_PORT) &&
-             Ovirt::Service.ovirt?(:server => ost.ipaddr, :verify_ssl => false)
+          if ManageIQ::NetworkDiscovery::Port.open?(ost, ::Ovirt::Service::DEFAULT_PORT) &&
+             ::Ovirt::Service.ovirt?(:server => ost.ipaddr, :verify_ssl => false)
             ost.hypervisor << :rhevm
           end
         end


### PR DESCRIPTION
Due to moving the provider discovery code, "Ovirt" was evaluated to
ManageIQ::Providers::Ovirt.
It should evaluate to the Ovirt Model defined in the ovirt-gem.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1559796