### PR TITLE
vm.hardware.nics[i].lan should return the network attached to the vm

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
@@ -74,6 +74,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
         preloaded_disks = collect_disks_as_hash(res[:disk])
         collect_disks_from_attachments(res[:vm], preloaded_disks)
         collect_disks_from_attachments(res[:template], preloaded_disks)
+        collect_vnic_profiles(res)
         res
       end
     end
@@ -253,6 +254,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
 
     def collect_networks
       connection.system_service.networks_service.list
+    end
+
+    def collect_vnic_profiles(inv)
+      inv[:vnic_profiles] = connection.system_service.vnic_profiles_service.list
     end
 
     def collect_datacenters

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -12,7 +12,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
     result[:hosts], uids[:hosts], uids[:lans], uids[:switches], uids[:guest_devices], uids[:scsi_luns] = host_inv_to_hashes(inv[:host], inv, uids[:clusters], uids[:storages])
     vms_inv = Array(inv[:vm]) + Array(inv[:template])
     result[:vms], uids[:vms], added_hosts_from_vms =
-      vm_inv_to_hashes(vms_inv, inv[:storage], uids[:storages], uids[:clusters], uids[:hosts], uids[:lans])
+      vm_inv_to_hashes(vms_inv, inv[:storage], uids[:storages], uids[:clusters], uids[:hosts], uids[:lans], inv[:vnic_profiles])
     result[:folders] = datacenter_inv_to_hashes(inv[:datacenter], uids[:clusters], uids[:vms], uids[:storages], uids[:hosts])
 
     # Link up the root folder
@@ -371,7 +371,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
     host_os && host_os[:type] || host_inv[:type]
   end
 
-  def self.vm_inv_to_hashes(inv, _storage_inv, storage_uids, cluster_uids, host_uids, lan_uids)
+  def self.vm_inv_to_hashes(inv, _storage_inv, storage_uids, cluster_uids, host_uids, lan_uids, vnic_profiles)
     result = []
     result_uids = {}
     guest_device_uids = {}
@@ -418,7 +418,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
       host_mor = host_id
       hardware = vm_inv_to_hardware_hash(vm_inv)
       hardware[:disks] = vm_inv_to_disk_hashes(vm_inv, storage_uids)
-      hardware[:guest_devices], guest_device_uids[mor] = vm_inv_to_guest_device_hashes(vm_inv, lan_uids[host_mor])
+      hardware[:guest_devices], guest_device_uids[mor] = vm_inv_to_guest_device_hashes(vm_inv, lan_uids[host_mor], vnic_profiles)
       hardware[:networks] = vm_inv_to_network_hashes(vm_inv, guest_device_uids[mor])
 
       ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm_inv[:href])
@@ -490,7 +490,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
     result
   end
 
-  def self.vm_inv_to_guest_device_hashes(inv, lan_uids)
+  def self.vm_inv_to_guest_device_hashes(inv, lan_uids, _vnic_profiles)
     inv = inv[:nics]
 
     result = []

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
@@ -94,8 +94,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
       HostInventory.new(:inv => inv, :logger => _log).host_inv_to_hashes(inv, ems_inv, cluster_uids, storage_uids)
     end
 
-    def self.vm_inv_to_hashes(inv, storage_inv, storage_uids, cluster_uids, host_uids, lan_uids)
-      VmInventory.new(:inv => inv, :logger => _log).vm_inv_to_hashes(inv, storage_inv, storage_uids, cluster_uids, host_uids, lan_uids)
+    def self.vm_inv_to_hashes(inv, storage_inv, storage_uids, cluster_uids, host_uids, lan_uids, vnic_profiles)
+      VmInventory.new(:inv => inv, :logger => _log).vm_inv_to_hashes(inv, storage_inv, storage_uids, cluster_uids, host_uids, lan_uids, vnic_profiles)
     end
 
     def self.datacenter_inv_to_hashes(inv, cluster_uids, vm_uids, storage_uids, host_uids)

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
@@ -162,7 +162,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
           :uid_ems => uid,
           :name    => name,
 
-          :lans    => [{:name => name, :uid_ems => uid, :tag => tag_value}]
+          :lans    => [lan]
         }
 
         result << new_result
@@ -279,12 +279,12 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         guest_device = guest_device_uids.fetch_path(:pnic, uid)
 
         # Get the ip section
-        ip = vnic.ip.presence || {}
+        ip = vnic.ip.presence || nil
 
         new_result = {
           :description => vnic.name,
-          :ipaddress   => ip.address,
-          :subnet_mask => ip.netmask,
+          :ipaddress   => ip&.address,
+          :subnet_mask => ip&.netmask,
         }
 
         result << new_result

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
@@ -7,7 +7,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
       @_log = args[:logger]
     end
 
-    def vm_inv_to_hashes(inv, _storage_inv, storage_uids, cluster_uids, host_uids, lan_uids)
+    def vm_inv_to_hashes(inv, _storage_inv, storage_uids, cluster_uids, host_uids, lan_uids, vnic_profiles)
       result = []
       result_uids = {}
       guest_device_uids = {}
