### PR TITLE
Fix attach_floppy to pass "floppy" type

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -380,7 +380,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       def attach_floppy(filename_hash)
         name, content = filename_hash.first
         file = OvirtSDK4::File.new(:name => name, :content => content)
-        payload = OvirtSDK4::Payload.new(:files => [file])
+        payload = OvirtSDK4::Payload.new(:files => [file], type: "floppy")
         vm = get
         vm.payloads ||= []
         vm.payloads << payload

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration_spec.rb
@@ -42,6 +42,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration do
           files = payload.files
           file = files.first
           expect(payloads.count).to eq(1)
+          expect(payload.type).to eq("floppy")
           expect(files.count).to eq(1)
           expect(file.name).to eq(cust_template.default_filename)
           expect(file.content).to eq("#some_script")


### PR DESCRIPTION
The type of the payload was not passed.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1613326