### PR TITLE
No need to override disconnect_inv from core

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -85,12 +85,6 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
     ext_management_system.ovirt_services.vm_exists_on_provider?(self)
   end
 
-  def disconnect_inv
-    disconnect_storage
-
-    super
-  end
-
   #
   # UI Button Validation Methods
   #


### PR DESCRIPTION
Core is going to call disconnect_storage from disconnect_inv so no need
to override it.

Depends: https://github.com/ManageIQ/manageiq/pull/18200

https://bugzilla.redhat.com/show_bug.cgi?id=1644770