### PR TITLE
Preserving Last Boot time

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -282,6 +282,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
   def network_from_nic(nic, dc, networks)
     return unless dc
+
     network_id = nic.dig(:network, :id)
     if network_id
       # TODO: check to indexed_networks = networks.index_by(:id)
@@ -354,7 +355,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
                              else
                                persister.vms
                              end
-      persister_vm = collection_persister.find_or_build(vm.id).assign_attributes(
+      attrs_to_assign = {
         :type             => template ? "ManageIQ::Providers::Redhat::InfraManager::Template" : "ManageIQ::Providers::Redhat::InfraManager::Vm",
         :ems_ref          => ems_ref,
         :ems_ref_obj      => ems_ref,
@@ -367,14 +368,17 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :memory_limit     => extract_vm_memory_policy(vm, :max),
         :memory_reserve   => vm_memory_reserve(vm),
         :raw_power_state  => template ? "never" : vm.status,
-        :boot_time        => vm.try(:start_time),
         :host             => host,
         :ems_cluster      => persister.ems_clusters.lazy_find({:uid_ems => vm.cluster.id}, :ref => :by_uid_ems),
         :storages         => storages,
         :storage          => storages.first,
         :parent           => parent_folder,
-        :resource_pool    => resource_pool,
-      )
+        :resource_pool    => resource_pool
+      }
+      boot_time = vm.try(:start_time)
+      attrs_to_assign[:boot_time] = boot_time unless boot_time.nil?
+
+      persister_vm = collection_persister.find_or_build(vm.id).assign_attributes(attrs_to_assign)
 
       snapshots(persister_vm, vm)
       vm_hardware(persister_vm, vm, disks, template, host)
@@ -490,6 +494,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
     collector.collect_nics(vm).each do |nic|
       next if nic.blank?
+
       mac = nic.mac && nic.mac.address ? nic.mac.address : nil
       network = mac && networks.present? ? networks[mac] : nil
 
@@ -524,6 +529,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
   def snapshots(persister_vm, vm)
     snaps = []
     return snaps if vm.try(:snapshots).nil?
+
     snapshots = collector.collect_snapshots(vm)
     snapshots = snapshots.sort_by(&:date).reverse
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_async_graph_spec.rb
@@ -68,6 +68,23 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(VmOrTemplate.where(:uid_ems => "3a9401a0-bf3d-4496-8acf-edd3e903511f").count).to eq 1
   end
 
+  it 'preserve last boot time after vm refresh' do
+    vm = FactoryBot.create(:vm_redhat,
+                           :ext_management_system => @ems,
+                           :ems_ref               => "/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d",
+                           :ems_ref_obj           => "/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d",
+                           :uid_ems               => "1010ec66-5d68-4ae6-b72b-824f5885259d",
+                           :vendor                => "redhat",
+                           :boot_time             => Time.zone.parse("2017-08-02T06:53:36.148"),
+                           :raw_power_state       => "up")
+
+    EmsRefresh.refresh(@ems)
+    @ems.reload
+
+    refresh_vm = VmOrTemplate.find_by(:uid_ems => "1010ec66-5d68-4ae6-b72b-824f5885259d")
+    expect(refresh_vm.boot_time).to eq(vm.boot_time)
+  end
+
   def assert_table_counts(_lan_number)
     expect(ExtManagementSystem.count).to eq(2)
     expect(EmsFolder.count).to eq(7)


### PR DESCRIPTION
When a vm goes in down status, the start_time info is missing and we can
avoid to overwrite with a nil the information we may already have.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1571895