### PR TITLE
Fix slow specs

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
@@ -20,7 +20,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       before(:each) do
         @ems         = FactoryBot.create(:ems_redhat_with_authentication)
         @vm_template = FactoryBot.create(:template_redhat, :name => "template1", :ext_management_system => @ems, :operating_system => @os, :cpu_limit => -1, :cpu_reserve => 0)
-        @vm          = FactoryBot.create(:vm_redhat, :name => "vm1",       :location => "abc/def.vmx")
+        @vm          = FactoryBot.create(:vm_redhat, :name => "vm1", :location => "abc/def.vmx")
         @pr          = FactoryBot.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
         @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
         @vm_prov = FactoryBot.create(:miq_provision_redhat, :userid => @admin.userid, :miq_request => @pr, :source => @vm_template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
@@ -47,17 +47,17 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
         end
 
         it "with :default disk_format value" do
-          @vm_prov.options[:disk_format] = %w(default Default)
+          @vm_prov.options[:disk_format] = %w[default Default]
           expect(@vm_prov.sparse_disk_value).to be_nil
         end
 
         it "with :thin disk_format value" do
-          @vm_prov.options[:disk_format] = %w(thin Thin)
+          @vm_prov.options[:disk_format] = %w[thin Thin]
           expect(@vm_prov.sparse_disk_value).to be_truthy
         end
 
         it "with :preallocated disk_format value" do
-          @vm_prov.options[:disk_format] = %w(preallocated Preallocated)
+          @vm_prov.options[:disk_format] = %w[preallocated Preallocated]
           expect(@vm_prov.sparse_disk_value).to be_falsey
         end
       end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
@@ -168,6 +168,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
         context "customize_destination" do
           it "when destination_image_locked is false" do
             allow(@vm_prov).to receive(:for_destination).and_return("display_string")
+            allow(@vm_prov).to receive(:destination_disks_locked?).and_return(false)
             expect(@vm_prov).to receive(:configure_container)
 
             @vm_prov.customize_destination

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -139,6 +139,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
       let(:vm) { FactoryBot.create(:vm_redhat, :ext_management_system => ems, :storage => storage) }
 
       it "does not support publish" do
+        allow(ems).to receive(:supported_api_versions).and_return([4])
         allow(vm).to receive(:power_state).and_return("on")
 
         expect(vm.supports_publish?).to be_falsey

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -169,8 +169,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
   describe "#unregister" do
     before do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-      @ems  = FactoryBot.create(:ems_redhat_with_authentication, :zone => zone)
-      @vm   = FactoryBot.create(:vm_redhat, :ext_management_system => @ems)
+      @ems = FactoryBot.create(:ems_redhat_with_authentication, :zone => zone)
+      @vm = FactoryBot.create(:vm_redhat, :ext_management_system => @ems)
       @vm_proxy = double("OvirtSDK4::Vm.new")
       @vm_service = double("OvirtSDK4::Vm")
     end


### PR DESCRIPTION
Two specs were slow 'cause they were hitting low level libraries (OvirtSDK4) waiting for the timeout.
This PR introduces mock values and some lint fixes