### PR TITLE
Replace PARAMS_FOR_CREATE constant with @ ||=

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -129,89 +129,87 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     self::EventCatcher
   end
 
-  PARAMS_FOR_CREATE = {
-    :title  => "Configure Ovirt",
-    :fields => [
-      {
-        :component  => "text-field",
-        :name       => "endpoints.default.server",
-        :label      => "Server Hostname/IP Address",
-        :isRequired => true,
-        :validate   => [{:type => "required-validator"}]
-      },
-      {
-        :component  => "text-field",
-        :name       => "endpoints.default.username",
-        :label      => "Username",
-        :isRequired => true,
-        :validate   => [{:type => "required-validator"}]
-      },
-      {
-        :component  => "text-field",
-        :name       => "endpoints.default.password",
-        :label      => "Password",
-        :type       => "password",
-        :isRequired => true,
-        :validate   => [{:type => "required-validator"}]
-      },
-      {
-        :component => "text-field",
-        :name      => "endpoints.default.port",
-        :label     => "Port",
-        :type      => "number",
-      },
-      {
-        :component => "checkbox",
-        :name      => "endpoints.default.verify_ssl",
-        :label     => "Verify SSL"
-      },
-      {
-        :component => "text-field",
-        :name      => "endpoints.default.ca_certs",
-        :label     => "Certificate Authority Certificates"
-      },
-      {
-        :component  => "text-field",
-        :name       => "endpoints.metrics.username",
-        :label      => "Username",
-        :isRequired => true,
-        :validate   => [{:type => "required-validator"}]
-      },
-      {
-        :component  => "text-field",
-        :name       => "endpoints.metrics.password",
-        :label      => "Password",
-        :type       => "password",
-        :isRequired => true,
-        :validate   => [{:type => "required-validator"}]
-      },
-      {
-        :component => "text-field",
-        :name      => "endpoints.metrics.port",
-        :label     => "Port",
-        :type      => "number",
-      },
-      {
-        :component => "text-field",
-        :name      => "endpoints.metrics.database",
-        :label     => "Database Name"
-      },
-      {
-        :component => "text-field",
-        :name      => "endpoints.ssh.username",
-        :label     => "Username"
-      },
-      {
-        :component => "text-field",
-        :name      => "endpoints.ssh.private_key",
-        :label     => "Private Key",
-        :type      => "password"
-      }
-    ]
-  }.freeze
-
   def self.params_for_create
-    PARAMS_FOR_CREATE
+    @params_for_create ||= {
+      :title  => "Configure Ovirt",
+      :fields => [
+        {
+          :component  => "text-field",
+          :name       => "endpoints.default.server",
+          :label      => "Server Hostname/IP Address",
+          :isRequired => true,
+          :validate   => [{:type => "required-validator"}]
+        },
+        {
+          :component  => "text-field",
+          :name       => "endpoints.default.username",
+          :label      => "Username",
+          :isRequired => true,
+          :validate   => [{:type => "required-validator"}]
+        },
+        {
+          :component  => "text-field",
+          :name       => "endpoints.default.password",
+          :label      => "Password",
+          :type       => "password",
+          :isRequired => true,
+          :validate   => [{:type => "required-validator"}]
+        },
+        {
+          :component => "text-field",
+          :name      => "endpoints.default.port",
+          :label     => "Port",
+          :type      => "number",
+        },
+        {
+          :component => "checkbox",
+          :name      => "endpoints.default.verify_ssl",
+          :label     => "Verify SSL"
+        },
+        {
+          :component => "text-field",
+          :name      => "endpoints.default.ca_certs",
+          :label     => "Certificate Authority Certificates"
+        },
+        {
+          :component  => "text-field",
+          :name       => "endpoints.metrics.username",
+          :label      => "Username",
+          :isRequired => true,
+          :validate   => [{:type => "required-validator"}]
+        },
+        {
+          :component  => "text-field",
+          :name       => "endpoints.metrics.password",
+          :label      => "Password",
+          :type       => "password",
+          :isRequired => true,
+          :validate   => [{:type => "required-validator"}]
+        },
+        {
+          :component => "text-field",
+          :name      => "endpoints.metrics.port",
+          :label     => "Port",
+          :type      => "number",
+        },
+        {
+          :component => "text-field",
+          :name      => "endpoints.metrics.database",
+          :label     => "Database Name"
+        },
+        {
+          :component => "text-field",
+          :name      => "endpoints.ssh.username",
+          :label     => "Username"
+        },
+        {
+          :component => "text-field",
+          :name      => "endpoints.ssh.private_key",
+          :label     => "Private Key",
+          :type      => "password"
+        }
+      ]
+    }.freeze
   end
 
   def host_quick_stats(host)


### PR DESCRIPTION
Prevent people from using the constant directly by defining
`@params_for_create ||= {}.freeze`