### PR TITLE
[GAPRINDASHVILI] fix miq custom attributes deleted

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
@@ -117,8 +117,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::TargetCollection < Mana
     )
     add_inventory_collection(
       infra.vm_and_template_ems_custom_fields(
-        :arel     => CustomAttribute.joins("INNER JOIN vms ON vms.id = custom_attributes.resource_id")
-         .where(:vms => { :ems_ref => manager_refs }),
         :strategy => :local_db_find_missing_references
       )
     )


### PR DESCRIPTION
The full refresh persister was using the :vm_and_template_ems_custom_fields
association but the targeted persister was using the :custom_attributes
association.  This caused targeted refresh to clear all
miq_custom_attributes which were added outside of refresh.

Master PR: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/265

https://bugzilla.redhat.com/show_bug.cgi?id=1594833