### PR TITLE
Add skeletal provisioning to V4

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -524,6 +524,12 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       end
 
       def create_vm(options)
+        return create_skeletal_vm(options) if options[:clone_type] == :skeletal
+
+        create_cloned_vm(options)
+      end
+
+      def create_cloned_vm(options)
         vms_service = connection.system_service.vms_service
         cluster = ovirt_services.cluster_from_href(options[:cluster], connection)
         template = get
@@ -534,6 +540,55 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
                                 :cluster          => cluster,
                                 :disk_attachments => disk_attachments)
         vms_service.add(vm, :clone => clone)
+      end
+
+      def create_skeletal_vm(options)
+        vms_service = connection.system_service.vms_service
+        cluster = ovirt_services.cluster_from_href(options[:cluster], connection)
+        template = get
+        vm = build_vm_from_hash(:name     => options[:name],
+                                :template => blank_template_sdk_obj,
+                                :cluster  => cluster)
+        vm_res = vms_service.add(vm, :clone => false)
+        add_disk_attachments_to_vm(template, vm_res, vms_service, options)
+        vm_res
+      end
+
+      def blank_template_sdk_obj
+        connection.system_service.templates_service.template_service("00000000-0000-0000-0000-000000000000").get
+      end
+
+      def add_disk_attachments_to_vm(template, vm_res, vms_service, options)
+        disk_attachments = build_skeletal_disk_attachments(template, options[:sparse], options[:storage], options[:name], options[:disk_format])
+        disk_attachments_service = vms_service.vm_service(vm_res.id).disk_attachments_service
+        disk_attachments.each do |disk_attachment|
+          disk_attachments_service.add(disk_attachment)
+        end
+      end
+
+      def build_skeletal_disk_attachments(template, sparse, storage_href, vm_name, disk_format)
+        disk_attachments = connection.follow_link(template.disk_attachments)
+        apply_full_disk_details_on_diks_attachments(disk_attachments)
+        apply_sparsity_on_disk_attachments(disk_attachments, sparse, disk_format) unless sparse.nil?
+        apply_storage_domain_on_disk_attachments(disk_attachments, storage_href) unless storage_href.nil?
+        apply_name_on_disk_attachments(disk_attachments, vm_name)
+        nullify_disk_ids(disk_attachments)
+        disk_attachments
+      end
+
+      def nullify_disk_ids(disk_attachments)
+        disk_attachments.each do |disk_attachment|
+          disk_attachment.disk.href = nil
+          disk_attachment.disk.id = nil
+        end
+      end
+
+      def apply_full_disk_details_on_diks_attachments(disk_attachments)
+        disk_attachments.each do |disk_attachment|
+          current_disk = disk_attachment.disk
+          disk = connection.system_service.disks_service.disk_service(current_disk.id).get
+          disk_attachment.disk = disk
+        end
       end
 
       def build_disk_attachments(template, sparse, storage_href, vm_name, disk_format)

--- a/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4_spec.rb
@@ -298,6 +298,20 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V
       end
     end
 
