### PR TITLE
Remove old redhat refresh_parser

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -8,7 +8,6 @@ class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::Network
   require_nested :MetricsCollectorWorker
   require_nested :NetworkPort
   require_nested :NetworkRouter
-  require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
   require_nested :SecurityGroup

--- a/app/models/manageiq/providers/redhat/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresh_parser.rb
@@ -1,4 +1,0 @@
-module ManageIQ::Providers
-  class Redhat::NetworkManager::RefreshParser < Openstack::NetworkManager::RefreshParser
-  end
-end


### PR DESCRIPTION
We removed a bunch of old refresh parsers and this one needs to go, as well. 

Thank, Adam!

@miq-bot assign @agrare 