### PR TITLE
mapping from "powering_up" to "on"

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -36,9 +36,10 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
   end
 
   POWER_STATES = {
-    'up'        => 'on',
-    'down'      => 'off',
-    'suspended' => 'suspended',
+    'up'          => 'on',
+    'powering_up' => 'on',
+    'down'        => 'off',
+    'suspended'   => 'suspended',
   }.freeze
 
   def provider_object(connection = nil)


### PR DESCRIPTION
User story:
"VM don't change power_state until BitLocker password not entered
but if you want enter BitLocker password, you need access to HTML5 console
and if power state unknown HTML5 console is unable
if we are mapped 'powering_up' to 'on' it's solve this problem"