### PR TITLE
Remove ems_ref_obj

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
@@ -121,7 +121,6 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParser
     dc_hash = {
         :type         => 'Datacenter',
         :ems_ref      => dc_ems_ref,
-        :ems_ref_obj  => dc_ems_ref,
         :uid_ems      => dc.id,
         :ems_children => {:folders => [vm_folder_hash, host_folder_hash]}
     }
@@ -133,14 +132,15 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParser
     ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm_data.href)
 
     template = ems_ref.include?('/templates/')
+    type     = template ? "ManageIQ::Providers::Redhat::InfraManager::Template" : "ManageIQ::Providers::Redhat::InfraManager::Vm"
+
     vm_id = vm_data.id
     vm_hash = {
-        :type => template ? "ManageIQ::Providers::Redhat::InfraManager::Template" : "ManageIQ::Providers::Redhat::InfraManager::Vm",
-        :ems_ref => ems_ref,
-        :ems_ref_obj => ems_ref,
-        :uid_ems => vm_id,
-        :vendor => "redhat",
-        :name => parse_target_name(message, event_type),
+        :type     => type,
+        :ems_ref  => ems_ref,
+        :uid_ems  => vm_id,
+        :vendor   => "redhat",
+        :name     => parse_target_name(message, event_type),
         :location => "#{vm_id}.ovf",
         :template => template,
     }
