### PR TITLE
Fix parse_targeted_inventory to call inv.parse

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
@@ -75,7 +75,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
       _log.debug "#{log_header} Parsing inventory..."
       hashes, = Benchmark.realtime_block(:parse_inventory) do
         if ems.use_graph_refresh?
-          inventory.inventory_collections
+          inventory.parse
         else
           Parse::ParserBuilder.new(ems).build.ems_inv_to_hashes(inventory)
         end


### PR DESCRIPTION
Instead of calling inventory.inventory_collections and return an array
of inventory collections, convention is to call inventory.parse and
return a persister which is handled easier by the subsequent
save_inventory method.