### PR TITLE
Use old refresh as default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,7 +55,7 @@
     :user:
 :ems_refresh:
   :rhevm:
-    :inventory_object_refresh: true
+    :inventory_object_refresh: false
     :pipeline: 40
     :connections: 10
   :redhat_network:


### PR DESCRIPTION
Use the old refresh as default since graph refresh is not optimized for
large environments yet.

This is due to: https://bugzilla.redhat.com/show_bug.cgi?id=1566468