### PR TITLE
We can use strategy :local_db_find_missing_references for all ICs

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
@@ -22,16 +22,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::TargetCollection < Mana
   end
 
   def strategy
-    ems_ref = if @collection_group == :vms_dependency
-                references(:vms)
-              else
-                references(@collection_group)
-              end
-
-    if ems_ref.blank?
-      :local_db_find_references
-    else
-      :local_db_find_missing_references unless @collection_group == :vms_dependency
-    end
+    :local_db_find_missing_references
   end
 end


### PR DESCRIPTION
We can use strategy :local_db_find_missing_references for all ICs,
with a spec that ensures the custom attributes are correctly created
and deleted.