### PR TITLE
No need to specify use_ovirt_engine_sdk anymore

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
@@ -25,7 +25,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventParser do
 
     before(:each) do
       inventory_wrapper_class = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4
-      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
       user_mock = load_response_mock_for('user')
       allow_any_instance_of(inventory_wrapper_class)
         .to receive(:username_by_href).and_return("#{user_mock.name}@#{user_mock.domain.name}")

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
@@ -50,7 +50,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
       let(:ovirtSDK4_mac) { OvirtSDK4::Mac.new(:address => mac_address) }
 
       before do
-        stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
         allow(ems.ovirt_services).to receive(:get_vm_proxy).and_return(rhevm_vm)
         allow(rhevm_vm).to receive_messages(:nics => [rhevm_nic1, rhevm_nic2], :ext_management_system => ems)
         allow(ems).to receive(:with_provider_connection).and_yield(connection)

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -83,10 +83,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine do
   end
 
   context "version 4" do
-    before do
-      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
-    end
-
     ## BRANCH STATES
     def test_autostart_destination_with_use_cloud_init
       task.phase_context[:boot_with_cloud_init] = true

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine_spec.rb
@@ -22,17 +22,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
     end
 
     describe "post provisioning" do
-      context "version 4" do
-        before do
-          @vm_service = double("vm_service")
-          allow(@vm).to receive(:with_provider_object).and_yield(@vm_service)
-          stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
-        end
+      let(:vm_service) { double("vm_service") }
 
-        it "#post_provision" do
-          expect(@vm_service).to receive(:update).with(:payloads => [])
-          @task.post_provision
-        end
+      it "#post_provision" do
+        allow(@vm).to receive(:with_provider_object).and_yield(vm_service)
+        expect(vm_service).to receive(:update).with(:payloads => [])
+        @task.post_provision
       end
     end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
@@ -209,7 +209,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
     let!(:template) { FactoryBot.create(:template_redhat, :ext_management_system => ems, :ems_cluster => cluster1) }
 
     before do
-      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
       allow(workflow).to receive(:source_ems).and_return(ems)
       @vlans = {}
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresh_recording_modifier_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresh_recording_modifier_spec.rb
@@ -7,8 +7,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults
     init_connection_vcr
-
-    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
   ORIG_YML_PATH = 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
@@ -7,8 +7,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults(:hostname => 'pluto-vdsg.eng.lab.tlv.redhat.com', :ipaddress => '10.35.19.13', :port => 443)
     init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording.yml')
-
-    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
   it "will perform a full refresh on v4.1" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_custom_attributes_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_custom_attributes_spec.rb
@@ -9,8 +9,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_custom_attrs.yml')
 
     @collector = ManageIQ::Providers::Redhat::Inventory::Collector
-
-    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
   CASSETTE_PATH = "#{described_class.parent.name.underscore}/refresh/refresher_ovn_provider".freeze

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_host_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_host_spec.rb
@@ -14,8 +14,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       @collector = ManageIQ::Providers::Redhat::Inventory::Collector
       allow_any_instance_of(@collector)
                        .to receive(:collect_vnic_profiles).and_return([])
-
-      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
     end
 
     let(:models_for_host_target) { [ExtManagementSystem, EmsFolder, EmsCluster, Storage, HostStorage, Switch, HostSwitch, Lan, CustomAttribute] }

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_template_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_template_spec.rb
@@ -6,8 +6,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults
     init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_graph_target_template.yml')
-
-    stub_settings_merge(:ems => {:ems_redhat => {:use_ovirt_engine_sdk => true}})
   end
 
   COUNTED_MODELS = [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_vm_spec.rb
@@ -13,8 +13,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     @collector = ManageIQ::Providers::Redhat::Inventory::Collector
     allow_any_instance_of(@collector)
                      .to receive(:collect_vnic_profiles).and_return([])
-
-    stub_settings_merge(:ems => {:ems_redhat => {:use_ovirt_engine_sdk => true}})
   end
 
   COUNTED_MODELS = [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_huge_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_huge_async_spec.rb
@@ -10,8 +10,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults
     init_connection_vcr
-
-    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
   ORIG_YML_PATH = 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_lans_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_lans_spec.rb
@@ -7,8 +7,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults(:hostname => 'pluto-vdsg.eng.lab.tlv.redhat.com', :ipaddress => '10.35.19.13', :port => 443)
     init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_lans_refresh_recording.yml')
-
-    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
   it "lans are not duplicated after refresh" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_network_spec.rb
@@ -7,8 +7,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults(:hostname => 'pluto-vdsg.eng.lab.tlv.redhat.com', :port => 443)
     init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_network_recording.yml')
-
-    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
   it "will perform a full refresh on v4.1" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_target_host_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_target_host_4_spec.rb
@@ -13,7 +13,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     stub_settings_merge(
       :ems => {
         :ems_redhat => {
-          :use_ovirt_engine_sdk => true,
           :resolve_ip_addresses => false
         }
       }

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -55,37 +55,23 @@ describe ManageIQ::Providers::Redhat::InfraManager do
   end
 
   context "#vm_reconfigure" do
-    context "version 4" do
-      context "#vm_reconfigure" do
-        before do
-          _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-          @ems = FactoryBot.create(:ems_redhat_with_authentication, :zone => zone)
-          @vm = FactoryBot.create(:vm_redhat, :ext_management_system => @ems)
+    let!(:zone) do
+      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone
+    end
 
-          @rhevm_vm_attrs = double('rhevm_vm_attrs')
-          stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => use_ovirt_engine_sdk } })
-          @v4_strategy_instance = instance_double(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4)
-          allow(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4)
-            .to receive(:new)
-            .and_return(@v4_strategy_instance)
-        end
+    let!(:ems) { FactoryBot.create(:ems_redhat_with_authentication, :zone => zone) }
+    let!(:vm) { FactoryBot.create(:vm_redhat, :ext_management_system => ems) }
+    let(:ovirt_services_instance) { instance_double(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4) }
 
-        context "use_ovirt_engine_sdk is set to true" do
-          let(:use_ovirt_engine_sdk) { true }
-          it 'sends vm_reconfigure to the right ovirt_services' do
-            expect(@v4_strategy_instance).to receive(:vm_reconfigure).with(@vm, {})
-            @ems.vm_reconfigure(@vm)
-          end
-        end
+    it 'sends vm_reconfigure to ovirt_services' do
+      allow(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4)
+        .to receive(:new)
+        .and_return(ovirt_services_instance)
 
-        context "use_ovirt_engine_sdk is set to false" do
-          let(:use_ovirt_engine_sdk) { false }
-          it 'sends vm_reconfigure to the right ovirt_services' do
-            expect(@v4_strategy_instance).to receive(:vm_reconfigure).with(@vm, {})
-            @ems.vm_reconfigure(@vm)
-          end
-        end
-      end
+      expect(ovirt_services_instance).to receive(:vm_reconfigure).with(vm, {})
+
+      ems.vm_reconfigure(vm)
     end
   end
 


### PR DESCRIPTION
We are not using :use_ovirt_engine_sdk property setting 'cause the
ovirt SDK is the only one used right now.
No need to merge settings in specs nor to check with different values