### PR TITLE
PGError does not exist anymore

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -522,7 +522,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
         message = error.message
         message = error.message[6..-1] if message.starts_with?('FATAL:')
         message = message.strip
-        _log.warn("PG::Error: #{message}")
+        _log.warn("#{error.class.name}: #{message}")
         MiqException::MiqEVMLoginError.new(message)
       else
         MiqException::MiqEVMLoginError.new(error.to_s)

--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -515,7 +515,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     # @return [Exception] The exception that the ManageIQ expects.
     #
     # @api private
-    #rhevm_metrics_connect_options
+    # rhevm_metrics_connect_options
     def adapt_metrics_error(error)
       case error
       when PG::Error

--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -515,14 +515,14 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     # @return [Exception] The exception that the ManageIQ expects.
     #
     # @api private
-    #
+    #rhevm_metrics_connect_options
     def adapt_metrics_error(error)
       case error
-      when PGError
+      when PG::Error
         message = error.message
         message = error.message[6..-1] if message.starts_with?('FATAL:')
         message = message.strip
-        _log.warn("PGError: #{message}")
+        _log.warn("PG::Error: #{message}")
         MiqException::MiqEVMLoginError.new(message)
       else
         MiqException::MiqEVMLoginError.new(error.to_s)

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -49,9 +49,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       it 'raises MiqEVMLoginError in case of connection error' do
         msg = "FATAL:  no pg_hba.conf entry for host ...."
         allow(OvirtMetrics).to receive(:connect).and_raise(msg)
-        expect {
-          ems.verify_credentials('metrics')
-        }.to raise_error(MiqException::MiqEVMLoginError)
+        expect { ems.verify_credentials('metrics') }.to raise_error(MiqException::MiqEVMLoginError)
       end
     end
   end

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -48,7 +48,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     context "metrics" do
       it 'raises MiqEVMLoginError in case of connection error' do
         msg = "FATAL:  no pg_hba.conf entry for host ...."
-        allow(OvirtMetrics).to receive(:connect).and_raise(msg)
+        allow(OvirtMetrics).to receive(:connect).and_raise(PG::ConnectionBad, msg)
         expect { ems.verify_credentials('metrics') }.to raise_error(MiqException::MiqEVMLoginError)
       end
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -42,6 +42,20 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     end
   end
 
+  describe "verify_credentials" do
+    let(:ems) { FactoryBot.create(:ems_redhat) }
+
+    context "metrics" do
+      it 'raises MiqEVMLoginError in case of connection error' do
+        msg = "FATAL:  no pg_hba.conf entry for host ...."
+        allow(OvirtMetrics).to receive(:connect).and_raise(msg)
+        expect {
+          ems.verify_credentials('metrics')
+        }.to raise_error(MiqException::MiqEVMLoginError)
+      end
+    end
+  end
+
   context "#vm_reconfigure" do
     context "version 4" do
       context "#vm_reconfigure" do


### PR DESCRIPTION
With new versions of the gem, pg has changed the error hierarchy.
The usage of PGError was causing problems in displaying the correct
exception in case of Postgres connection errors (wrong credentials,
db versions, ...)

Related to BZ bug: https://bugzilla.redhat.com/show_bug.cgi?id=1734770