### PR TITLE
Fix sporadic test failure on sorting IDs

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/ovirt_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/ovirt_refresher_spec_common.rb
@@ -7,7 +7,7 @@ module OvirtRefresherSpecCommon
     models.each do |model|
       inventory[model.name] = model.all.collect do |rec|
         rec.attributes.except(*skip_attributes)
-      end.sort { |rec| rec["id"] }
+      end.sort_by { |rec| rec["id"] }
     end
     inventory
   end


### PR DESCRIPTION
When comparing whole tables we need to sort by id, this was done with
`#sort` instead of `#sort_by` leading to sporadic failures.

Example: https://travis-ci.org/ManageIQ/manageiq-providers-ovirt/jobs/497964470