### PR TITLE
Use the same assoc for targeted and full refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
@@ -6,7 +6,13 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::TargetCollection < Mana
 
     @collection_group = nil
 
-    add_collection(infra, :custom_attributes)
+    add_collection(infra, :vm_and_template_ems_custom_fields) do |builder|
+      builder.add_properties(
+        :model_class => ::CustomAttribute,
+        :manager_ref => %i(name),
+      )
+      builder.add_inventory_attributes(%i(section name value source resource))
+    end
   end
 
   # not added to IC properties


### PR DESCRIPTION
The full refresh persister was using the :vm_and_template_ems_custom_fields
association but the targeted persister was using the :custom_attributes
association.  This caused targeted refresh to clear all
miq_custom_attributes which were added outside of refresh.