### PR TITLE
[GAPRINDASHVILI] Fix targeted refresh clearing other VMs ems_custom_attrs

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
@@ -117,7 +117,9 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::TargetCollection < Mana
     )
     add_inventory_collection(
       infra.vm_and_template_ems_custom_fields(
-        :strategy => :local_db_find_missing_references
+        :strategy => :local_db_find_missing_references,
+        :arel     => CustomAttribute.joins("INNER JOIN vms ON vms.id = custom_attributes.resource_id")
+         .where(:vms => { :ems_ref => manager_refs }, :source => "VC"),
       )
     )
   end


### PR DESCRIPTION
Fix an issue where targeted refresh is clearing other VM's
ems_custom_attributes

Test taken from https://github.com/ManageIQ/manageiq-providers-ovirt/pull/270