### PR TITLE
Travis - change postgres to 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
 install: bin/setup
 after_script: bundle exec codeclimate-test-reporter
 notifications:


### PR DESCRIPTION
Upgrading postgres to 9.5 on travis.

Related to https://github.com/ManageIQ/manageiq/pull/18090

@miq-bot add_label hammer/yes