### PR TITLE
Remove two unused methods

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -76,14 +76,6 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     supported_auth_types.include?(authtype.to_s)
   end
 
-  def rhevm_service
-    @rhevm_service ||= connect(:service => "Service")
-  end
-
-  def rhevm_inventory
-    @rhevm_inventory ||= connect(:service => "Inventory")
-  end
-
   def ovirt_services
     @ovirt_services ||= ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4.new(:ems => self)
   end


### PR DESCRIPTION
rhevm_inventory and rhevm_service seems are not used anywhere in the
code

@miq-bot add_label cleanup