### PR TITLE
Excluding archived vms from reconfigurable? method.

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure
   # Show Reconfigure VM task
   def reconfigurable?
-    true
+    active?
   end
 
   def max_total_vcpus

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm/reconfigure_spec.rb
@@ -1,9 +1,28 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure do
   let(:storage) { FactoryBot.create(:storage_nfs, :ems_ref => "http://example.com/storages/XYZ") }
-  let(:vm) { FactoryBot.create(:vm_redhat, :storage => storage) }
+  let(:vm)      { FactoryBot.create(:vm_redhat, :storage => storage) }
 
-  it "#reconfigurable?" do
-    expect(vm.reconfigurable?).to be_truthy
+  describe "#reconfigurable?" do
+    let(:vm_active)   { FactoryBot.create(:vm_redhat, :storage => storage, :ext_management_system => ems) }
+    let(:vm_retired)  { FactoryBot.create(:vm_redhat, :retired => true, :storage => storage, :ext_management_system => ems) }
+    let(:vm_archived) { FactoryBot.create(:vm_redhat) }
+    let(:ems)         { FactoryBot.create(:ext_management_system) }
+
+    it 'returns true for active vm' do
+      expect(vm_active.reconfigurable?).to be_truthy
+    end
+
+    it 'returns false for orphaned vm' do
+      expect(vm.reconfigurable?).to be_falsey
+    end
+
+    it 'returns false for retired vm' do
+      expect(vm_retired.reconfigurable?).to be_falsey
+    end
+
+    it 'returns false for archived vm' do
+      expect(vm_archived.reconfigurable?).to be_falsey
+    end
   end
 
   it "#max_total_vcpus" do


### PR DESCRIPTION
As a result of request from related BZ below we are excluding archived vms from being able to be reconfigurable. Similar change is being made in 1 more repository(https://github.com/ManageIQ/manageiq-providers-vmware/pull/467).

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1743533