### PR TITLE
Pass id to AR::Base find, not AR::Base objs

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
@@ -98,7 +98,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       target_hash, target_klass, target_find = ep_class.parse_new_target(add_vm_event, description, @ems, name)
 
       new_vm = VCR.use_cassette("#{described_class.name.underscore}_target_new_vm", :allow_unused_http_interactions => true) do
-        EmsRefresh.refresh_new_target(@ems, target_hash, target_klass, target_find)
+        EmsRefresh.refresh_new_target(@ems.id, target_hash, target_klass, target_find)
       end
 
       # Check the new vm's uid matches the event


### PR DESCRIPTION
On Rails 5.1, this raises an ArgumentError.

```
  1) ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher targeted refresh of a Vm should refresh new vm
     Failure/Error: ems = ExtManagementSystem.find(ems_id)

     ArgumentError:
       You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.
     # ./spec/manageiq/app/models/ems_refresh.rb:108:in `refresh_new_target'
     # ./spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb:101:in `block (4 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb:100:in `block (3 levels) in <top (required)>'
```