### PR TITLE
Add supports_conversion_host to Vm

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -35,6 +35,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
     end
   end
 
+  supports :conversion_host
+
   POWER_STATES = {
     'up'          => 'on',
     'powering_up' => 'on',

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -159,6 +159,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
     end
   end
 
+  describe "#support_conversion_host" do
+    it "supports conversion_host" do
+      expect(FactoryBot.create(:vm_redhat).supports_conversion_host?).to eq true
+    end
+  end
+
   describe "#disconnect_storage" do
     before(:each) do
       _, _, zone = EvmSpecHelper.create_guid_miq_server_zone


### PR DESCRIPTION
With the introduction of the Unified Conversion host Image (UCI), the conversion hosts will be virtual machines in either OpenStack or RHV. Currently, only hosts are allowed as conversion hosts in RHV. This PR is to adds the support for VMs.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1749775
