### PR TITLE
Add exception to the too short parameters name

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,3 +1,8 @@
 GlobalVars:
   AllowedVariables:
-    - $rhevm_log
+  - $rhevm_log
+
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+  - vm
+  - dc


### PR DESCRIPTION
Parameter names like 'vm' and 'dc' seem to be enough meaninful despite
they are less than three characters length