### PR TITLE
Fix disk_type attribute

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -577,7 +577,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
           :location        => index.to_s,
           :size            => (device[:provisioned_size] || device[:size]).to_i,
           :size_on_disk    => device[:actual_size] ? device[:actual_size].to_i : 0,
-          :disk_type       => device[:sparse] == true ? 'thin' : 'thick',
+          :disk_type       => device[:format] == 'raw' ? 'thick' : 'thin',
           :mode            => 'persistent',
           :bootable        => device[:bootable]
         }

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
@@ -234,7 +234,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
             :location        => index.to_s,
             :size            => device.provisioned_size.to_i,
             :size_on_disk    => device.actual_size.to_i,
-            :disk_type       => device.sparse == true ? 'thin' : 'thick',
+            :disk_type       => device.format == 'raw' ? 'thick' : 'thin',
             :mode            => 'persistent',
             :bootable        => device.try(:bootable)
           }

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -457,7 +457,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
           :location        => index.to_s,
           :size            => device.provisioned_size.to_i,
           :size_on_disk    => device.actual_size.to_i,
-          :disk_type       => device.sparse == true ? 'thin' : 'thick',
+          :disk_type       => device.format == 'raw' ? 'thick' : 'thin',
           :mode            => 'persistent',
           :bootable        => device.try(:bootable),
           :storage         => persister.storages.lazy_find(ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(storage_ref))

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -664,7 +664,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :size            => 6_442_450_944,
         :size_on_disk    => 0,
         :mode            => "persistent",
-        :disk_type       => "thin",
+        :disk_type       => "thick",
         :start_connected => true
       )
       expect(disk.storage).to eq(@storage) ## CHECK MANUALLY
@@ -777,7 +777,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :size            => 6_442_450_944,
         :size_on_disk    => 1_838_448_640,
         :mode            => "persistent",
-        :disk_type       => "thin",
+        :disk_type       => "thick",
         :start_connected => true
       )
       expect(disk.storage).to eq(@storage) ## CHECK MANUALLY

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -629,7 +629,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :size            => 6_442_450_944,
         :size_on_disk    => 0,
         :mode            => "persistent",
-        :disk_type       => "thin",
+        :disk_type       => "thick",
         :start_connected => true
       )
       expect(disk.storage).to eq(@storage) ## CHECK MANUALLY
@@ -742,7 +742,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :size            => 6_442_450_944,
         :size_on_disk    => 1_838_448_640,
         :mode            => "persistent",
-        :disk_type       => "thin",
+        :disk_type       => "thick",
         :start_connected => true
       )
       expect(disk.storage).to eq(@storage) ## CHECK MANUALLY

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
@@ -316,7 +316,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :present            => true,
       :start_connected    => true,
       :auto_detect        => nil,
-      :disk_type          => "thin",
+      :disk_type          => "thick",
       :storage_id         => storage.id,
       :backing_id         => nil,
       :backing_type       => nil,


### PR DESCRIPTION
We were calculating the disk_type based on the sparse property of the
disk. This is incorrect, it should actually be calculated based on the
format property.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1598747