### PR TITLE
Fix AnsibleRoleWorkflow spec

### DIFF
--- a/spec/models/manageiq/providers/redhat/ansible_role_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/ansible_role_workflow_spec.rb
@@ -17,17 +17,17 @@ describe ManageIQ::Providers::Redhat::AnsibleRoleWorkflow do
   end
 
   context "per_role" do
-    let(:state) { "waiting_to_start" }
+    let(:state) { "pre_execute" }
     context "ca_string given" do
       let(:extra_vars)   { { :arg1 => "res1", :ca_string => "my_ca" } }
       it "creates a tmp dir for certs in pre role" do
-        job.signal(:start)
+        job.signal(:pre_execute)
         expect(job.context[:ansible_cert_dir]).not_to be_nil
         expect(File.directory?(job.context[:ansible_cert_dir])).to be_truthy
       end
 
       it "creates a file and adds its path to the extra vars" do
-        job.signal(:start)
+        job.signal(:pre_execute)
         ec_file_path = job.options[:extra_vars][:engine_cafile]
         expect(ec_file_path).not_to be_nil
         data = File.read(ec_file_path)
@@ -36,14 +36,14 @@ describe ManageIQ::Providers::Redhat::AnsibleRoleWorkflow do
       end
 
       it "deletes the ca_string var" do
-        job.signal(:start)
+        job.signal(:pre_execute)
         expect(job.reload.options[:extra_vars][:ca_string]).to be_nil
       end
     end
 
     context "ca_string not given" do
       it "does not create a tmp dir for certs" do
-        job.signal(:start)
+        job.signal(:pre_execute)
         expect(job.context[:ansible_cert_dir]).to be_nil
       end
     end


### PR DESCRIPTION
The start method in the base class changed from calling pre_execute
directly to signaling it as a state transition in [1].

This caused this spec to fail because the expectations assumed the
pre_execute method had run.

[1] https://github.com/ManageIQ/manageiq/pull/19145