+    RSpec::Matchers.define :disk_attachments_with_properly_set_attributes do |opts|
+      sparsity = opts[:sparse]
+      storage_domain_href = opts[:storage]
+      disk_format = opts[:disk_format]
+      match do |disk_attachment|
+        res = true
+        res &&= (disk_attachment.disk.sparse == sparsity)
+        res &&= all_storage_domains_match_href?(disk_attachment.disk, storage_domain_href) if storage_domain_href
+        res &&= (disk_attachment.disk.name =~ /#{opts[:name]}_Disk\d/)
+        res &&= (disk_attachment.disk.format == disk_format)
+        res &&= disk_attachment.disk.id.nil?
+        res
+      end
+    end
     RSpec::Matchers.define :vm_with_disk_attachments_not_set do
       match { |actual| actual.disk_attachments.blank? }
     end
@@ -311,8 +325,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V
         @source_template = double("template")
         storage_domain = OvirtSDK4::StorageDomain.new(:href => "/api/storagedomains/href")
         storage_domain_old = OvirtSDK4::StorageDomain.new(:href => "/api/storagedomains/href_old")
-        disk = OvirtSDK4::Disk.new(:storage_domains => [storage_domain_old])
-        disk2 = OvirtSDK4::Disk.new(:storage_domains => [storage_domain_old])
+        disk = OvirtSDK4::Disk.new(:id => "disk_id1", :storage_domains => [storage_domain_old])
+        disk2 = OvirtSDK4::Disk.new(:id => "disk_id2", :storage_domains => [storage_domain_old])
         @disk_attachments = [OvirtSDK4::DiskAttachment.new(:disk => disk), OvirtSDK4::DiskAttachment.new(:disk => disk2)]
         @sdk_template = OvirtSDK4::Template.new(:disk_attachments => @disk_attachments)
         @ems = FactoryBot.create(:ems_redhat_with_authentication)
@@ -333,13 +347,34 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V
         allow(@source_template).to receive(:with_provider_object).and_yield(rhevm_template)
         allow(connection).to receive(:follow_link).with(@sdk_template.disk_attachments).and_return(@disk_attachments)
         allow(@ovirt_services).to receive(:populate_phase_context)
+        allow(rhevm_template).to receive(:blank_template_sdk_obj).and_return(OvirtSDK4::Template.new)
+        @disks_service = double(OvirtSDK4::DisksService)
+        @disk_service = double(OvirtSDK4::DiskService)
+        allow(system_services).to receive(:disks_service).and_return(@disks_service)
+        @disk1_service = double(OvirtSDK4::Disk, :get => disk)
+        @disk2_service = double(OvirtSDK4::Disk, :get => disk2)
+        allow(@disks_service).to receive(:disk_service).with(disk.id).and_return(@disk1_service)
+        allow(@disks_service).to receive(:disk_service).with(disk2.id).and_return(@disk2_service)
+        @vm_service = double(OvirtSDK4::VmService, :disk_attachments_service => @sdk_template.disk_attachments)
+        allow(@vms_service).to receive(:vm_service).and_return(@vm_service)
       end
 
       context "clone_type is full" do
         let(:create_options) { { :sparse => true } }
         it "requests to clone the vm as independant and sets the disk attachments attributes" do
-          opts = {:name => "provision_vm", :cluster => "/api/clusters/href", :clone_type => :full, :sparse => false, :storage => "/api/storagedomains/href", :disk_foramt => "cow"}
+          opts = {:name => "provision_vm", :cluster => "/api/clusters/href", :clone_type => :full, :sparse => false, :storage => "/api/storagedomains/href", :disk_format => "cow"}
           expect(@vms_service).to receive(:add).with(vm_with_properly_set_disk_attachments(opts), :clone => true)
+          @ovirt_services.start_clone(@source_template, opts, {})
+        end
+      end
+
+      context "clone_type is skeletal" do
+        let(:create_options) { { :sparse => true } }
+        it "requests to clone the vm as independant and sets the disk attachments attributes" do
+          opts = {:name => "provision_vm", :cluster => "/api/clusters/href", :clone_type => :skeletal, :sparse => false, :storage => "/api/storagedomains/href", :disk_format => "cow"}
+          expect(@vms_service).to receive(:add).and_return(OvirtSDK4::Vm.new(:id => "new_vm_id"))
+          expect(@sdk_template.disk_attachments).to receive(:add).with(disk_attachments_with_properly_set_attributes(opts))
+          expect(@sdk_template.disk_attachments).to receive(:add).with(disk_attachments_with_properly_set_attributes(opts))
           @ovirt_services.start_clone(@source_template, opts, {})
         end
       end


### PR DESCRIPTION
We did not implement skeletal provisioning for V4, the idea is to create
a new VM with new disks that have the same parameters as the original
ones but are not cloned.
The VM will have the blank template as its original template.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1716929