### PR TITLE
[WIP] Fix count changed by setup of parent ems in factory

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
@@ -59,7 +59,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(ExtManagementSystem.count).to eq(1)
     expect(EmsFolder.count).to eq(7)
     expect(EmsCluster.count).to eq(4)
-    expect(Host.count).to eq(2)
+    expect(Host.count).to eq(1)
     expect(ResourcePool.count).to eq(4)
     expect(VmOrTemplate.count).to eq(38)
     expect(Vm.count).to eq(27)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -37,7 +37,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(ExtManagementSystem.count).to eq(2)
     expect(EmsFolder.count).to eq(7)
     expect(EmsCluster.count).to eq(3)
-    expect(Host.count).to eq(3)
+    expect(Host.count).to eq(1)
     expect(ResourcePool.count).to eq(3)
     expect(VmOrTemplate.count).to eq(17)
     expect(Vm.count).to eq(14)


### PR DESCRIPTION
Since we are now validating that provider types exist and are supported, the ems specs needed to only use leaf subclasses (as it makes no sense to add, or test, an intermediate class) so https://github.com/ManageIQ/manageiq/pull/18842/files broke a bunch of the provider repos in which we are testing things we'll never actually use in real code. 