### PR TITLE
Update specs to match behavior of change in core PR 19212 (auth user changed)

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
@@ -111,7 +111,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(20)
-    expect(MiqQueue.count).to eq(8)
+    expect(MiqQueue.count).to eq(6)
 
     expect(CloudNetwork.count).to eq(6)
     expect(CloudSubnet.count).to eq(2)


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/19212

This breaks one current spec because the current code triggers `raise_event(:changed)` more often than it should. See https://github.com/ManageIQ/manageiq/pull/19212#issuecomment-526627820 for details.

With the PR in question, the mere act of creation would not trigger an auth changed event, only an update, so the MiqQueue numbers are lower.