### PR TITLE
Use the same assoc for targeted and full refresh #2

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/vms_collections.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/vms_collections.rb
@@ -86,8 +86,6 @@ module ManageIQ::Providers::Redhat::Inventory::Persister::Definitions::InfraGrou
         :model_class => ::CustomAttribute,
         :manager_ref => %i(name)
       )
-      builder.add_properties(:arel => CustomAttribute.joins("INNER JOIN vms ON vms.id = custom_attributes.resource_id").where(:vms => { :ems_ref => manager_refs })) if targeted?
-
       builder.add_inventory_attributes(%i(section name value source resource))
     end
   end

--- a/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
@@ -5,14 +5,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::TargetCollection < Mana
     initialize_infra_inventory_collections
 
     @collection_group = nil
-
-    add_collection(infra, :vm_and_template_ems_custom_fields) do |builder|
-      builder.add_properties(
-        :model_class => ::CustomAttribute,
-        :manager_ref => %i(name),
-      )
-      builder.add_inventory_attributes(%i(section name value source resource))
-    end
   end
 
   # not added to IC properties


### PR DESCRIPTION
Successor of: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/265

`:vm_and_template_ems_custom_fields` belongs to another `@collection_group`, it can result to different strategy in targeted refresh.

Original fix should remove `arel` property for `targeted?` and `:custom_attributes` IC, which replaces this one

Cc @agrare, @borod108 