### PR TITLE
Add support for CA for Ansible role

### DIFF
--- a/app/models/manageiq/providers/redhat/ansible_role_workflow.rb
+++ b/app/models/manageiq/providers/redhat/ansible_role_workflow.rb
@@ -1,0 +1,27 @@
+class ManageIQ::Providers::Redhat::AnsibleRoleWorkflow < ManageIQ::Providers::AnsibleRoleWorkflow
+  def pre_role
+    handle_ca_string
+    super
+  end
+
+  def post_playback
+    FileUtils.remove_entry(context[:ansible_cert_dir]) if context[:ansible_cert_dir]
+    super
+  end
+
+  def handle_ca_string
+    ca_string = options[:extra_vars] && options[:extra_vars].delete(:ca_string)
+    return if ca_string.nil?
+    context[:ansible_cert_dir] = Dir.mktmpdir("rhv_ansible_workflow")
+    options[:extra_vars][:engine_cafile] = create_cert_file(ca_string)
+    save
+  end
+
+  def create_cert_file(ca_string)
+    local_filename = File.join(context[:ansible_cert_dir], "ca_#{SecureRandom.hex}")
+    File.open(local_filename, 'w') {|f| f.write(ca_string) }
+    local_filename
+  end
+
+  alias start pre_role
+end

--- a/spec/models/manageiq/providers/redhat/ansible_role_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/ansible_role_workflow_spec.rb
@@ -1,0 +1,51 @@
+describe ManageIQ::Providers::Redhat::AnsibleRoleWorkflow do
+  let(:job)          { ManageIQ::Providers::Redhat::AnsibleRoleWorkflow.create_job(*options).tap { |job| job.state = state } }
+  let(:role_options) { {:role_name => 'role_name', :roles_path => 'path/role', :role_skip_facts => true } }
+  let(:extra_vars)   { { arg1: "arg2" } }
+  let(:options)      { [{"ENV" => "VAR"}, extra_vars, role_options] }
+  let(:state)        { "waiting_to_start" }
+
+  before do
+    my_server = double("my_server", :guid => "guid1")
+    allow(MiqServer).to receive(:my_server).and_return(my_server)
+  end
+
+  context ".create_job" do
+    it "leaves job waiting to start" do
+      expect(job.state).to eq("waiting_to_start")
+    end
+  end
+
+  context "per_role" do
+    let(:state) { "waiting_to_start" }
+    context "ca_string given" do
+      let(:extra_vars)   { { :arg1 => "res1", :ca_string => "my_ca" } }
+      it "creates a tmp dir for certs in pre role" do
+        job.signal(:start)
+        expect(job.context[:ansible_cert_dir]).not_to be_nil
+        expect(File.directory?(job.context[:ansible_cert_dir])).to be_truthy
+      end
+
+      it "creates creates a file and adds its path to the extra vars" do
+        job.signal(:start)
+        ec_file_path = job.options[:extra_vars][:engine_cafile]
+        expect(ec_file_path).not_to be_nil
+        data = File.read(ec_file_path)
+        expect(data).to eq("my_ca")
+        expect(job.reload.options[:extra_vars][:engine_cafile]).to eq(ec_file_path)
+      end
+
+      it "deletes the ca_string var" do
+        job.signal(:start)
+        expect(job.reload.options[:extra_vars][:ca_string]).to be_nil
+      end
+    end
+
+    context "ca_string not given" do
+      it "does not create a tmp dir for certs" do
+        job.signal(:start)
+        expect(job.context[:ansible_cert_dir]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a CA string is passed as an extra_var create a temporary directory
and in it create a file with the string as its content.
Pass the path of the file as the engine_cafile to the Ansible role.

This is part of implementing: https://bugzilla.redhat.com/show_bug.cgi?id=1644605