### PR TITLE
[WIP] Fix pxe provisioning

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -53,7 +53,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
 
   def prepare_customization_template_substitution_options(mac_address = nil)
     super.tap do |substitution_options|
-      substitution_options[:sysprep_timezone] = extract_timezone(substitution_options[:sysprep_timezone])
+      substitution_options[:sysprep_timezone] = extract_timezone(substitution_options[:sysprep_timezone]) if substitution_options
     end
   end
 


### PR DESCRIPTION
Overriding function in the provider did not account for the case when
prepare_customization_template_substitution_options custom template is not provided.
Added handling for that case.

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1633516