### PR TITLE
Data-Driven create params and validate_credentials

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -195,6 +195,17 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
         :name      => "endpoints.metrics.database",
         :label     => "Database Name"
       },
+      {
+        :component => "text-field",
+        :name      => "endpoints.ssh.username",
+        :label     => "Username"
+      },
+      {
+        :component => "text-field",
+        :name      => "endpoints.ssh.private_key",
+        :label     => "Private Key",
+        :type      => "password"
+      }
     ]
   }.freeze
 

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -128,6 +128,80 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     self::EventCatcher
   end
 
+  PARAMS_FOR_CREATE = {
+    :title  => "Configure Ovirt",
+    :fields => [
+      {
+        :component  => "text-field",
+        :name       => "endpoints.default.server",
+        :label      => "Server Hostname/IP Address",
+        :isRequired => true,
+        :validate   => [{:type => "required-validator"}]
+      },
+      {
+        :component  => "text-field",
+        :name       => "endpoints.default.username",
+        :label      => "Username",
+        :isRequired => true,
+        :validate   => [{:type => "required-validator"}]
+      },
+      {
+        :component  => "text-field",
+        :name       => "endpoints.default.password",
+        :label      => "Password",
+        :type       => "password",
+        :isRequired => true,
+        :validate   => [{:type => "required-validator"}]
+      },
+      {
+        :component => "text-field",
+        :name      => "endpoints.default.port",
+        :label     => "Port",
+        :type      => "number",
+      },
+      {
+        :component => "checkbox",
+        :name      => "endpoints.default.verify_ssl",
+        :label     => "Verify SSL"
+      },
+      {
+        :component => "text-field",
+        :name      => "endpoints.default.ca_certs",
+        :label     => "Certificate Authority Certificates"
+      },
+      {
+        :component  => "text-field",
+        :name       => "endpoints.metrics.username",
+        :label      => "Username",
+        :isRequired => true,
+        :validate   => [{:type => "required-validator"}]
+      },
+      {
+        :component  => "text-field",
+        :name       => "endpoints.metrics.password",
+        :label      => "Password",
+        :type       => "password",
+        :isRequired => true,
+        :validate   => [{:type => "required-validator"}]
+      },
+      {
+        :component => "text-field",
+        :name      => "endpoints.metrics.port",
+        :label     => "Port",
+        :type      => "number",
+      },
+      {
+        :component => "text-field",
+        :name      => "endpoints.metrics.database",
+        :label     => "Database Name"
+      },
+    ]
+  }.freeze
+
+  def self.params_for_create
+    PARAMS_FOR_CREATE
+  end
+
   def host_quick_stats(host)
     qs = {}
     with_provider_connection(:version => 4) do |connection|

--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -248,6 +248,51 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       end
     end
 
+    # Validate Credentials
+    #
+    # args: {
+    #   "endpoints" => {
+    #     "default" => {
+    #       "username" => String,
+    #       "password" => String,
+    #       "server" => String,
+    #       "port" => Integer,
+    #       "verify_ssl" => [VERIFY_NONE, VERIFY_PEER],
+    #       "ca_certs" => String
+    #     },
+    #     "metrics" => {
+    #       "metrics_username" => String,
+    #       "metrics_password" => String,
+    #       "metrics_port" => Integer,
+    #     }
+    #   }
+    # }
+    def validate_credentials(args)
+      default_endpoint = args.dig("endpoints", "default")
+      metrics_endpoint = args.dig("endpoints", "metrics")
+
+      username, password, server, port, verify_ssl, ca_certs = default_endpoint&.values_at(
+        "username", "password", "server", "port", "verify_ssl", "ca_certs"
+      )
+
+      metrics_username, metrics_password, metrics_port, metrics_database = metrics_endpoint&.values_at(
+        "metrics_username", "metrics_password", "metrics_port", "metrics_database"
+      )
+
+      raw_connect(
+        :username         => username,
+        :password         => password,
+        :server           => server,
+        :port             => port,
+        :verify_ssl       => verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE,
+        :ca_certs         => ca_certs,
+        :metrics_username => metrics_username,
+        :metrics_password => metrics_password,
+        :metrics_port     => metrics_port,
+        :metrics_database => metrics_database
+      )
+    end
+
     #
     # This method is called only when the UI button to verify the connection details is clicked. It isn't used create
     # the connections actually used by the provider.
@@ -265,7 +310,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     #   be checked.
     # @option opts [String] :ca_certs The custom trusted CA certificates used to check the TLS certificates of the
     #   API server, in PEM format. A blank or nil value means that no custom CA certificates should be used.
-    # @option opts [String] :metrics_userid The name of the metrics database user.
+    # @option opts [String] :metrics_username The name of the metrics database user.
     # @option opts [String] :metrics_password The password of the metrics database user.
     # @options opts [String] :metrics_server The host name or IP address of the metrics database server.
     # @options opts [Integer] :metrics_port ('5432') The port number of the metrics database server.


### PR DESCRIPTION
Add a data-driven-forms params_for_create allowing dynamic API driven
UI form building and add the standard validate_credentials API.