### PR TITLE
Skip VMs missing a cluster when saving relats

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -25,7 +25,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
       ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(cluster.href)
 
-      persister.ems_clusters.find_or_build(ems_ref).assign_attributes(
+      persister.ems_clusters.build(
         :ems_ref       => ems_ref,
         :ems_ref_obj   => ems_ref,
         :uid_ems       => cluster.id,
@@ -151,7 +151,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :connection_state => connection_state,
         :power_state      => power_state,
         :maintenance      => power_state == 'maintenance',
-        :ems_cluster      => persister.ems_clusters.lazy_find(ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(cluster.href)),
+        :ems_cluster      => persister.ems_clusters.lazy_find({:uid_ems => cluster.id}, :ref => :by_uid_ems),
         :ipmi_address     => ipmi_address,
       )
 
@@ -365,7 +365,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :raw_power_state  => template ? "never" : vm.status,
         :boot_time        => vm.try(:start_time),
         :host             => persister.hosts.lazy_find(host_ems_ref),
-        :ems_cluster      => persister.ems_clusters.lazy_find(ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm.cluster.href)),
+        :ems_cluster      => persister.ems_clusters.lazy_find({:uid_ems => vm.cluster.id}, :ref => :by_uid_ems),
         :storages         => storages,
         :storage          => storages.first,
       )

--- a/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_collections.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_collections.rb
@@ -21,7 +21,7 @@ module ManageIQ::Providers::Redhat::Inventory::Persister::Definitions::InfraColl
   # --- IC groups definitions ---
 
   def add_clusters_group
-    add_collection(infra, :ems_clusters)
+    add_ems_clusters
     add_resource_pools
   end
 

--- a/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/cluster_collections.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/cluster_collections.rb
@@ -1,6 +1,14 @@
 module ManageIQ::Providers::Redhat::Inventory::Persister::Definitions::InfraGroup::ClusterCollections
   extend ActiveSupport::Concern
 
+  def add_ems_clusters
+    add_collection(infra, :ems_clusters) do |builder|
+      builder.add_properties(
+        :secondary_refs => {:by_uid_ems => %i(uid_ems)}
+      )
+    end
+  end
+
   # group :ems_clusters
   def add_resource_pools
     add_collection(infra, :resource_pools) do |builder|

--- a/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/vms_dependency_collections.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_group/vms_dependency_collections.rb
@@ -47,7 +47,7 @@ module ManageIQ::Providers::Redhat::Inventory::Persister::Definitions::InfraGrou
       template_collection = inventory_collection.dependency_attributes[:templates].try(:first)
       datacenter_collection = inventory_collection.dependency_attributes[:datacenters].try(:first)
 
-      vms_and_templates = vm_collection.data + template_collection.data
+      vms_and_templates         = (vm_collection.data + template_collection.data).reject { |vm| vm.ems_cluster.nil? }
       indexed_vms_and_templates = vms_and_templates.each_with_object({}) { |vm, obj| (obj[vm.ems_cluster.ems_ref] ||= []) << vm }
 
       datacenter_collection.data.each do |dc|


### PR DESCRIPTION
Fixes the ems_cluster reference from hosts and vms on RHV 4.3 where the cluster href (and thus ems_ref) is of a different format from what can be seen from the vm/host.

The cluster.id is always consistent however which maps to the uid_ems, so we can use a secondary ref index to lazy find the cluster by the id instead of href.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1668720