### PR TITLE
Fix refreshing ipmi from host

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -117,11 +117,6 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
       hardware[:guest_devices], guest_device_uids[mor] = host_inv_to_guest_device_hashes(host_inv, switch_uids[mor], ems_inv)
       hardware[:networks] = host_inv_to_network_hashes(host_inv, guest_device_uids[mor])
 
-      ipmi_address = nil
-      if host_inv.attributes.fetch_path(:power_management, :type).to_s.include?('ipmi')
-        ipmi_address = host_inv.attributes.fetch_path(:power_management, :address)
-      end
-
       host_os_version = host_inv[:os][:version] if host_inv[:os]
       ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(host_inv[:href])
       new_result = {
@@ -148,7 +143,6 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
         :host_switches    => switches,
 
       }
-      new_result[:ipmi_address] = ipmi_address unless ipmi_address.blank?
 
       result << new_result
       result_uids[mor] = new_result

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
@@ -47,11 +47,6 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         hardware[:guest_devices], guest_device_uids[host_id] = host_inv_to_guest_device_hashes(host_inv, switch_uids[host_id], ems_inv)
         hardware[:networks] = host_inv_to_network_hashes(host_inv, guest_device_uids[host_id])
 
-        ipmi_address = nil
-        if host_inv.dig(:power_management, :type).to_s.include?('ipmi')
-          ipmi_address = host_inv.dig(:power_management, :address)
-        end
-
         host_os_version = host_inv.dig(:os, :version)
         ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(host_inv.href)
         new_result = {
@@ -75,7 +70,6 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
           :switches         => switches,
           :host_switches    => switches,
         }
-        new_result[:ipmi_address] = ipmi_address unless ipmi_address.blank?
 
         result << new_result
         result_uids[host_id] = new_result

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -126,11 +126,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       nics = collector.collect_host_nics(host)
       ipaddress = host_to_ip(nics, hostname) || host.address
 
-      ipmi_address = nil
-      if host.dig(:power_management, :type).to_s.include?('ipmi')
-        ipmi_address = host.dig(:power_management, :address)
-      end
-
       host_os_version = host.dig(:os, :version)
       ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(host.href)
 
@@ -152,7 +147,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :power_state      => power_state,
         :maintenance      => power_state == 'maintenance',
         :ems_cluster      => persister.ems_clusters.lazy_find({:uid_ems => cluster.id}, :ref => :by_uid_ems),
-        :ipmi_address     => ipmi_address,
       )
 
       host_storages(dc, persister_host)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_graph_target_host_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_graph_target_host_spec.rb
@@ -31,11 +31,15 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       host = @ems.hosts.find_by(:ems_ref => "/api/hosts/f9dbfd16-3c79-4028-9304-9acf3b8857ba")
       EmsRefresh.refresh(host)
       host.reload
-
       expect(serialize_inventory(models_for_host_target)).to eq(saved_inventory)
-
+      host.update_attribute(:ipmi_address, "127.0.0.1")
+      host.update_authentication(:ipmi => {:userid => "a", :password => "a"})
       EmsRefresh.refresh(host)
       host.reload
+
+      expect(Host.count).to eq(2)
+      expect(host.ipmi_address).to eq("127.0.0.1")
+      expect(host.authentications.first.userid).to eq("a")
 
       expect(host.switches.map { |switch| [switch.uid_ems, switch.name] }).to contain_exactly(
         a_collection_containing_exactly("00000000-0000-0000-0000-000000000009", "ovirtmgmt"),


### PR DESCRIPTION
Retrieving ipmi from host is not relevant for rhv anymore due to the
current complexity of fencing so it does not make sense to get it from
the provider.
However if it is set manually by the user, it should not be deleted.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1669011