### PR TITLE
Mock revoke_access_token

### DIFF
--- a/spec/support/ovirt_sdk/connection_vcr.rb
+++ b/spec/support/ovirt_sdk/connection_vcr.rb
@@ -42,6 +42,11 @@ module Spec::Support::OvirtSDK
       super
     end
 
+    def revoke_access_token
+      return unless is_recording
+      super
+    end
+
     def http_response_to_hash(http_response)
       {
         :body    => http_response.body,

--- a/spec/support/ovirt_sdk/connection_vcr.rb
+++ b/spec/support/ovirt_sdk/connection_vcr.rb
@@ -44,6 +44,7 @@ module Spec::Support::OvirtSDK
 
     def revoke_access_token
       return unless is_recording
+
       super
     end
 


### PR DESCRIPTION
Hitting the real revoke_access_token implementation was causing specs to hang on some OS (depending on the tcp timeout)