### PR TITLE
Use the host_geust_devices inventory collection

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -239,7 +239,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         attributes[:network] = persister_nic
       end
 
-      persister.guest_devices.find_or_build_by(
+      persister.host_guest_devices.find_or_build_by(
         :hardware => persister_hardware,
         :uid_ems  => nic.id
       ).assign_attributes(attributes)

--- a/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_collections.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/definitions/infra_collections.rb
@@ -52,6 +52,7 @@ module ManageIQ::Providers::Redhat::Inventory::Persister::Definitions::InfraColl
 
   def add_hosts_group
     %i(hosts
+       host_guest_devices
        host_hardwares
        host_networks
        host_operating_systems


### PR DESCRIPTION
Prevent duplication of host guest_devices by using the correct
association.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1691109