### PR TITLE
Fix refreshing vm ips - multiple reported devices

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -426,7 +426,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
     devices = collector.collect_vm_devices(vm)
     devices.to_miq_a.each do |device|
       nets = device.ips
-      return addresses unless nets
+      next unless nets
 
       ipaddresses = ipaddresses(addresses, device, nets)
       ipaddresses.each do |ipv4address, ipv6address|

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -87,7 +87,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(Lan.count).to eq(3)
     expect(MiqScsiLun.count).to eq(0)
     expect(MiqScsiTarget.count).to eq(0)
-    expect(Network.count).to eq(6)
+    expect(Network.count).to eq(8)
     expect(OperatingSystem.count).to eq(20)
     expect(Snapshot.count).to eq(17)
     expect(Switch.count).to eq(3)
@@ -518,6 +518,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       )
       nic.lan == @lan
 
+      expect(v.ipaddresses).to eq(["10.35.18.141", "10.8.198.74", "2620:52:0:2310:21a:4aff:fe16:151", "fe80::292b:fe88:1efc:ed5a", "2620:52:0:8c4:77cd:1729:6e0f:d0fa", "fe80::21a:4aff:fe16:151"])
+
       guest_device = v.hardware.guest_devices.find_by(:device_name => "nic1")
       expect(guest_device.network).not_to be_nil
       expect(guest_device.network).to have_attributes(
@@ -526,7 +528,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :hostname    => "vm-18-82.eng.lab.tlv.redhat.com"
       )
 
-      expect(v.hardware.networks.size).to eq(2)
+      expect(v.hardware.networks.size).to eq(4)
       network = v.hardware.networks.find_by(:ipv6address => "fe80::21a:4aff:fe16:151")
       expect(network).not_to be_nil
       expect(network).to have_attributes(

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -53,7 +53,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(Lan.count).to eq(3)
     expect(MiqScsiLun.count).to eq(0)
     expect(MiqScsiTarget.count).to eq(0)
-    expect(Network.count).to eq(6)
+    expect(Network.count).to eq(8)
     expect(OperatingSystem.count).to eq(20)
     expect(Snapshot.count).to eq(17)
     # the old code expects 3 and new 2
@@ -493,7 +493,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :hostname    => "vm-18-82.eng.lab.tlv.redhat.com"
       )
 
-      expect(v.hardware.networks.size).to eq(2)
+      expect(v.hardware.networks.size).to eq(4)
       network = v.hardware.networks.find_by(:ipv6address => "fe80::21a:4aff:fe16:151")
       expect(network).not_to be_nil
       expect(network).to have_attributes(

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
@@ -5161,6 +5161,38 @@ https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f
                     <type>network</type>
                     <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
                 </reported_device>
+                <reported_device href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/76697262-7230-2d6e-6963-35323a35343a" id="76697262-7230-2d6e-6963-35323a35343a">
+                  <name>virbr0-nic</name>
+                  <description>guest reported data</description>
+                  <mac>
+                    <address>52:54:00:0d:fe:94</address>
+                  </mac>
+                  <type>network</type>
+                  <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+                </reported_device>
+                <reported_device href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/656e7333-3030-3a31-613a-34613a35313a" id="656e7333-3030-3a31-613a-34613a35313a">
+                  <name>ens3</name>
+                  <description>guest reported data</description>
+                  <ips>
+                    <ip>
+                      <address>10.8.198.74</address>
+                      <version>v4</version>
+                    </ip>
+                    <ip>
+                      <address>2620:52:0:8c4:77cd:1729:6e0f:d0fa</address>
+                      <version>v6</version>
+                    </ip>
+                    <ip>
+                      <address>fe80::292b:fe88:1efc:ed5a</address>
+                      <version>v6</version>
+                    </ip>
+                  </ips>
+                  <mac>
+                    <address>00:1a:4a:51:00:0f</address>
+                  </mac>
+                  <type>network</type>
+                  <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+                </reported_device>
             </reported_devices>
             <vnic_profile href="/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903" id="361634d2-4975-4ef7-8429-c009871ce903"/>
         </nic>
@@ -5200,6 +5232,38 @@ https://localhost:8443/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f
             </mac>
             <type>network</type>
             <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+        </reported_device>
+        <reported_device href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/76697262-7230-2d6e-6963-35323a35343a" id="76697262-7230-2d6e-6963-35323a35343a">
+          <name>virbr0-nic</name>
+          <description>guest reported data</description>
+          <mac>
+            <address>52:54:00:0d:fe:94</address>
+          </mac>
+          <type>network</type>
+          <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
+        </reported_device>
+        <reported_device href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/656e7333-3030-3a31-613a-34613a35313a" id="656e7333-3030-3a31-613a-34613a35313a">
+          <name>ens3</name>
+          <description>guest reported data</description>
+          <ips>
+            <ip>
+              <address>10.8.198.74</address>
+              <version>v4</version>
+            </ip>
+            <ip>
+              <address>2620:52:0:8c4:77cd:1729:6e0f:d0fa</address>
+              <version>v6</version>
+            </ip>
+            <ip>
+              <address>fe80::292b:fe88:1efc:ed5a</address>
+              <version>v6</version>
+            </ip>
+          </ips>
+          <mac>
+            <address>00:1a:4a:51:00:0f</address>
+          </mac>
+          <type>network</type>
+          <vm href="/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f" id="3a9401a0-bf3d-4496-8acf-edd3e903511f"/>
         </reported_device>
     </reported_devices>
   :code: 200


### PR DESCRIPTION
When a vm would have several network reported devices and one of them
would not have an ipaddress we would not get the ips from all the
devices that come after it.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1686884