### PR TITLE
RHEV SSH Keypair auth always returns true

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -18,6 +18,11 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     @supported_features ||= supported_api_versions.collect { |version| self.class.api_features[version.to_s] }.flatten.uniq
   end
 
+  def authentication_status_ok?(type = nil)
+    return true if type == :ssh_keypair
+    super
+  end
+
   def use_graph_refresh?
     Settings.ems_refresh.rhevm.try(:[], :inventory_object_refresh) &&
       use_ovirt_sdk? && supported_api_versions.include?('4')


### PR DESCRIPTION
Currently we do not validate ssh keypair on rhev. It should always
return true for ssh_keypair type authentication.

This is part of the pull requests that solve: https://bugzilla.redhat.com/show_bug.cgi?id=1561353