### PR TITLE
Ems metadata improvements

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -73,7 +73,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
     collector.datacenters.each do |datacenter|
       ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(datacenter.href)
 
-      persister.root_folders.find_or_build('root_dc').assign_attributes(
+      persister.ems_folders.find_or_build('root_dc').assign_attributes(
         :name    => 'Datacenters',
         :type    => 'EmsFolder',
         :uid_ems => 'root_dc',
@@ -90,7 +90,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       )
 
       host_folder_uid = "#{uid}_host"
-      persister.host_folders.find_or_build(host_folder_uid).assign_attributes(
+      persister.ems_folders.find_or_build(host_folder_uid).assign_attributes(
         :name    => 'host',
         :type    => 'EmsFolder',
         :uid_ems => host_folder_uid,
@@ -98,7 +98,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       )
 
       vm_folder_uid = "#{uid}_vm"
-      persister.vm_folders.find_or_build(vm_folder_uid).assign_attributes(
+      persister.ems_folders.find_or_build(vm_folder_uid).assign_attributes(
         :name    => 'vm',
         :type    => 'EmsFolder',
         :uid_ems => vm_folder_uid,

--- a/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
   def initialize_inventory_collections
     add_inventory_collections(
       infra,
-      %i(ems_clusters hosts resource_pools vms miq_templates
+      %i(ems_clusters ems_folders hosts resource_pools vms miq_templates
          storages vm_and_template_ems_custom_fields disks guest_devices hardwares
          host_hardwares host_networks host_operating_systems host_storages
          host_switches lans networks operating_systems snapshots switches)
@@ -40,25 +40,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
         :dependency_attributes => {
           :snapshots => [collections[:snapshots]]
         }
-      )
-    )
-
-    add_inventory_collection(
-      infra.vm_folders(
-        :arel     => manager.ems_folders.where(:name => 'vm'),
-        :strategy => :local_db_find_missing_references
-      )
-    )
-    add_inventory_collection(
-      infra.host_folders(
-        :arel     => manager.ems_folders.where(:name => 'host'),
-        :strategy => :local_db_find_missing_references
-      )
-    )
-    add_inventory_collection(
-      infra.root_folders(
-        :arel     => manager.ems_folders.where(:uid_ems => 'root_dc'),
-        :strategy => :local_db_find_missing_references
       )
     )
   end

--- a/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
@@ -150,24 +150,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::TargetCollection < Mana
         :strategy => :local_db_find_missing_references
       )
     )
-    add_inventory_collection(
-      infra.vm_folders(
-        :arel     => manager.ems_folders.where(:uid_ems => manager_refs.collect { |ref| "#{URI(ref).path.split('/').last}_vm" }),
-        :strategy => :local_db_find_missing_references
-      )
-    )
-    add_inventory_collection(
-      infra.host_folders(
-        :arel     => manager.ems_folders.where(:uid_ems => manager_refs.collect { |ref| "#{URI(ref).path.split('/').last}_host" }),
-        :strategy => :local_db_find_missing_references
-      )
-    )
-    add_inventory_collection(
-      infra.root_folders(
-        :arel     => manager.ems_folders.where(:uid_ems => 'root_dc'),
-        :strategy => :local_db_find_missing_references
-      )
-    )
   end
 
   def add_storages_inventory_collcetions(manager_refs)

--- a/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
@@ -16,46 +16,6 @@ class ManageIQ::Providers::Redhat::InventoryCollectionDefault::InfraManager < Ma
       super(attributes.merge!(extra_attributes))
     end
 
-    def vm_folders(extra_attributes = {})
-      attributes = {
-        :model_class                 => ::EmsFolder,
-        :inventory_object_attributes => [
-          :name,
-          :type,
-          :uid_ems,
-          :hidden
-        ],
-        :association                 => :vm_folders,
-        :manager_ref                 => [:uid_ems],
-        :attributes_blacklist        => [:ems_children],
-        :builder_params              => {
-          :ems_id => ->(persister) { persister.manager.id },
-        },
-      }
-
-      attributes.merge!(extra_attributes)
-    end
-
-    def host_folders(extra_attributes = {})
-      attributes = {
-        :model_class                 => ::EmsFolder,
-        :inventory_object_attributes => [
-          :name,
-          :type,
-          :uid_ems,
-          :hidden
-        ],
-        :association                 => :host_folders,
-        :manager_ref                 => [:uid_ems],
-        :attributes_blacklist        => [:ems_children],
-        :builder_params              => {
-          :ems_id => ->(persister) { persister.manager.id },
-        },
-      }
-
-      attributes.merge!(extra_attributes)
-    end
-
     def hosts(extra_attributes = {})
       attributes = {
         :model_class                 => ::Host,
@@ -106,26 +66,6 @@ class ManageIQ::Providers::Redhat::InventoryCollectionDefault::InfraManager < Ma
             end
           end
         end
-      }
-
-      attributes.merge!(extra_attributes)
-    end
-
-    def root_folders(extra_attributes = {})
-      attributes = {
-        :model_class                 => ::EmsFolder,
-        :inventory_object_attributes => [
-          :name,
-          :type,
-          :uid_ems,
-          :hidden
-        ],
-        :association                 => :root_folders,
-        :manager_ref                 => [:uid_ems],
-        :attributes_blacklist        => [:ems_children],
-        :builder_params              => {
-          :ems_id => ->(persister) { persister.manager.id },
-        },
       }
 
       attributes.merge!(extra_attributes)

--- a/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
@@ -136,17 +136,24 @@ class ManageIQ::Providers::Redhat::InventoryCollectionDefault::InfraManager < Ma
     def ems_clusters_children(extra_attributes = {})
       ems_cluster_children_save_block = lambda do |_ems, inventory_collection|
         cluster_collection = inventory_collection.dependency_attributes[:clusters].try(:first)
+        cluster_model      = cluster_collection.model_class
+
         vm_collection = inventory_collection.dependency_attributes[:vms].try(:first)
+        vm_model      = vm_collection.model_class
 
-        cluster_collection.each do |cluster|
-          vms = vm_collection.data.select { |vm| cluster.ems_ref == vm.ems_cluster.ems_ref }
+        vms_by_cluster = Hash.new { |h, k| h[k] = []}
+        vm_collection.data.each { |vm| vms_by_cluster[vm.ems_cluster&.id] << vm }
 
-          ActiveRecord::Base.transaction do
-            vs = VmOrTemplate.find(vms.map(&:id))
+        ActiveRecord::Base.transaction do
+          clusters_by_id = cluster_model.find(cluster_collection.data.map(&:id)).index_by(&:id)
+          vms_by_id      = vm_model.find(vm_collection.data.map(&:id)).index_by(&:id)
+
+          clusters_by_id.each do |cluster_id, cluster|
             rp = ResourcePool.find_by(:uid_ems => "#{cluster.uid_ems}_respool")
-            rp.with_relationship_type("ems_metadata") { rp.add_child vs }
-            c = EmsCluster.find(cluster.id)
-            c.with_relationship_type("ems_metadata") { c.add_child rp }
+            cluster.with_relationship_type("ems_metadata") { cluster.add_child(rp) }
+
+            vms = vms_by_id.values_at(*vms_by_cluster[cluster_id]&.map(&:id) || [])
+            rp.with_relationship_type("ems_metadata") { rp.add_children(vms) }
           end
         end
       end


### PR DESCRIPTION
Consolidate the vm/host/root folder collections into a single standard ems_folders collection and rewrite ems_clusters_children to do a single query for all clusters and save in a single transaction instead of a transaction per cluster.