@@ -53,7 +53,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         host_mor = host_id
         hardware = vm_inv_to_hardware_hash(vm_inv)
         hardware[:disks] = vm_inv_to_disk_hashes(vm_inv, storage_uids)
-        hardware[:guest_devices], guest_device_uids[vm_id] = vm_inv_to_guest_device_hashes(vm_inv, lan_uids[host_mor])
+        hardware[:guest_devices], guest_device_uids[vm_id] = vm_inv_to_guest_device_hashes(vm_inv, lan_uids[host_mor], vnic_profiles)
         hardware[:networks] = vm_inv_to_network_hashes(vm_inv, guest_device_uids[vm_id])
 
         ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm_inv.href)
@@ -123,7 +123,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
       result
     end
 
-    def vm_inv_to_guest_device_hashes(inv, lan_uids)
+    def vm_inv_to_guest_device_hashes(inv, lan_uids, vnic_profiles)
       inv = inv.nics
 
       result = []
@@ -135,7 +135,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         address = data.dig(:mac, :address)
         name = data.name
 
-        lan = lan_uids[data.dig(:network, :id)] unless lan_uids.nil?
+        profile_id = data.dig(:vnic_profile, :id)
+        vnic_profile = vnic_profiles.detect { |p| p.id == profile_id } if profile_id && vnic_profiles
+        network_id = vnic_profile.dig(:network, :id) if vnic_profile
+        lan = lan_uids[network_id] unless lan_uids.nil? || network_id.nil?
 
         new_result = {
           :uid_ems         => uid,

--- a/app/models/manageiq/providers/redhat/inventory/collector.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector.rb
@@ -41,6 +41,12 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManagerRefresh::Invent
     end
   end
 
+  def collect_vnic_profiles
+    manager.with_provider_connection(VERSION_HASH) do |connection|
+      connection.system_service.vnic_profiles_service.list
+    end
+  end
+
   def collect_storagedomains
     manager.with_provider_connection(VERSION_HASH) do |connection|
       connection.system_service.storage_domains_service.list

--- a/app/models/manageiq/providers/redhat/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector/infra_manager.rb
@@ -39,6 +39,10 @@ class ManageIQ::Providers::Redhat::Inventory::Collector::InfraManager < ManageIQ
     collected_inventory[:network]
   end
 
+  def collect_vnic_profiles
+    collected_inventory[:vnic_profiles]
+  end
+
   def collect_host_nics(host)
     host.nics
   end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -540,7 +540,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :start_connected => true,
         :address         => "00:1a:4a:16:01:51"
       )
-      # nic.lan.should == @lan # TODO: Hook up this connection
+      nic.lan == @lan
 
       guest_device = v.hardware.guest_devices.find_by(:device_name => "nic1")
       expect(guest_device.network).not_to be_nil
@@ -683,7 +683,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :start_connected => true,
         :address         => "00:1a:4a:16:01:53"
       )
-      # nic.lan.should == @lan # TODO: Hook up this connection
+      nic.lan == @lan
 
       expect(v.parent_datacenter).to have_attributes(
         :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -504,7 +504,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :start_connected => true,
         :address         => "00:1a:4a:16:01:51"
       )
-      # nic.lan.should == @lan # TODO: Hook up this connection
+      nic.lan == @lan
 
       guest_device = v.hardware.guest_devices.find_by(:device_name => "nic1")
       expect(guest_device.network).not_to be_nil
@@ -647,7 +647,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :start_connected => true,
         :address         => "00:1a:4a:16:01:53"
       )
