### PR TITLE
Don't call Gem::Version.new() with a nil version

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
     return unless content = customization_template_content
     with_provider_destination { |d| d.update_cloud_init!(content) }
 
-    if Gem::Version.new(source.ext_management_system.api_version) >= Gem::Version.new("3.5.5.0")
+    if source.ext_management_system.api_version && Gem::Version.new(source.ext_management_system.api_version) >= Gem::Version.new("3.5.5.0")
       phase_context[:boot_with_cloud_init] = true
     end
   end


### PR DESCRIPTION
If the EMS api_version is nil don't call Gem::Version.new() to prevent
the exception:
```
ArgumentError:
  Malformed version number string
```

This behavior changed in gem version 2.7.7

https://travis-ci.org/ManageIQ/manageiq-providers-ovirt/builds/380600591#L1969