### PR TITLE
Persister: optimized InventoryCollection definitions

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/definitions/network_collections.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::Redhat::Inventory::Persister::Definitions::NetworkCo
       builder.add_properties(
         :model_class => ManageIQ::Providers::Openstack::CloudManager::CloudTenant
       )
-      builder.add_builder_params(
+      builder.add_default_values(
         :ems_id => manager.parent_manager.try(:id) # changed from :ext_management_system
       )
     end


### PR DESCRIPTION
**Issue**: https://github.com/ManageIQ/manageiq/issues/17396
- [x] **depends on** https://github.com/ManageIQ/manageiq/pull/17621

Method rename `add_builder_params` => `add_default_values`