### PR TITLE
Fix provisioning independent VM

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -520,7 +520,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
         vm = build_vm_from_hash(:name     => options[:name],
                                 :template => template,
                                 :cluster  => cluster)
-        vms_service.add(vm)
+        vms_service.add(vm, :clone => options[:clone_type] == :full)
       end
 
       def build_vm_from_hash(args)

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
@@ -38,11 +38,23 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Cloning
     clone_options = {
       :name       => dest_name,
       :cluster    => dest_cluster.ems_ref,
-      :clone_type => get_option(:linked_clone) ? :linked : :full,
+      :clone_type => clone_type,
       :sparse     => sparse_disk_value
     }
     clone_options[:storage] = dest_datastore.ems_ref unless dest_datastore.nil?
     clone_options
+  end
+
+  def clone_type
+    get_option(:linked_clone).nil? ? clone_type_by_disk_format : clone_type_by_linked_clone
+  end
+
+  def clone_type_by_linked_clone
+    get_option(:linked_clone) ? :linked : :full
+  end
+
+  def clone_type_by_disk_format
+    get_option(:disk_format) == 'preallocated' ? :full : :linked
   end
 
   def template_clone_options

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
@@ -72,7 +72,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
           clone_options = @vm_prov.prepare_for_clone_task
 
           expect(clone_options[:name]).to eq(@target_vm_name)
-          expect(clone_options[:clone_type]).to eq(:full)
+          expect(clone_options[:clone_type]).to eq(:linked)
           expect(clone_options[:cluster]).to eq(@ems_cluster.ems_ref)
         end
 
@@ -88,6 +88,23 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
           clone_options = @vm_prov.prepare_for_clone_task
 
           expect(clone_options[:clone_type]).to eq(:full)
+        end
+
+        context "no liked_clone defined" do
+          before { @vm_prov.options[:linked_clone] = nil }
+          it "with disk_format preallocated" do
+            @vm_prov.options[:disk_format] = "preallocated"
+            clone_options = @vm_prov.prepare_for_clone_task
+
+            expect(clone_options[:clone_type]).to eq(:full)
+          end
+
+          it "with disk format thin" do
+            @vm_prov.options[:disk_format] = "thin"
+            clone_options = @vm_prov.prepare_for_clone_task
+
+            expect(clone_options[:clone_type]).to eq(:linked)
+          end
         end
       end
 


### PR DESCRIPTION
We ignored the clone_type parameter during provisioning from template.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1598747