### PR TITLE
[WIP] Fix iscsi storage duplication

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
@@ -54,11 +54,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         location = if storage_type == 'NFS' || storage_type == 'GLUSTERFS'
                      "#{storage_inv.dig(:storage, :address)}:#{storage_inv.dig(:storage, :path)}"
                    else
-                     # TODO: this is taking only one location for some reason. Need to investigate
-                     # how this is used
-                     logical_units = storage_inv.dig(:storage, :volume_group, :logical_units)
-                     logical_unit =  logical_units && logical_units.first
-                     logical_unit && logical_unit.id
+                     storage_inv.dig(:storage, :volume_group, :id)
                    end
 
         free        = storage_inv.try(:available).to_i

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -44,9 +44,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       location = if storage_type == 'NFS' || storage_type == 'GLUSTERFS'
                    "#{storagedomain.dig(:storage, :address)}:#{storagedomain.dig(:storage, :path)}"
                  else
-                   logical_units = storagedomain.dig(:storage, :volume_group, :logical_units)
-                   logical_unit =  logical_units && logical_units.first
-                   logical_unit && logical_unit.id
+                   storagedomain.dig(:storage, :volume_group, :id)
                  end
 
       free        = storagedomain.try(:available).to_i


### PR DESCRIPTION
Storages are identified by their location attribute, which in the case
of the iscsi was based on the id of the first lun in the volume group.
Order of the returned luns is not guarnteed so this would sometimes
change if the luns were changed on the provider side.

We will now base the location on the volume_group id.