### PR TITLE
[wip] Add support for CA in Ansible calls

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -28,15 +28,8 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       use_ovirt_sdk? && supported_api_versions.include?('4')
   end
 
-  def connect(options = {})
-    raise "no credentials defined" if missing_credentials?(options[:auth_type])
-    version = options[:version] || highest_allowed_api_version
-    unless options[:skip_supported_api_validation] || supports_the_api_version?(version)
-      raise "version #{version} of the api is not supported by the provider"
-    end
-
-    # Prepare the options to call the method that creates the actual connection:
-    connect_options = {
+  def apply_connection_options_defaults(options)
+    {
       :id         => id,
       :scheme     => options[:scheme] || 'https',
       :server     => options[:ip] || address,
@@ -48,7 +41,17 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       :verify_ssl => default_endpoint.verify_ssl,
       :ca_certs   => default_endpoint.certificate_authority
     }
+  end
 
+  def connect(options = {})
+    raise "no credentials defined" if missing_credentials?(options[:auth_type])
+    version = options[:version] || highest_allowed_api_version
+    unless options[:skip_supported_api_validation] || supports_the_api_version?(version)
+      raise "version #{version} of the api is not supported by the provider"
+    end
+
+    # Prepare the options to call the method that creates the actual connection:
+    connect_options = apply_connection_options_defaults(options)
     # Starting with version 4 of oVirt authentication doesn't work when using directly the IP address, it requires
     # the fully qualified host name, so if we received an IP address we try to convert it into the corresponding
     # host name:

--- a/app/models/manageiq/providers/redhat/infra_manager/ems_cluster.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ems_cluster.rb
@@ -1,12 +1,18 @@
 class ManageIQ::Providers::Redhat::InfraManager::EmsCluster < ManageIQ::Providers::InfraManager::EmsCluster
   def upgrade(options = {})
     role_options = {:role_name => "oVirt.cluster-upgrade"}
-    job = ManageIQ::Providers::AnsibleRoleWorkflow.create_job({}, extra_vars_for_upgrade(options), role_options)
+    job = ManageIQ::Providers::AnsibleRoleWorkflow.create_job({}, extra_vars_for_upgrade(options), role_options, :hook_object => cert_file_creator)
     job.signal(:start)
     job.miq_task
   end
 
   private
+
+  def cert_file_creator
+    cert = ext_management_system.default_endpoint.certificate_authority
+    return nil unless cert
+    CertificateFileCreator.new(cert)
+  end
 
   def extra_vars_for_upgrade(options = {})
     connect_options = ext_management_system.apply_connection_options_defaults(options)
@@ -25,5 +31,18 @@ class ManageIQ::Providers::Redhat::InfraManager::EmsCluster < ManageIQ::Provider
       :cluster_name    => name,
       :hostname        => "localhost"
     }
+  end
+
+  class CertificateFileCreator
+    attr_accessor :cert
+    def initialize(cert)
+      @cert = cert
+    end
+
+    def after_dir_create(base_dir, _env_vars, extra_vars, _ansible_runner_method, _playbook_or_role_args)
+      local_filename = File.join(base_dir, "ca_#{SecureRandom.hex}")
+      File.open(local_filename, 'w') {|f| f.write(cert) }
+      extra_vars[:engine_cafile] = local_filename
+    end
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/ems_cluster.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ems_cluster.rb
@@ -1,0 +1,29 @@
+class ManageIQ::Providers::Redhat::InfraManager::EmsCluster < ManageIQ::Providers::InfraManager::EmsCluster
+  def upgrade(options = {})
+    role_options = {:role_name => "oVirt.cluster-upgrade"}
+    job = ManageIQ::Providers::AnsibleRoleWorkflow.create_job({}, extra_vars_for_upgrade(options), role_options)
+    job.signal(:start)
+    job.miq_task
+  end
+
+  private
+
+  def extra_vars_for_upgrade(options = {})
+    connect_options = ext_management_system.apply_connection_options_defaults(options)
+
+    url = URI::Generic.build(
+      :scheme => connect_options[:scheme],
+      :host   => connect_options[:server],
+      :port   => connect_options[:port],
+      :path   => connect_options[:path]
+    ).to_s
+
+    {
+      :engine_url      => url,
+      :engine_user     => connect_options[:username],
+      :engine_password => connect_options[:password],
+      :cluster_name    => name,
+      :hostname        => "localhost"
+    }
+  end
+end

--- a/spec/models/manageiq/providers/redhat/infra_manager/ems_cluster_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/ems_cluster_spec.rb
@@ -1,0 +1,21 @@
+describe ManageIQ::Providers::Redhat::InfraManager::EmsCluster do
+  context "#upgrade" do
+    before do
+      @ems = FactoryGirl.create(:ems_redhat_with_authentication)
+      @cluster = FactoryGirl.create(:ems_cluster_redhat, :ems_id => @ems.id)
+      my_server = double("my_server", :guid => "guid1")
+      allow(MiqServer).to receive(:my_server).and_return(my_server)
+    end
+    it "sends the right parameters to the upgrade" do
+      env_vars = {}
+      extra_args = {:engine_url      => "https://#{@ems.address}/ovirt-engine/api",
+                    :engine_user     => @ems.authentication_userid,
+                    :engine_password => @ems.authentication_password,
+                    :cluster_name    => @cluster.name,
+                    :hostname        => "localhost"}
+      role_arg = {:role_name=>"oVirt.cluster-upgrade"}
+      expect(ManageIQ::Providers::AnsibleRoleWorkflow).to receive(:create_job).with(env_vars, extra_args, role_arg).and_call_original
+      @cluster.upgrade
+    end
+  end
+end

--- a/spec/models/manageiq/providers/redhat/infra_manager/ems_cluster_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/ems_cluster_spec.rb
@@ -5,6 +5,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::EmsCluster do
       @cluster = FactoryGirl.create(:ems_cluster_redhat, :ems_id => @ems.id)
       my_server = double("my_server", :guid => "guid1")
       allow(MiqServer).to receive(:my_server).and_return(my_server)
+      @ems.default_endpoint.update_attribute(:certificate_authority, "cert auth")
     end
     it "sends the right parameters to the upgrade" do
       env_vars = {}
@@ -14,7 +15,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::EmsCluster do
                     :cluster_name    => @cluster.name,
                     :hostname        => "localhost"}
       role_arg = {:role_name=>"oVirt.cluster-upgrade"}
-      expect(ManageIQ::Providers::AnsibleRoleWorkflow).to receive(:create_job).with(env_vars, extra_args, role_arg).and_call_original
+      file_creator_class = ManageIQ::Providers::Redhat::InfraManager::EmsCluster::CertificateFileCreator
+      expect(ManageIQ::Providers::AnsibleRoleWorkflow).to receive(:create_job).with(env_vars, extra_args, role_arg, :hook_object => kind_of(file_creator_class)).and_call_original
       @cluster.upgrade
     end
   end


### PR DESCRIPTION
Support creating a file from the certificate attached to the provider
and pass its path to the Ansible role.

This is part of implementing: https://bugzilla.redhat.com/show_bug.cgi?id=1644605