### PR TITLE
Update Ovirt for the new switch modeling

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -145,6 +145,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
         :ems_cluster      => cluster_uids[host_inv.attributes.fetch_path(:cluster, :id)],
         :hardware         => hardware,
         :switches         => switches,
+        :host_switches    => switches,
 
       }
       new_result[:ipmi_address] = ipmi_address unless ipmi_address.blank?

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -240,7 +240,8 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
       unless network.nil?
         switch_uid = network.try(:id) || network.name
-        attributes[:switch] = persister.switches.lazy_find(switch_uid)
+        persister_host = persister.hosts.lazy_find(ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(host.href))
+        attributes[:switch] = persister.host_virtual_switches.lazy_find(:host => persister_host, :uid_ems => switch_uid)
         attributes[:network] = persister_nic
       end
 
@@ -260,7 +261,8 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       uid = network.try(:id) || network.name
       name = network.name
 
-      persister_switch = persister.switches.find_or_build(uid).assign_attributes(
+      persister_switch = persister.host_virtual_switches.find_or_build_by(:host => persister_host, :uid_ems => uid).assign_attributes(
+        :host    => persister_host,
         :uid_ems => uid,
         :name    => name,
         :lans    => [lans(network)]

--- a/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
       %i(ems_clusters hosts resource_pools vms miq_templates
          storages vm_and_template_ems_custom_fields disks guest_devices hardwares
          host_hardwares host_networks host_operating_systems host_storages
-         host_switches lans networks operating_systems snapshots switches)
+         host_switches lans networks operating_systems snapshots host_virtual_switches)
     )
 
     add_inventory_collection(

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -112,8 +112,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(Network.count).to eq(6)
     expect(OperatingSystem.count).to eq(20)
     expect(Snapshot.count).to eq(17)
-    # the old code expects 3 and new 2
-    expect(Switch.count).to eq(2)
+    expect(Switch.count).to eq(3)
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(45)


### PR DESCRIPTION
Update the Ovirt refresh_parser and graph refresh parsing/persister for the split out host-local switch model.

Depends on: https://github.com/ManageIQ/manageiq/pull/17420