### PR TITLE
Fix host ip address parsing

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -170,7 +170,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
       end
     end
 
-    unless ipaddress.nil?
+    if ipaddress.nil?
       warn_msg = "IP lookup for host in VIM inventory data...Failed."
       if [nil, "localhost", "localhost.localdomain", "127.0.0.1"].include?(hostname)
         _log.warn warn_msg

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -599,7 +599,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       end
     end
 
-    unless ipaddress.nil?
+    if ipaddress.nil?
       unless [nil, "localhost", "localhost.localdomain", "127.0.0.1"].include?(hostname)
         begin
           ipaddress = Socket.getaddrinfo(hostname, nil)[0][3]

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
@@ -196,7 +196,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :ems_ref_obj      => "/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db",
       :name             => "per410-rh1",
       :hostname         => "192.168.252.232",
-      :ipaddress        => "10.35.18.14",
+      :ipaddress        => "192.168.252.232",
       :uid_ems          => "2f1d11cc-e269-11e2-839c-005056a217db",
       :vmm_vendor       => "redhat",
       :vmm_version      => nil,

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -312,7 +312,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :ems_ref_obj      => "/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a",
         :name             => "bodh1",
         :hostname         => "bodh1.usersys.redhat.com",
-        :ipaddress        => "10.35.18.14",
+        :ipaddress        => "10.35.19.12",
         :uid_ems          => "5bf6b336-f86d-4551-ac08-d34621ec5f0a",
         :vmm_vendor       => "redhat",
         :vmm_version      => "7",

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_spec.rb
@@ -279,7 +279,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
         :ems_ref_obj      => "/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a",
         :name             => "bodh1",
         :hostname         => "bodh1.usersys.redhat.com",
-        :ipaddress        => "10.35.18.14",
+        :ipaddress        => "10.35.19.12",
         :uid_ems          => "5bf6b336-f86d-4551-ac08-d34621ec5f0a",
         :vmm_vendor       => "redhat",
         :vmm_version      => "7",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,3 @@
-RSpec.configure do |config|
-  config.before(:each) do
-    allow(Socket).to receive(:getaddrinfo).and_return([["AF_INET", 0, "10.35.18.14", "10.35.18.14", 2, 1, 6], ["AF_INET", 0, "10.35.18.14", "10.35.18.14", 2, 2, 17], ["AF_INET", 0, "10.35.18.14", "10.35.18.14", 2, 3, 0]])
-  end
-end
-
 if ENV['CI']
   require 'simplecov'
   SimpleCov.start


### PR DESCRIPTION
There was an issue parsing the host ipaddress where if it were present
it would be overwritten by a DNS lookup, instead of doing the DNS lookup
if it were nil.  This led to a number of workarounds in the specs to
stub the Socket.getaddrinfo call which wouldn't be needed if it used the
ip addr from inventory properly.