### PR TITLE
Fix specs - numeric only passwords

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4_spec.rb
@@ -3,7 +3,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4 do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryBot.create(:ems_redhat, :zone => zone, :hostname => "localhost", :ipaddress => "localhost",
                               :port => 8443)
-    @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
+    @ems.update_authentication(:default => {:userid => "admin@internal", :password => "pass123"})
     @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
     allow(@ems).to(receive(:supported_api_versions).and_return([3, 4]))
     stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/ovirt_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/ovirt_refresher_spec_common.rb
@@ -28,7 +28,7 @@ module OvirtRefresherSpecCommon
                  zone: @zone)
     @ems = FactoryBot.create(:ems_redhat, :zone => zone, :hostname => hostname, :ipaddress => ipaddress,
                              :port => port)
-    @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
+    @ems.update_authentication(:default => {:userid => "admin@internal", :password => "pass123"})
     @ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
     allow(@ems).to(receive(:supported_api_versions).and_return(%w(3 4)))
 

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_ovn_provider.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_ovn_provider.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456},"tenantName":"admin"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -78,7 +78,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456},"tenantName":"admin"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -161,7 +161,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456},"tenantName":"admin"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -202,7 +202,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456},"tenantName":"admin"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -243,7 +243,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456},"tenantName":"admin"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -284,7 +284,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456},"tenantName":"admin"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -325,7 +325,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456},"tenantName":"admin"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -366,7 +366,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456},"tenantName":"admin"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -407,7 +407,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456}}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -480,7 +480,7 @@ http_interactions:
     uri: http://localhost:35357/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":123456},"tenantName":"tenant"}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":pass123},"tenantName":"tenant"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0


### PR DESCRIPTION
Specs were red due to having numeric only passwords for OVN.
See: https://github.com/ManageIQ/manageiq-providers-openstack/pull/504
This changes the spec passwords to alphanumeric strings.