### PR TITLE
Add safe operator for bz 1633540 to protect against empty source_vms

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -160,7 +160,7 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
 
   def allowed_customization_templates(options = {})
     if supports_native_clone?
-      if get_source_vm.platform == 'windows'
+      if get_source_vm&.platform == 'windows'
         allowed_sysprep_customization_templates(options)
       else
         allowed_cloud_init_customization_templates(options)


### PR DESCRIPTION
If the [get_source_and_targets[:vm]](https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_provision_virt_workflow.rb#L394) fails, the [source_vms](https://github.com/ManageIQ/manageiq-providers-ovirt/blob/master/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb#L163) will be nil and maybe we could just use the safe op thingy?
 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1633540