### PR TITLE
[GAPRINDASHVILI] fix targeted refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector/target_collection.rb
@@ -214,7 +214,7 @@ class ManageIQ::Providers::Redhat::Inventory::Collector::TargetCollection < Mana
     changed_hosts = manager.hosts.where(:ems_ref => references(:hosts))
 
     changed_hosts.each do |host|
-      add_simple_target!(:ems_clusters, uuid_from_target(host.ems_cluster))
+      add_simple_target!(:ems_clusters, host.ems_cluster.ems_ref)
       host.storages.each do |storage|
         add_simple_target!(:storagedomains, storage.ems_ref)
       end

--- a/app/models/manageiq/providers/redhat/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector/target_collection.rb
@@ -216,7 +216,7 @@ class ManageIQ::Providers::Redhat::Inventory::Collector::TargetCollection < Mana
     changed_hosts.each do |host|
       add_simple_target!(:ems_clusters, uuid_from_target(host.ems_cluster))
       host.storages.each do |storage|
-        add_simple_target!(:storagedomains, uuid_from_target(storage))
+        add_simple_target!(:storagedomains, storage.ems_ref)
       end
       host.switches.each do |switch|
         add_simple_target!(:networks, switch.uid_ems)

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -263,8 +263,9 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       persister_switch = persister.switches.find_or_build(uid).assign_attributes(
         :uid_ems => uid,
         :name    => name,
-        :lans    => [lans(network)]
       )
+
+      lans(network, persister_switch)
 
       persister.host_switches.find_or_build_by(
         :host   => persister_host,
@@ -292,7 +293,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
     network
   end
 
-  def lans(network)
+  def lans(network, persister_switch)
     tag_value = nil
     if network
       uid = network.id
@@ -309,7 +310,8 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
     persister.lans.find_or_build(uid).assign_attributes(
       :name    => name,
       :uid_ems => uid,
-      :tag     => tag_value
+      :tag     => tag_value,
+      :switch  => persister_switch,
     )
   end
 

--- a/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
@@ -219,7 +219,7 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::TargetCollection < Mana
     )
     add_inventory_collection(
       infra.host_storages(
-        :arel     => manager.host_storages.where(:ems_ref => manager_refs),
+        :arel     => manager.host_storages.joins(:host).where(:hosts => {:ems_ref => manager_refs}),
         :strategy => :local_db_find_missing_references
       )
     )

--- a/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/target_collection.rb
@@ -233,7 +233,7 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::TargetCollection < Mana
     )
     add_inventory_collection(
       infra.host_networks(
-        :arel     => manager.networks.joins(:hardware => :host).where(
+        :arel     => manager.host_networks.joins(:hardware => :host).where(
           :hardware => {'hosts' => {:ems_ref => manager_refs}}
         ),
         :strategy => :local_db_find_missing_references

--- a/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory_collection_default/infra_manager.rb
@@ -408,6 +408,7 @@ class ManageIQ::Providers::Redhat::InventoryCollectionDefault::InfraManager < Ma
         :model_class                 => ::Lan,
         :inventory_object_attributes => [
           :name,
+          :switch,
           :uid_ems,
           :tag
         ]


### PR DESCRIPTION
We discovered an issue with oVirt targeted host refresh which led to lans being cleared.  We proceeded to discover more issues:

After a targeted refresh of a host:
1. Lans would be deleted
2. An extra cluster was created
3. Extra networks were created
4. Storages were duplicated
5. HostStorages were being duplicated and failing on duplicate key constraints

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1619431