### PR TITLE
Don't collect security groups in rhev refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
@@ -10,11 +10,12 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
       targets_with_data = targets.collect do |target|
         _log.info "Filtering inventory for #{target.class} [#{target.name}] id: [#{target.id}]..."
 
+        ems_api_version = inventory.service.version_string.match(/([\d][\.\d]+)/)
         if ems.use_graph_refresh?
           data = ManageIQ::Providers::Redhat::Inventory.build(ems, target)
 
           # TODO: remove when graph refresh supports ems updates
-          ems.api_version = inventory.service.version_string
+          ems.api_version = ems_api_version
           ems.save
         else
           case target
@@ -35,9 +36,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
 
         case ems.highest_allowed_api_version
         when '3'
-          data[:ems_api_version] = {:api_version => inventory.service.version_string}
+          data[:ems_api_version] = {:api_version => ems_api_version}
         when '4'
-          data.instance_variable_set(:@ems_api_version, :api_version => inventory.service.version_string)
+          data.instance_variable_set(:@ems_api_version, :api_version => ems_api_version)
         end
 
         _log.info "Filtering inventory...Complete"

--- a/app/models/manageiq/providers/redhat/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector/network_manager.rb
@@ -1,4 +1,8 @@
 class ManageIQ::Providers::Redhat::Inventory::Collector::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Collector::NetworkManager
+  def security_groups
+    []
+  end
+
   def tenants
     @tenants = manager.openstack_handle.tenants
   end

--- a/app/models/manageiq/providers/redhat/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector/network_manager.rb
@@ -1,9 +1,20 @@
 class ManageIQ::Providers::Redhat::Inventory::Collector::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Collector::NetworkManager
   def security_groups
-    []
+    supports_security_groups? ? super : []
   end
 
   def tenants
     @tenants = manager.openstack_handle.tenants
+  end
+
+  private
+
+  def supports_security_groups?
+    rhv_api_version >= Gem::Version.new("4.3") || rhv_api_version < Gem::Version.new("4.2.7")
+  end
+
+  def rhv_api_version
+    infra_manager = manager.parent_manager
+    Gem::Version.new(infra_manager.api_version) if infra_manager.api_version
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -104,7 +104,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
   def assert_ems
     expect(@ems).to have_attributes(
-      :api_version => "4.2.0_master.",
+      :api_version => "4.2.0",
       :uid_ems     => nil
     )
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -70,7 +70,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
   def assert_ems
     expect(@ems).to have_attributes(
-      :api_version => "4.2.0_master.",
+      :api_version => "4.2.0",
       :uid_ems     => nil
     )
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -14,6 +14,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
   it "will perform a full refresh on v4.1" do
     EmsRefresh.refresh(@ems)
+    @ems.reload
     VCR.use_cassette("#{described_class.name.underscore}_ovn_provider") do
       Fog::OpenStack.instance_variable_set(:@version, nil)
       EmsRefresh.refresh(@ems.network_manager)


### PR DESCRIPTION
Wanted to get the conversation started here with @borod108 and @aufi
Is this an appropriate solution for both ovirt and openstack?

@borod108 I'd like to add a rhv version check, something like:

```
def security_groups
  manager.api_version > 4.2.6 && manager.api_version < 4.3 ? [] : super
end
```

Can you help with the correct versions to check for there?

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649886