### PR TITLE
The OpenStack Network RefreshWorker was removed

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresh_worker/runner.rb
@@ -1,2 +1,2 @@
-class ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker::Runner < ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker::Runner
+class ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
 end


### PR DESCRIPTION
The NetworkManager::RefreshWorker was removed in https://github.com/ManageIQ/manageiq-providers-openstack/pull/538 because the CloudManager::RefreshWorker does all the work for it.  This was inheriting from the NetworkManager::RefreshWorker::Runner but ther wasn't anything overridden from the BaseManager::RefreshWorker::Runner so we can just inherit directly from that.