### PR TITLE
Replace custom snapshot_parent saver

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -519,6 +519,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :uid_ems        => snapshot.id,
         :uid            => snapshot.id,
         :parent_uid     => parent_id,
+        :parent         => persister.snapshots.lazy_find(parent_id),
         :name           => name,
         :description    => description,
         :create_time    => snapshot.date.getutc,

--- a/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_collections.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_collections.rb
@@ -47,7 +47,6 @@ module ManageIQ::Providers::Redhat::Inventory::Persister::Definitions::InfraColl
   def add_vms_dependency_collections_group
     add_ems_folder_children
     add_ems_cluster_children
-    add_snapshot_parent
   end
 
   def add_datacenters_group

--- a/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/vms_collections.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/vms_collections.rb
@@ -14,6 +14,7 @@ module ManageIQ::Providers::Redhat::Inventory::Persister::Definitions::InfraGrou
     add_collection(infra, :snapshots) do |builder|
       builder.add_properties(
         :manager_ref => %i(uid),
+        :strategy    => :local_db_find_missing_references,
       )
     end
   end

--- a/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/vms_dependency_collections.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/vms_dependency_collections.rb
@@ -37,18 +37,6 @@ module ManageIQ::Providers::Redhat::Inventory::Persister::Definitions::InfraGrou
     end
   end
 
-  # group :vms_dependency
-  def add_snapshot_parent
-    add_collection(infra, :snapshot_parent, {},
-                   {
-                     :auto_inventory_attributes => false,
-                     :without_model_class       => true
-                   }) do |builder|
-
-      builder.add_dependency_attributes(:snapshots => [collections[:snapshots]])
-    end
-  end
-
   # ---
 
   # Custom save block for ems_folder_children IC


### PR DESCRIPTION
Use a standard lazy_find for the snapshot parent link instead of a
custom saver.