@@ -160,7 +160,6 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParser
 
     cluster_hash = {
         :ems_ref      => cluster_ref,
-        :ems_ref_obj  => cluster_ref,
         :uid_ems      => cluster_data.id,
         :name         => cluster_name,
         :ems_children => {:resource_pools => []}

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/relocation.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/relocation.rb
@@ -20,8 +20,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Relocation
       raise _("The VM '%{name}' can not be migrated to the same host it is already running on.") % {:name => name}
     end
 
-    host_mor = host.ems_ref_obj
-    pool_mor = pool.ems_ref_obj
+    host_mor = host.ems_ref
+    pool_mor = pool.ems_ref
     run_command_via_parent(:vm_migrate, :host => host_mor, :pool => pool_mor, :priority => priority, :state => state)
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
@@ -26,7 +26,7 @@ module ManageIQ::Providers::Redhat::InfraManager::VmImport
       :password          => auth.password,
       :url               => vmware_import_url(source_provider, vm),
       :cluster_id        => EmsCluster.find(target_params[:cluster_id]).uid_ems,
-      :storage_domain_id => Storage.find(target_params[:storage_id]).ems_ref_obj.split('/').last,
+      :storage_domain_id => Storage.find(target_params[:storage_id]).ems_ref.split('/').last,
       :sparse            => target_params[:sparse],
       :drivers_iso       => target_params[:drivers_iso] != '' ? target_params[:drivers_iso] : nil
     )

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -52,7 +52,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
       persister.clusters.build(
         :ems_ref     => ems_ref,
-        :ems_ref_obj => ems_ref,
         :uid_ems     => cluster.id,
         :name        => cluster.name,
         :parent      => cluster_parent,
@@ -78,7 +77,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
       persister.storages.find_or_build(ems_ref).assign_attributes(
         :ems_ref             => ems_ref,
-        :ems_ref_obj         => ems_ref,
         :name                => storagedomain.try(:name),
         :store_type          => storage_type,
         :storage_domain_type => storagedomain.dig(:type, :downcase),
@@ -109,7 +107,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :name        => datacenter.name,
         :type        => 'Datacenter',
         :ems_ref     => ems_ref,
-        :ems_ref_obj => ems_ref,
         :uid_ems     => uid,
         :parent      => persister.ems_folders.lazy_find("root_dc"),
       )
@@ -161,7 +158,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       persister_host = persister.hosts.find_or_build(ems_ref).assign_attributes(
         :type             => 'ManageIQ::Providers::Redhat::InfraManager::Host',
         :ems_ref          => ems_ref,
-        :ems_ref_obj      => ems_ref,
         :name             => host.name || hostname,
         :hostname         => hostname,
         :ipaddress        => ipaddress,
@@ -365,7 +361,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       attrs_to_assign = {
         :type             => template ? "ManageIQ::Providers::Redhat::InfraManager::Template" : "ManageIQ::Providers::Redhat::InfraManager::Vm",
         :ems_ref          => ems_ref,
-        :ems_ref_obj      => ems_ref,
         :uid_ems          => vm.id,
         :connection_state => "connected",
         :vendor           => "redhat",

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
@@ -36,7 +36,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     FactoryBot.create(:host_redhat,
                        :ext_management_system => nil,
                        :ems_ref               => "/api/hosts/ce40bb38-f10a-43f3-8e15-d0ffad692a19",
-                       :ems_ref_obj           => "/api/hosts/ce40bb38-f10a-43f3-8e15-d0ffad692a19",
                        :name                  => "bodh1",
                        :hostname              => "bodh1.usersys.redhat.com",
                        :ipaddress             => "10.35.19.12",
@@ -54,7 +53,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     @vm = FactoryBot.create(:vm_redhat,
                              :ext_management_system => nil,
                              :ems_ref               => "/api/vms/8070fa6d-5b82-412c-9d41-a00017205c73",
-                             :ems_ref_obj           => "/api/vms/8070fa6d-5b82-412c-9d41-a00017205c73",
                              :uid_ems               => "8070fa6d-5b82-412c-9d41-a00017205c73",
                              :vendor                => "redhat",
                              :raw_power_state       => "up",
@@ -72,7 +70,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     vm = FactoryBot.create(:vm_redhat,
                            :ext_management_system => @ems,
                            :ems_ref               => "/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d",
-                           :ems_ref_obj           => "/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d",
                            :uid_ems               => "1010ec66-5d68-4ae6-b72b-824f5885259d",
                            :vendor                => "redhat",
                            :boot_time             => Time.zone.parse("2017-08-02T06:53:36.148"),
@@ -256,7 +253,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     @cluster = EmsCluster.find_by(:name => 'newd1_cluster')
     expect(@cluster).to have_attributes(
       :ems_ref                 => "/api/clusters/1c273044-e6ca-492f-9ac2-47381b626808",
-      :ems_ref_obj             => "/api/clusters/1c273044-e6ca-492f-9ac2-47381b626808",
       :uid_ems                 => "1c273044-e6ca-492f-9ac2-47381b626808",
       :name                    => "newd1_cluster",
       :ha_enabled              => nil, # TODO: Should be true
@@ -272,7 +268,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
     expect(@default_rp).to have_attributes(
       :ems_ref               => nil,
-      :ems_ref_obj           => nil,
       :name                  => "Default for Cluster newd1_cluster",
       :type                  => "ManageIQ::Providers::Redhat::InfraManager::ResourcePool",
       :uid_ems               => "1c273044-e6ca-492f-9ac2-47381b626808_respool",
@@ -294,7 +289,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     @storage = Storage.find_by(:name => "data_spider_1")
     expect(@storage).to have_attributes(
       :ems_ref                       => "/api/storagedomains/723b4112-1502-4b01-83a7-2ba87d1bbb35",
-      :ems_ref_obj                   => "/api/storagedomains/723b4112-1502-4b01-83a7-2ba87d1bbb35",
       :name                          => "data_spider_1",
       :store_type                    => "NFS",
       :total_space                   => 53_687_091_200,
@@ -310,7 +304,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     @storage2 = Storage.find_by(:name => "venus-data-1")
     expect(@storage2).to have_attributes(
       :ems_ref                       => "/api/storagedomains/26c8cd54-65d4-424f-a870-8145439bba1c",
-      :ems_ref_obj                   => "/api/storagedomains/26c8cd54-65d4-424f-a870-8145439bba1c",
       :name                          => "venus-data-1",
       :store_type                    => "NFS",
       :total_space                   => 207_232_172_032,
@@ -327,7 +320,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       @host = ManageIQ::Providers::Redhat::InfraManager::Host.find_by(:name => "bodh1")
       expect(@host).to have_attributes(
         :ems_ref          => "/api/hosts/ce40bb38-f10a-43f3-8e15-d0ffad692a19",
-        :ems_ref_obj      => "/api/hosts/ce40bb38-f10a-43f3-8e15-d0ffad692a19",
         :name             => "bodh1",
         :hostname         => "bodh1.usersys.redhat.com",
         :ipaddress        => "10.46.10.132",
@@ -552,7 +544,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_datacenter).to have_attributes(
         :ems_ref     => "/api/datacenters/944df9ee-3274-43c4-908f-8c35e59e483b",
-        :ems_ref_obj => "/api/datacenters/944df9ee-3274-43c4-908f-8c35e59e483b",
         :uid_ems     => "944df9ee-3274-43c4-908f-8c35e59e483b",
         :name        => "newd1",
         :type        => "Datacenter",
@@ -561,7 +552,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "root_dc",
         :name        => "Datacenters",
         :type        => nil,
@@ -570,7 +560,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_blue_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "944df9ee-3274-43c4-908f-8c35e59e483b_vm",
         :name        => "vm",
         :type        => nil,
@@ -583,7 +572,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       expect(v).to have_attributes(
         :template              => false,
         :ems_ref               => "/api/vms/8070fa6d-5b82-412c-9d41-a00017205c73",
-        :ems_ref_obj           => "/api/vms/8070fa6d-5b82-412c-9d41-a00017205c73",
         :uid_ems               => "8070fa6d-5b82-412c-9d41-a00017205c73",
         :vendor                => "redhat",
         :raw_power_state       => "down",
@@ -679,7 +667,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_datacenter).to have_attributes(
         :ems_ref     => "/api/datacenters/944df9ee-3274-43c4-908f-8c35e59e483b",
-        :ems_ref_obj => "/api/datacenters/944df9ee-3274-43c4-908f-8c35e59e483b",
         :folder_path => "Datacenters/newd1",
         :name        => "newd1",
         :type        => "Datacenter",
@@ -688,7 +675,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "root_dc",
         :name        => "Datacenters",
         :type        => nil,
@@ -697,7 +683,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_blue_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "944df9ee-3274-43c4-908f-8c35e59e483b_vm",
         :name        => "vm",
         :type        => nil,
@@ -710,7 +695,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       expect(v).to have_attributes(
         :template              => true,
         :ems_ref               => "/api/templates/bcdd6891-68c9-4629-8c72-668c2353ab11",
-        :ems_ref_obj           => "/api/templates/bcdd6891-68c9-4629-8c72-668c2353ab11",
         :uid_ems               => "bcdd6891-68c9-4629-8c72-668c2353ab11",
         :vendor                => "redhat",
         :power_state           => "never",
@@ -781,7 +765,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_datacenter).to have_attributes(
         :ems_ref     => "/api/datacenters/944df9ee-3274-43c4-908f-8c35e59e483b",
-        :ems_ref_obj => "/api/datacenters/944df9ee-3274-43c4-908f-8c35e59e483b",
         :folder_path => "Datacenters/newd1",
         :name        => "newd1",
         :type        => "Datacenter",
@@ -790,7 +773,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "root_dc",
         :name        => "Datacenters",
         :type        => nil,
@@ -799,7 +781,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_blue_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "944df9ee-3274-43c4-908f-8c35e59e483b_vm",
         :name        => "vm",
         :type        => nil,

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_network_spec.rb
@@ -220,7 +220,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     @cluster = EmsCluster.find_by(:name => 'cc1')
     expect(@cluster).to have_attributes(
       :ems_ref                 => "/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf",
-      :ems_ref_obj             => "/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf",
       :uid_ems                 => "504ae500-3476-450e-8243-f6df0f7f7acf",
       :name                    => "cc1",
       :ha_enabled              => nil, # TODO: Should be true
@@ -236,7 +235,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
     expect(@default_rp).to have_attributes(
       :ems_ref               => nil,
-      :ems_ref_obj           => nil,
       :uid_ems               => "504ae500-3476-450e-8243-f6df0f7f7acf_respool",
       :name                  => "Default for Cluster cc1",
       :type                  => "ManageIQ::Providers::Redhat::InfraManager::ResourcePool",
@@ -258,7 +256,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     @storage = Storage.find_by(:name => "data1")
     expect(@storage).to have_attributes(
       :ems_ref                       => "/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02",
-      :ems_ref_obj                   => "/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02",
       :name                          => "data1",
       :store_type                    => "NFS",
       :total_space                   => 53_687_091_200,
@@ -274,7 +271,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     @storage2 = Storage.find_by(:name => "data2")
     expect(@storage2).to have_attributes(
       :ems_ref                       => "/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb",
-      :ems_ref_obj                   => "/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb",
       :name                          => "data2",
       :store_type                    => "NFS",
       :total_space                   => 53_687_091_200,
@@ -291,7 +287,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       @host = ManageIQ::Providers::Redhat::InfraManager::Host.find_by(:name => "bodh1")
       expect(@host).to have_attributes(
         :ems_ref          => "/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a",
-        :ems_ref_obj      => "/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a",
         :name             => "bodh1",
         :hostname         => "bodh1.usersys.redhat.com",
         :ipaddress        => "10.35.19.12",
@@ -401,7 +396,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       expect(v).to have_attributes(
         :template              => false,
         :ems_ref               => "/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f",
-        :ems_ref_obj           => "/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f",
         :uid_ems               => "3a9401a0-bf3d-4496-8acf-edd3e903511f",
         :vendor                => "redhat",
         :raw_power_state       => "up",
@@ -519,7 +513,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_datacenter).to have_attributes(
         :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
-        :ems_ref_obj => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
         :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
         :name        => "dc1",
         :type        => "Datacenter",
@@ -528,7 +521,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "root_dc",
         :name        => "Datacenters",
         :type        => nil,
@@ -537,7 +529,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_blue_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1_vm",
         :name        => "vm",
         :type        => nil,
@@ -550,7 +541,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       expect(v).to have_attributes(
         :template              => false,
         :ems_ref               => "/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d",
-        :ems_ref_obj           => "/api/vms/1010ec66-5d68-4ae6-b72b-824f5885259d",
         :uid_ems               => "1010ec66-5d68-4ae6-b72b-824f5885259d",
         :vendor                => "redhat",
         :raw_power_state       => "down",
@@ -645,7 +635,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_datacenter).to have_attributes(
         :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
-        :ems_ref_obj => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
         :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
         :name        => "dc1",
         :type        => "Datacenter",
@@ -654,7 +643,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "root_dc",
         :name        => "Datacenters",
         :type        => nil,
@@ -663,7 +651,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_blue_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1_vm",
         :name        => "vm",
         :type        => nil,
@@ -676,7 +663,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       expect(v).to have_attributes(
         :template              => true,
         :ems_ref               => "/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79",
-        :ems_ref_obj           => "/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79",
         :uid_ems               => "785e845e-baa0-4812-8a8c-467f37ad6c79",
         :vendor                => "redhat",
         :power_state           => "never",
@@ -747,7 +733,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_datacenter).to have_attributes(
         :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
-        :ems_ref_obj => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
         :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
         :name        => "dc1",
         :type        => "Datacenter",
@@ -756,7 +741,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "root_dc",
         :name        => "Datacenters",
         :type        => nil,
@@ -765,7 +749,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
       expect(v.parent_blue_folder).to have_attributes(
         :ems_ref     => nil,
-        :ems_ref_obj => nil,
         :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1_vm",
         :name        => "vm",
         :type        => nil,

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::VmImport do
   let(:cluster_path_escaped)  { 'Folder1%2FFolder%20%40%23%24*2%2FCompute%203%2FFolder4%2FCluster%205' }
 
   let(:cluster_guid) { cluster.uid_ems }
-  let(:storage_guid) { storage.ems_ref_obj.split('/').last }
+  let(:storage_guid) { storage.ems_ref.split('/').last }
 
   let(:new_name)  { 'created-vm' }
   let(:new_vm_id) { '6820ad2a-a8c0-4b4e-baf2-3482357ba352' }


### PR DESCRIPTION
The ems_ref_obj property was added for VMware because the simple ems_ref
isn't enough to fully identify an object, everyone else simply set
ems_ref_obj = ems_ref which was pointless.

https://github.com/ManageIQ/manageiq/pull/19430