-      # nic.lan.should == @lan # TODO: Hook up this connection
+      nic.lan == @lan
 
       expect(v.parent_datacenter).to have_attributes(
         :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_custom_attributes_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_custom_attributes_spec.rb
@@ -9,6 +9,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ovirt_service = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
     allow_any_instance_of(@ovirt_service)
       .to receive(:collect_external_network_providers).and_return(load_response_mock_for('external_network_providers'))
+    @collector = ManageIQ::Providers::Redhat::Inventory::Collector
+    allow_any_instance_of(@collector)
+      .to receive(:collect_vnic_profiles).and_return([])
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
     @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
     allow(@ems).to(receive(:supported_api_versions).and_return(%w(3 4)))

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_graph_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_graph_target_vm_spec.rb
@@ -7,6 +7,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       @ovirt_service = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
       allow_any_instance_of(@ovirt_service)
         .to receive(:collect_external_network_providers).and_return(load_response_mock_for('external_network_providers'))
+      @ovirt_service_inventory = ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4
+      allow_any_instance_of(@ovirt_service_inventory)
+        .to receive(:collect_vnic_profiles).and_return([])
+      @collector = ManageIQ::Providers::Redhat::Inventory::Collector
+      allow_any_instance_of(@collector)
+        .to receive(:collect_vnic_profiles).and_return([])
       @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
       @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
       allow(@ems).to receive(:supported_api_versions).and_return(%w(3 4))

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
@@ -125,6 +125,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     collector_class = ManageIQ::Providers::Redhat::Inventory::Collector
     allow_any_instance_of(collector_class).to receive(:collect_attached_disks).and_return(load_response_mock_for('disks'))
     allow_any_instance_of(collector_class).to receive(:collect_vm_devices).and_return([])
+    allow_any_instance_of(collector_class).to receive(:collect_vnic_profiles).and_return([])
     allow_any_instance_of(collector_class).to receive(:collect_nics).and_return(load_response_mock_for('nics'))
     allow_any_instance_of(collector_class).to receive(:collect_snapshots).and_return(load_response_mock_for('snapshots'))
     target_collector_class = ManageIQ::Providers::Redhat::Inventory::Collector::TargetCollection

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_publish_vm_to_template.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_publish_vm_to_template.yml
@@ -7138,6 +7138,18 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/networks{}GET:
     content-length: '316'
     correlation-id: 792546a2-ac96-47e5-bfdd-aacfb838d845
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vnic_profiles/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '93'
+    correlation-id: df567c87-e710-4955-8457-74a5d6418fe1
+  :message:
 https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_graph_target_template.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_graph_target_template.yml
@@ -1555,6 +1555,18 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/networks{}GET:
     content-length: '313'
     correlation-id: c0e2600b-775b-4357-9d01-497be8255e01
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vnic_profiles/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '93'
+    correlation-id: df567c87-e710-4955-8457-74a5d6418fe1
+  :message:
 https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm.yml
@@ -1561,6 +1561,18 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/networks{}GET:
     content-length: '313'
     correlation-id: 7f0abcb5-63e6-4162-92f9-c9702421ef1a
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vnic_profiles/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '93'
+    correlation-id: df567c87-e710-4955-8457-74a5d6418fe1
+  :message:
 https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
@@ -6157,6 +6157,30 @@ https://localhost:8443/ovirt-engine/api/networks{}GET:
     correlation-id: a42fa1c3-640d-4ac7-a79a-87e1822c7fe5
     date: Thu, 03 Aug 2017 10:38:48 GMT
   :message: 
+https://localhost:8443/ovirt-engine/api/vnicprofiles{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vnic_profiles>
+       <vnic_profile href="/ovirt-engine/api/vnicprofiles/ce947d91-1a6f-47c1-b722-5dd45869ea3f" id="ce947d91-1a6f-47c1-b722-5dd45869ea3f">
+           <name>ovirtmgmt</name>
+           <link href="/ovirt-engine/api/vnicprofiles/ce947d91-1a6f-47c1-b722-5dd45869ea3f/permissions" rel="permissions"/>
+           <pass_through>
+                <mode>disabled</mode>
+           </pass_through>
+           <port_mirroring>false</port_mirroring>
+           <network href="/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef" id="6ad90f38-5496-47fb-9882-5aa55e1314ef"/>
+           <network_filter href="/ovirt-engine/api/networkfilters/dcedb4d0-3c16-11e8-afa4-54e1ad8f7407" id="dcedb4d0-3c16-11e8-afa4-54e1ad8f7407"/>
+       </vnic_profile>
+    </vnic_profiles>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '347'
+    correlation-id: cc78dfe6-da13-475c-aee8-31e9cc1ae17f
+    date: Thu, 03 Aug 2017 10:38:48 GMT
+  :message:
 https://localhost:8443/ovirt-engine/api/datacenters{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_custom_attrs.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_custom_attrs.yml
@@ -2743,6 +2743,18 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/networks{}GET:
     content-length: '313'
     correlation-id: 0fb84808-a1db-4c32-95b5-07dbac8410c7
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vnic_profiles/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '93'
+    correlation-id: df567c87-e710-4955-8457-74a5d6418fe1
+  :message:
 https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml
@@ -1055,6 +1055,18 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/networks{}GET:
     content-length: '313'
     correlation-id: 82bfa65e-562b-4e83-89ff-2a3bd5ddbfd1
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vnic_profiles/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '93'
+    correlation-id: df567c87-e710-4955-8457-74a5d6418fe1
+  :message:
 https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_target_template_disconnect.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_target_template_disconnect.yml
@@ -5005,6 +5005,18 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/networks{}GET:
     content-length: '313'
     correlation-id: b8623f69-88a5-42cf-ba56-6685e241e5ed
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vnic_profiles/>
+  :code: 200
+  :headers:
+    content-encoding: gzip
+    connection: keep-alive
+    content-type: application/xml
+    content-length: '93'
+    correlation-id: df567c87-e710-4955-8457-74a5d6418fe1
+  :message:
 https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>


### PR DESCRIPTION
The 'lan' table contains a mapping of the the networks attached to the
hosts.

If a vm is running, vm.hardware.nics[i].lan should return the host network
it is attached to.

There are two reasons it wasn't working -

1. host_inventory didn't store the same instance of the lan in the 'hash'
and in 'lan_uids'.
Since the vm_inventory used the 'lan_uids' instance, it didn't get the
id of the lan once it was stored to the db (the id was updated on the
'hash' instance).

2. The vnic (vm nic) returned by the ovirt sdk doesn't contain the network
name (the value is always null). The network should be retrieved using the
vnic profile.

* Similar fixes were done to the relevant files in graph refresh.
* v3 wasn't fixed.

Fixes https://bugzilla.redhat.com/1572917