### PR TITLE
Add support to set VM memory and number of CPUs

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -156,12 +156,15 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def vm_set_memory(vm, options = {})
-    spec = { 'memoryMB' => options['value'] }
+    spec = { 'memoryMB' => options[:value] }
     vm_reconfigure(vm, :spec => spec)
   end
 
   def vm_set_num_cpus(vm, options = {})
-    spec = { 'numCPUs' => options[:value] }
+    cpu_total = options[:value]
+    spec = { 'numCPUs' => cpu_total }
+    cpu_sockets = cpu_total / vm.cpu_cores_per_socket
+    spec['numCoresPerSocket'] = cpu_total if cpu_sockets < 1
     vm_reconfigure(vm, :spec => spec)
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -155,6 +155,16 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     ovirt_services_for_reconfigure.vm_reconfigure(vm, options)
   end
 
+  def vm_set_memory(vm, options = {})
+    spec = { 'memoryMB' => options['value'] }
+    vm_reconfigure(vm, :spec => spec)
+  end
+
+  def vm_set_num_cpus(vm, options = {})
+    spec = { 'numCPUs' => options[:value] }
+    vm_reconfigure(vm, :spec => spec)
+  end
+
   def add_disks(add_disks_spec, vm)
     storage = add_disks_spec[:storage]
     with_disk_attachments_service(vm) do |service|

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -174,14 +174,14 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       it 'cpu_topology from set_number_of_cpus with number of sockets >= 1' do
         allow(@vm).to receive(:cpu_cores_per_socket).and_return(2)
         options = { :user_event => "Console Request Action [vm_set_number_of_cpus], VM [#{@vm.name}]", :value => 2 }
-        expect(@rhevm_vm).to receive(:cpu_topology=).with({:sockets => 1})
+        expect(@rhevm_vm).to receive(:cpu_topology=).with(:sockets => 1)
         @ems.vm_set_num_cpus(@vm, options)
       end
 
       it 'cpu_topology from set_number_of_cpus with number of sockets < 1' do
         allow(@vm).to receive(:cpu_cores_per_socket).and_return(2)
         options = { :user_event => "Console Request Action [vm_set_number_of_cpus], VM [#{@vm.name}]", :value => 1 }
-        expect(@rhevm_vm).to receive(:cpu_topology=).with({:cores => 1, :sockets => 1})
+        expect(@rhevm_vm).to receive(:cpu_topology=).with(:cores => 1, :sockets => 1)
         @ems.vm_set_num_cpus(@vm, options)
       end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -170,6 +170,27 @@ describe ManageIQ::Providers::Redhat::InfraManager do
         expect(@rhevm_vm).to receive(:update_memory).with(1.gigabyte, adjusted)
         @ems.vm_reconfigure(@vm, :spec => spec)
       end
+
+      it 'cpu_topology from set_number_of_cpus with number of sockets >= 1' do
+        allow(@vm).to receive(:cpu_cores_per_socket).and_return(2)
+        options = { :user_event => "Console Request Action [vm_set_number_of_cpus], VM [#{@vm.name}]", :value => 2 }
+        expect(@rhevm_vm).to receive(:cpu_topology=).with({:sockets => 1})
+        @ems.vm_set_num_cpus(@vm, options)
+      end
+
+      it 'cpu_topology from set_number_of_cpus with number of sockets < 1' do
+        allow(@vm).to receive(:cpu_cores_per_socket).and_return(2)
+        options = { :user_event => "Console Request Action [vm_set_number_of_cpus], VM [#{@vm.name}]", :value => 1 }
+        expect(@rhevm_vm).to receive(:cpu_topology=).with({:cores => 1, :sockets => 1})
+        @ems.vm_set_num_cpus(@vm, options)
+      end
+
+      it 'adjusts memory from set_memory' do
+        options = { :user_event => "Console Request Action [vm_set_memory], VM [#{@vm.name}]", :value => 2048 }
+        allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:status, :state).and_return('down')
+        expect(@rhevm_vm).to receive(:update_memory).with(2.gigabytes, 2.gigabytes)
+        @ems.vm_set_memory(@vm, options)
+      end
     end
   end
 


### PR DESCRIPTION
VMware provider has support to set VM memory and number of CPUs. This PR adds the same same methods to oVirt provider. The implementation relies on `vm_reconfigure` which already implements the logic.

Blocks: https://github.com/ManageIQ/manageiq-automation_engine/pull/216
Associated BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1623021