### PR TITLE
Add supports_conversion_host to Host

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/host.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/host.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Redhat::InfraManager::Host < ::Host
-  MINIMUM_CONVERSION_HOST_VERSION = '4.2.4'.freeze
-
   def provider_object(connection = nil)
     ovirt_services_class = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Builder
                            .build_from_ems_or_connection(:ems => ext_management_system, :connection => connection)
@@ -27,9 +25,10 @@ class ManageIQ::Providers::Redhat::InfraManager::Host < ::Host
     end
   end
 
+  # The minimum supported version is 4.2.4, so we hard code it here.
   supports :conversion_host do
     version = ext_management_system.api_version
-    if version.nil? || Gem::Version.new(version) < Gem::Version.new(MINIMUM_CONVERSION_HOST_VERSION)
+    if version.nil? || Gem::Version.new(version) < Gem::Version.new('4.2.4')
       unsupported_reason_add(:conversion_host, 'RHV API version does not support conversion_host')
     end
   end

--- a/app/models/manageiq/providers/redhat/infra_manager/host.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/host.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Redhat::InfraManager::Host < ::Host
+  MINIMUM_CONVERSION_HOST_VERSION = '4.2.4'.freeze
+
   def provider_object(connection = nil)
     ovirt_services_class = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Builder
                            .build_from_ems_or_connection(:ems => ext_management_system, :connection => connection)
@@ -22,6 +24,13 @@ class ManageIQ::Providers::Redhat::InfraManager::Host < ::Host
   supports :quick_stats do
     unless ext_management_system.supports_quick_stats?
       unsupported_reason_add(:quick_stats, 'RHV API version does not support quick_stats')
+    end
+  end
+
+  supports :conversion_host do
+    version = ext_management_system.api_version
+    if version.nil? || Gem::Version.new(version) < Gem::Version.new(MINIMUM_CONVERSION_HOST_VERSION)
+      unsupported_reason_add(:conversion_host, 'RHV API version does not support conversion_host')
     end
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/host_spec.rb
@@ -3,12 +3,26 @@ describe ManageIQ::Providers::Redhat::InfraManager::Host do
   describe '#quickStats' do
     let(:ems) { FactoryBot.create(:ems_redhat_with_authentication) }
     subject { FactoryBot.create(:host_redhat, :ems_id => ems.id) }
+
     before(:each) do
       allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager)
         .to receive(:supported_api_versions).and_return([4])
     end
+
     it '.supports_quick_stats?' do
       expect(subject.supports_quick_stats?).to be true
+    end
+
+    it '.supports_conversion_host?' do
+      allow(subject.ext_management_system).to receive(:api_version).and_return('4.2.4')
+      expect(subject.supports_conversion_host?).to be true
+    end
+
+    it 'does not support_conversion_host? if the minimum api_version is not met' do
+      message = 'RHV API version does not support conversion_host'
+      allow(subject.ext_management_system).to receive(:api_version).and_return('4.2.3')
+      expect(subject.supports_conversion_host?).to be false
+      expect(subject.unsupported_reason(:conversion_host)).to eql(message)
     end
 
     it 'calls list on StatisticsService' do


### PR DESCRIPTION
This sets `supports :conversion_host` to the Host model.

The main purpose for this is for the ManageIQ REST API, where support for `conversion_host` will be checked before attempting to enable or disable the resource.

Part of the V2V effort.