### PR TITLE
Implement provisioning independent thin VM

### DIFF
--- a/app/models/manageiq/providers/redhat/dialog_field_visibility_service.rb
+++ b/app/models/manageiq/providers/redhat/dialog_field_visibility_service.rb
@@ -1,0 +1,8 @@
+class ManageIQ::Providers::Redhat::DialogFieldVisibilityService < ::DialogFieldVisibilityService
+  attr_reader :number_of_vms_visibility_service
+
+  def initialize(*args)
+    super(*args)
+    @linked_clone_visibility_service = ManageIQ::Providers::Redhat::LinkedCloneVisibilityService.new
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -528,7 +528,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
         cluster = ovirt_services.cluster_from_href(options[:cluster], connection)
         template = get
         clone = options[:clone_type] == :full
-        disk_attachments = clone ? build_disk_attachments(template, options[:sparse], options[:storage], options[:name]) : nil
+        disk_attachments = build_disk_attachments(template, options[:sparse], options[:storage], options[:name], options[:disk_format])
         vm = build_vm_from_hash(:name             => options[:name],
                                 :template         => template,
                                 :cluster          => cluster,
@@ -536,9 +536,9 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
         vms_service.add(vm, :clone => clone)
       end
 
-      def build_disk_attachments(template, sparse, storage_href, vm_name)
+      def build_disk_attachments(template, sparse, storage_href, vm_name, disk_format)
         disk_attachments = connection.follow_link(template.disk_attachments)
-        apply_sparsity_on_disk_attachments(disk_attachments, sparse) unless sparse.nil?
+        apply_sparsity_on_disk_attachments(disk_attachments, sparse, disk_format) unless sparse.nil?
         apply_storage_domain_on_disk_attachments(disk_attachments, storage_href) unless storage_href.nil?
         apply_name_on_disk_attachments(disk_attachments, vm_name)
         disk_attachments
@@ -556,9 +556,10 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
         end
       end
 
-      def apply_sparsity_on_disk_attachments(disk_attachments, sparse)
+      def apply_sparsity_on_disk_attachments(disk_attachments, sparse, disk_format)
         return if sparse.nil?
         disk_attachments.each do |disk_attachment|
+          disk_attachment.disk.format = disk_format
           disk_attachment.disk.sparse = sparse
         end
       end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -150,14 +150,6 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
     super(:force_platform => 'linux')
   end
 
-  def update_field_visibility_linked_clone(_options = {}, f)
-    show_flag = supports_native_clone? ? :edit : :hide
-    f[show_flag] << :linked_clone
-
-    show_flag = supports_linked_clone? ? :hide : :edit
-    f[show_flag] << :disk_format
-  end
-
   def allowed_customization_templates(options = {})
     if supports_native_clone?
       if get_source_vm&.platform == 'windows'
@@ -202,6 +194,16 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
   def set_on_vm_id_changed
     @datacenter_by_vm = nil
     super
+  end
+
+  def fields_to_clear
+    [:placement_host_name,
+     :placement_ds_name,
+     :placement_folder_name,
+     :placement_cluster_name,
+     :placement_rp_name,
+     :snapshot,
+     :placement_dc_name]
   end
 
   def allowed_hosts_obj(_options = {})
@@ -282,5 +284,10 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
     if get_source_vm.platform == 'windows'
       _("Template sealing is supported only for non-Windows OS.")
     end
+  end
+
+  def dialog_field_visibility_service
+    @dialog_field_visibility_service ||= ManageIQ::Providers::Redhat::DialogFieldVisibilityService.new
+    @dialog_field_visibility_service
   end
 end

--- a/app/models/manageiq/providers/redhat/linked_clone_visibility_service.rb
+++ b/app/models/manageiq/providers/redhat/linked_clone_visibility_service.rb
@@ -1,0 +1,14 @@
+class ManageIQ::Providers::Redhat::LinkedCloneVisibilityService
+  def determine_visibility(provision_type, _linked_clone, _snapshot_count)
+    field_names_to_edit = []
+    field_names_to_hide = []
+
+    if provision_type.to_s == 'native_clone'
+      field_names_to_edit += [:linked_clone]
+    else
+      field_names_to_hide += [:linked_clone]
+    end
+
+    { :hide => field_names_to_hide, :edit => field_names_to_edit }
+  end
+end

--- a/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4_spec.rb
@@ -286,11 +286,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V
     RSpec::Matchers.define :vm_with_properly_set_disk_attachments do |opts|
       sparsity = opts[:sparse]
       storage_domain_href = opts[:storage]
+      disk_format = opts[:disk_format]
       match do |actual|
         actual.disk_attachments.inject(true) do |res, disk_attachment|
           res &&= (disk_attachment.disk.sparse == sparsity)
           res &&= all_storage_domains_match_href?(disk_attachment.disk, storage_domain_href) if storage_domain_href
           res &&= (disk_attachment.disk.name =~ /#{opts[:name]}_Disk\d/)
+          res &&= (disk_attachment.disk.format == disk_format)
           res
         end
       end
@@ -336,16 +338,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V
       context "clone_type is full" do
         let(:create_options) { { :sparse => true } }
         it "requests to clone the vm as independant and sets the disk attachments attributes" do
-          opts = {:name => "provision_vm", :cluster => "/api/clusters/href", :clone_type => :full, :sparse => false, :storage => "/api/storagedomains/href"}
+          opts = {:name => "provision_vm", :cluster => "/api/clusters/href", :clone_type => :full, :sparse => false, :storage => "/api/storagedomains/href", :disk_foramt => "cow"}
           expect(@vms_service).to receive(:add).with(vm_with_properly_set_disk_attachments(opts), :clone => true)
-          @ovirt_services.start_clone(@source_template, opts, {})
-        end
-      end
-
-      context "clone_type is thin" do
-        it "requests to clone the vm as dependant and does not set the disk attachments attributes" do
-          opts = {:name => "provision_vm", :cluster => "/api/clusters/href", :clone_type => :thin, :sparse => true, :storage => "/api/storagedomains/href"}
-          expect(@vms_service).to receive(:add).with(vm_with_disk_attachments_not_set, :clone => false)
           @ovirt_services.start_clone(@source_template, opts, {})
         end
       end


### PR DESCRIPTION
Add the show the linked_clone button in the provisioning dialog so the
user can specify if they want the clone to be linked(dependant) or not
(clone/independent)

requires: https://github.com/ManageIQ/manageiq/pull/18833
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1712934