### PR TITLE
We need all VM details

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
@@ -277,7 +277,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
         # Retrieve the current representation of the virtual machine:
         # mandatory for memory parameters and to check if next_run_configuration_exists
 
-        vm = vm_service.get
+        vm = vm_service.get(:all_content => true)
         new_vm_specs = {}
 
         # Update the memory:

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_reconfigure_with_no_restart_needed_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_reconfigure_with_no_restart_needed_recording.yml
@@ -6,21 +6,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
         <cluster href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239" id="112b9702-ee9b-11e9-9d7c-5254005a3239">
             <actions>
                 <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/upgrade" rel="upgrade"/>
-                <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
                 <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
             </actions>
             <name>Default</name>
             <description>The default server cluster</description>
             <comment></comment>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networkfilters" rel="networkfilters"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networks" rel="networks"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glusterhooks" rel="glusterhooks"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glustervolumes" rel="glustervolumes"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/enabledfeatures" rel="enabledfeatures"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
             <ballooning_enabled>false</ballooning_enabled>
             <cpu>
                 <architecture>x86_64</architecture>
@@ -94,21 +94,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
         <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde">
             <actions>
                 <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/upgrade" rel="upgrade"/>
-                <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
                 <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
             </actions>
             <name>depot_cl</name>
             <description></description>
             <comment></comment>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networkfilters" rel="networkfilters"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networks" rel="networks"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glusterhooks" rel="glusterhooks"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glustervolumes" rel="glustervolumes"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/enabledfeatures" rel="enabledfeatures"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
             <ballooning_enabled>false</ballooning_enabled>
             <cpu>
                 <architecture>x86_64</architecture>
@@ -183,12 +183,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
     </clusters>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1453'
-    correlation-id: 66b95940-a781-4221-ab1b-a601b05ed247
+    content-length: '1454'
+    correlation-id: 78a61a4d-aa02-421c-9eb6-ae50b8721def
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -196,21 +196,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
         <cluster href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239" id="112b9702-ee9b-11e9-9d7c-5254005a3239">
             <actions>
                 <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/upgrade" rel="upgrade"/>
-                <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
                 <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
             </actions>
             <name>Default</name>
             <description>The default server cluster</description>
             <comment></comment>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networkfilters" rel="networkfilters"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networks" rel="networks"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glusterhooks" rel="glusterhooks"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glustervolumes" rel="glustervolumes"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/enabledfeatures" rel="enabledfeatures"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
             <ballooning_enabled>false</ballooning_enabled>
             <cpu>
                 <architecture>x86_64</architecture>
@@ -284,21 +284,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
         <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde">
             <actions>
                 <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/upgrade" rel="upgrade"/>
-                <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
                 <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
             </actions>
             <name>depot_cl</name>
             <description></description>
             <comment></comment>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networkfilters" rel="networkfilters"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networks" rel="networks"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glusterhooks" rel="glusterhooks"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glustervolumes" rel="glustervolumes"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/enabledfeatures" rel="enabledfeatures"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
             <ballooning_enabled>false</ballooning_enabled>
             <cpu>
                 <architecture>x86_64</architecture>
@@ -373,12 +373,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
     </clusters>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1453'
-    correlation-id: bf2bc872-ba72-4c43-ba5a-d9f403f17b8e
+    content-length: '1454'
+    correlation-id: 4d082245-4b72-4483-9e38-199e7861c4ce
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
 - :body: |
@@ -394,12 +394,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
             <name>depot_iso</name>
             <description></description>
             <comment></comment>
-            <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/disksnapshots" rel="disksnapshots"/>
-            <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/files" rel="files"/>
             <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/diskprofiles" rel="diskprofiles"/>
             <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/storageconnections" rel="storageconnections"/>
             <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/permissions" rel="permissions"/>
-            <available>517543559168</available>
+            <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/files" rel="files"/>
+            <available>515396075520</available>
             <backup>false</backup>
             <block_size>512</block_size>
             <committed>0</committed>
@@ -417,7 +417,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
             <supports_discard>false</supports_discard>
             <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
             <type>iso</type>
-            <used>18253611008</used>
+            <used>20401094656</used>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <wipe_after_delete>false</wipe_after_delete>
             <data_centers>
@@ -434,17 +434,17 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
             <name>depot_one</name>
             <description></description>
             <comment></comment>
-            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disksnapshots" rel="disksnapshots"/>
-            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/templates" rel="templates"/>
-            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/vms" rel="vms"/>
-            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
             <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
             <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/storageconnections" rel="storageconnections"/>
             <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/permissions" rel="permissions"/>
-            <available>517543559168</available>
+            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disksnapshots" rel="disksnapshots"/>
+            <available>515396075520</available>
             <backup>false</backup>
             <block_size>512</block_size>
-            <committed>16106127360</committed>
+            <committed>25769803776</committed>
             <critical_space_action_blocker>5</critical_space_action_blocker>
             <discard_after_delete>false</discard_after_delete>
             <external_status>ok</external_status>
@@ -459,7 +459,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
             <supports_discard>false</supports_discard>
             <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
             <type>data</type>
-            <used>18253611008</used>
+            <used>20401094656</used>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <wipe_after_delete>false</wipe_after_delete>
             <data_centers>
@@ -469,12 +469,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
     </storage_domains>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '856'
-    correlation-id: 35bc4078-a849-4250-a5d1-b433727de801
+    content-length: '858'
+    correlation-id: 0ae46122-1ae7-4b53-83db-303da7862e2e
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts{}GET:
 - :body: |
@@ -487,34 +487,34 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts{}GET:
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/deactivate" rel="deactivate"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/upgrade" rel="upgrade"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/activate" rel="activate"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/enrollcertificate" rel="enrollcertificate"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/setupnetworks" rel="setupnetworks"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/fence" rel="fence"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/approve" rel="approve"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/commitnetconfig" rel="commitnetconfig"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/enrollcertificate" rel="enrollcertificate"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/forceselectspm" rel="forceselectspm"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/iscsidiscover" rel="iscsidiscover"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/iscsilogin" rel="iscsilogin"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/unregisteredstoragedomainsdiscover" rel="unregisteredstoragedomainsdiscover"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/upgradecheck" rel="upgradecheck"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/syncallnetworks" rel="syncallnetworks"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/approve" rel="approve"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/commitnetconfig" rel="commitnetconfig"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/setupnetworks" rel="setupnetworks"/>
             </actions>
             <name>H1</name>
             <comment></comment>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/storage" rel="storage"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/networkattachments" rel="networkattachments"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/storageconnectionextensions" rel="storageconnectionextensions"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/unmanagednetworks" rel="unmanagednetworks"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/tags" rel="tags"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/fenceagents" rel="fenceagents"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/devices" rel="devices"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/hooks" rel="hooks"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics" rel="nics"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/numanodes" rel="numanodes"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/katelloerrata" rel="katelloerrata"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/permissions" rel="permissions"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/storage" rel="storage"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/storageconnectionextensions" rel="storageconnectionextensions"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/unmanagednetworks" rel="unmanagednetworks"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/statistics" rel="statistics"/>
             <address>host01-43.fritz.box</address>
             <auto_numa_status>disable</auto_numa_status>
@@ -621,34 +621,34 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts{}GET:
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/deactivate" rel="deactivate"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/upgrade" rel="upgrade"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/activate" rel="activate"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/enrollcertificate" rel="enrollcertificate"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/setupnetworks" rel="setupnetworks"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/fence" rel="fence"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/approve" rel="approve"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/commitnetconfig" rel="commitnetconfig"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/enrollcertificate" rel="enrollcertificate"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/forceselectspm" rel="forceselectspm"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/iscsidiscover" rel="iscsidiscover"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/iscsilogin" rel="iscsilogin"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/unregisteredstoragedomainsdiscover" rel="unregisteredstoragedomainsdiscover"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/upgradecheck" rel="upgradecheck"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/syncallnetworks" rel="syncallnetworks"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/approve" rel="approve"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/commitnetconfig" rel="commitnetconfig"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/setupnetworks" rel="setupnetworks"/>
             </actions>
             <name>H2</name>
             <comment></comment>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/storage" rel="storage"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/networkattachments" rel="networkattachments"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/storageconnectionextensions" rel="storageconnectionextensions"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/unmanagednetworks" rel="unmanagednetworks"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/tags" rel="tags"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/fenceagents" rel="fenceagents"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/devices" rel="devices"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/hooks" rel="hooks"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics" rel="nics"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/numanodes" rel="numanodes"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/katelloerrata" rel="katelloerrata"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/permissions" rel="permissions"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/storage" rel="storage"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/storageconnectionextensions" rel="storageconnectionextensions"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/unmanagednetworks" rel="unmanagednetworks"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/statistics" rel="statistics"/>
             <address>host02-43.fritz.box</address>
             <auto_numa_status>disable</auto_numa_status>
@@ -751,34 +751,166 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts{}GET:
     </hosts>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '2305'
-    correlation-id: a0a747b0-b0bd-4e35-95ee-d4ea8019b371
+    content-length: '2306'
+    correlation-id: e43cd7bc-0c3e-402a-926e-3dbbf55e0f75
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <vms>
+        <vm href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696" id="022ce494-f739-40a3-a29a-d26ce125f696">
+            <actions>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/suspend" rel="suspend"/>
+            </actions>
+            <name>deb10</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/backups" rel="backups"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+                <type>i440fx_sea_bios</type>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2019-12-13T11:55:45.246+01:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>true</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>1</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/e90b3fe6-5539-cb53-5631-a45511ae4be7" id="e90b3fe6-5539-cb53-5631-a45511ae4be7"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>2147483648</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <multi_queues_enabled>true</multi_queues_enabled>
+            <origin>rhev</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                        <device>cdrom</device>
+                    </devices>
+                </boot>
+                <type>debian_7</type>
+            </os>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <small_icon href="/ovirt-engine/api/icons/a172d76b-891a-c1c3-4d2c-0b8d578ee71b" id="a172d76b-891a-c1c3-4d2c-0b8d578ee71b"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>server</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c5926295-65ef-4dba-b234-26db503cb59d" id="c5926295-65ef-4dba-b234-26db503cb59d"/>
+            <quota id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <status>down</status>
+            <stop_reason></stop_reason>
+            <stop_time>2019-12-13T19:37:05.960+01:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
         <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
             <actions>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
@@ -787,22 +919,22 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms{}GET:
             <name>rhel7s</name>
             <description></description>
             <comment></comment>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
             <bios>
                 <boot_menu>
@@ -943,9 +1075,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms{}GET:
             <next_run_configuration_exists>false</next_run_configuration_exists>
             <numa_tune_mode>interleave</numa_tune_mode>
             <run_once>false</run_once>
-            <start_time>2019-12-02T12:31:18.745+01:00</start_time>
+            <start_time>2019-12-16T11:56:20.331+01:00</start_time>
             <status>up</status>
-            <stop_time>2019-12-02T12:31:18.018+01:00</stop_time>
+            <stop_time>2019-12-16T11:56:19.886+01:00</stop_time>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
             <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
             <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
@@ -953,12 +1085,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms{}GET:
     </vms>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '3241'
-    correlation-id: 0ab95117-c97b-4a5b-9d46-054ff5a415a8
+    content-length: '3731'
+    correlation-id: df2089a5-800b-4c24-8ffa-a4839c26d35d
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates{}GET:
 - :body: |
@@ -971,13 +1103,13 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates{}GET:
             <name>Blank</name>
             <description>Blank template</description>
             <comment></comment>
-            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/watchdogs" rel="watchdogs"/>
-            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/graphicsconsoles" rel="graphicsconsoles"/>
             <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/cdroms" rel="cdroms"/>
             <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments" rel="diskattachments"/>
-            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/graphicsconsoles" rel="graphicsconsoles"/>
             <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/permissions" rel="permissions"/>
             <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics" rel="nics"/>
             <bios>
                 <boot_menu>
                     <enabled>false</enabled>
@@ -1059,12 +1191,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates{}GET:
     </templates>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1118'
-    correlation-id: 3254b183-c5de-4878-8ac0-1f3750460039
+    content-length: '1117'
+    correlation-id: 0c5b6b61-7cc1-4fe4-8b75-efe07f955aad
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/networks{}GET:
 - :body: |
@@ -1075,8 +1207,8 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/networks{}GET:
             <description>Default Management Network</description>
             <comment></comment>
             <link href="/ovirt-engine/api/networks/5a2457bc-b7bd-414f-852e-f92784600e21/networklabels" rel="networklabels"/>
-            <link href="/ovirt-engine/api/networks/5a2457bc-b7bd-414f-852e-f92784600e21/vnicprofiles" rel="vnicprofiles"/>
             <link href="/ovirt-engine/api/networks/5a2457bc-b7bd-414f-852e-f92784600e21/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/5a2457bc-b7bd-414f-852e-f92784600e21/vnicprofiles" rel="vnicprofiles"/>
             <mtu>0</mtu>
             <stp>false</stp>
             <usages>
@@ -1087,12 +1219,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/networks{}GET:
     </networks>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '357'
-    correlation-id: a64b9bba-4e5a-4774-8266-fc5708212e73
+    correlation-id: be4e03c1-530c-467c-96b2-bc19555a2581
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{}GET:
 - :body: |
@@ -1101,12 +1233,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{}GET:
         <data_center href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc" id="e57249a3-d28a-455f-b30c-4ac0979f2ccc">
             <name>depot_dc</name>
             <description>Datacenter on depot machine</description>
-            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/networks" rel="networks"/>
-            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas" rel="quotas"/>
-            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/qoss" rel="qoss"/>
             <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/iscsibonds" rel="iscsibonds"/>
-            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/networks" rel="networks"/>
             <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/qoss" rel="qoss"/>
             <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/permissions" rel="permissions"/>
             <local>false</local>
             <quota_mode>disabled</quota_mode>
@@ -1127,57 +1259,25 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{}GET:
     </data_centers>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '461'
-    correlation-id: 760c6534-87e1-456b-950d-388eeef5a20d
+    content-length: '462'
+    correlation-id: 51ebd101-59bb-49fa-a848-048716682672
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <disks>
-        <disk href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e" id="56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e">
-            <actions>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/refreshlun" rel="refreshlun"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/copy" rel="copy"/>
-            </actions>
-            <name>OVF_STORE</name>
-            <description>OVF_STORE</description>
-            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/permissions" rel="permissions"/>
-            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/statistics" rel="statistics"/>
-            <actual_size>134217728</actual_size>
-            <alias>OVF_STORE</alias>
-            <backup>none</backup>
-            <content_type>ovf_store</content_type>
-            <format>raw</format>
-            <image_id>dc123508-bab4-4f54-9466-3c15118d240b</image_id>
-            <propagate_errors>false</propagate_errors>
-            <provisioned_size>134217728</provisioned_size>
-            <shareable>true</shareable>
-            <sparse>false</sparse>
-            <status>ok</status>
-            <storage_type>image</storage_type>
-            <wipe_after_delete>false</wipe_after_delete>
-            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
-            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
-            <storage_domains>
-                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
-            </storage_domains>
-        </disk>
         <disk href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9" id="8b900d4d-81a1-4cbd-8006-8f22c8011ac9">
             <actions>
                 <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/refreshlun" rel="refreshlun"/>
                 <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/move" rel="move"/>
             </actions>
             <name>OVF_STORE</name>
             <description>OVF_STORE</description>
@@ -1202,14 +1302,244 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
                 <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
             </storage_domains>
         </disk>
+        <disk href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e" id="56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/move" rel="move"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>dc123508-bab4-4f54-9466-3c15118d240b</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f" id="b36b5649-225d-4a6d-9e04-c9af2c76666f">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>0cf4683a-f50c-4fb5-829f-0ecca92d9659</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e" id="e84216fc-a2b2-42ea-8d4a-dcd94aca411e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>9ed45f07-e665-45d3-a8a5-4ffd8884dac7</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565" id="8eb8be48-4379-4949-8bae-af5188bba565">
+            <actions>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>0c89dcb2-fb80-485c-ac65-36f1b2c9eb33</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>15728640</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76" id="7ebad349-5c61-441d-9e11-363a7291bd76">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>bfefd45d-087b-4922-87e2-b1c5d3fa41ca</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5" id="dbaf0588-6176-4440-b6fb-ddd3e6083dd5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>b8e87b8a-4786-44f2-b40f-a71fa629e276</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd" id="4756cf62-5bf5-4f8a-9cd1-c0f186636ccd">
+            <actions>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>667b60a3-c904-44db-a638-c8ae79e90e61</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
         <disk href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668" id="f6e4775b-53be-4136-9e30-f0be18b70668">
             <actions>
                 <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/refreshlun" rel="refreshlun"/>
                 <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/move" rel="move"/>
             </actions>
             <name>rhel7s_Disk1</name>
             <description></description>
@@ -1235,59 +1565,390 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
                 <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
             </storage_domains>
         </disk>
+        <disk href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9" id="eda59258-5aa0-460b-92c5-df61517cc7e9">
+            <actions>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>4acdce24-ed39-47dc-ae93-3ae35bbb8e71</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>52428800</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945" id="ca2c392f-e067-4b1a-ab1f-47dc75174945">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>e85bdff0-468e-476d-86a9-3204502d3b68</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>15728640</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf" id="b7ec93e0-1838-4706-b1d5-6561aa8b5adf">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk4</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk4</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>9a016e0c-7156-4451-bd82-33e34ae368b4</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>41943040</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67" id="e7bef226-5566-4f84-bd1e-7766d0510c67">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk1</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/statistics" rel="statistics"/>
+            <actual_size>1971261440</actual_size>
+            <alias>deb10_Disk1</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>a086eb2a-7086-4627-afcf-7eb258246349</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>8589934592</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>1971261440</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5" id="f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>3a53a19e-e66b-426c-ba2c-f7028818348e</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264" id="e5d385bd-2ebb-4024-8c82-35eda60f5264">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk4</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk4</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>49a02400-0600-42e7-acc7-ef774230d8b2</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>36700160</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309" id="307617bd-7c0b-477c-8f29-cfb75511f309">
+            <actions>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>6e1e2d81-d8bc-42cd-b639-fc0741a7853b</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b" id="ad5379a3-99ef-4fa7-a182-7941b61cff1b">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>476a0207-ee6c-4332-947b-d438c7d9eafd</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97" id="d3ab1baa-2c8a-4c34-8880-866443108e97">
+            <actions>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>68a7c6e9-b7f4-400e-bab5-ad6a19fdb292</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>31457280</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199" id="6604e824-a911-4ce8-9225-feaeb1963199">
+            <actions>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>824929a3-d782-4660-8381-8948227c1c9d</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80" id="7c542c3c-586f-47e1-9deb-d0a742952f80">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>c8517c9e-584a-4ee0-a5df-c86da0946655</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
     </disks>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '993'
-    correlation-id: 3989b3ca-db31-4d72-b107-8f43361b1011
+    content-length: '2920'
+    correlation-id: eadbd3af-b797-4084-8312-f8bc3f452965
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <disks>
-        <disk href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e" id="56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e">
-            <actions>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/refreshlun" rel="refreshlun"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/copy" rel="copy"/>
-            </actions>
-            <name>OVF_STORE</name>
-            <description>OVF_STORE</description>
-            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/permissions" rel="permissions"/>
-            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/statistics" rel="statistics"/>
-            <actual_size>134217728</actual_size>
-            <alias>OVF_STORE</alias>
-            <backup>none</backup>
-            <content_type>ovf_store</content_type>
-            <format>raw</format>
-            <image_id>dc123508-bab4-4f54-9466-3c15118d240b</image_id>
-            <propagate_errors>false</propagate_errors>
-            <provisioned_size>134217728</provisioned_size>
-            <shareable>true</shareable>
-            <sparse>false</sparse>
-            <status>ok</status>
-            <storage_type>image</storage_type>
-            <wipe_after_delete>false</wipe_after_delete>
-            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
-            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
-            <storage_domains>
-                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
-            </storage_domains>
-        </disk>
         <disk href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9" id="8b900d4d-81a1-4cbd-8006-8f22c8011ac9">
             <actions>
                 <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/refreshlun" rel="refreshlun"/>
                 <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/move" rel="move"/>
             </actions>
             <name>OVF_STORE</name>
             <description>OVF_STORE</description>
@@ -1312,14 +1973,244 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
                 <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
             </storage_domains>
         </disk>
+        <disk href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e" id="56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/move" rel="move"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>dc123508-bab4-4f54-9466-3c15118d240b</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f" id="b36b5649-225d-4a6d-9e04-c9af2c76666f">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>0cf4683a-f50c-4fb5-829f-0ecca92d9659</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e" id="e84216fc-a2b2-42ea-8d4a-dcd94aca411e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>9ed45f07-e665-45d3-a8a5-4ffd8884dac7</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565" id="8eb8be48-4379-4949-8bae-af5188bba565">
+            <actions>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>0c89dcb2-fb80-485c-ac65-36f1b2c9eb33</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>15728640</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76" id="7ebad349-5c61-441d-9e11-363a7291bd76">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>bfefd45d-087b-4922-87e2-b1c5d3fa41ca</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5" id="dbaf0588-6176-4440-b6fb-ddd3e6083dd5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>b8e87b8a-4786-44f2-b40f-a71fa629e276</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd" id="4756cf62-5bf5-4f8a-9cd1-c0f186636ccd">
+            <actions>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>667b60a3-c904-44db-a638-c8ae79e90e61</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
         <disk href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668" id="f6e4775b-53be-4136-9e30-f0be18b70668">
             <actions>
                 <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/refreshlun" rel="refreshlun"/>
                 <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/move" rel="move"/>
             </actions>
             <name>rhel7s_Disk1</name>
             <description></description>
@@ -1345,15 +2236,378 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
                 <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
             </storage_domains>
         </disk>
+        <disk href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9" id="eda59258-5aa0-460b-92c5-df61517cc7e9">
+            <actions>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>4acdce24-ed39-47dc-ae93-3ae35bbb8e71</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>52428800</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945" id="ca2c392f-e067-4b1a-ab1f-47dc75174945">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>e85bdff0-468e-476d-86a9-3204502d3b68</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>15728640</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf" id="b7ec93e0-1838-4706-b1d5-6561aa8b5adf">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk4</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk4</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>9a016e0c-7156-4451-bd82-33e34ae368b4</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>41943040</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67" id="e7bef226-5566-4f84-bd1e-7766d0510c67">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk1</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/statistics" rel="statistics"/>
+            <actual_size>1971261440</actual_size>
+            <alias>deb10_Disk1</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>a086eb2a-7086-4627-afcf-7eb258246349</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>8589934592</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>1971261440</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5" id="f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>3a53a19e-e66b-426c-ba2c-f7028818348e</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264" id="e5d385bd-2ebb-4024-8c82-35eda60f5264">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk4</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk4</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>49a02400-0600-42e7-acc7-ef774230d8b2</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>36700160</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309" id="307617bd-7c0b-477c-8f29-cfb75511f309">
+            <actions>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>6e1e2d81-d8bc-42cd-b639-fc0741a7853b</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b" id="ad5379a3-99ef-4fa7-a182-7941b61cff1b">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>476a0207-ee6c-4332-947b-d438c7d9eafd</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97" id="d3ab1baa-2c8a-4c34-8880-866443108e97">
+            <actions>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>68a7c6e9-b7f4-400e-bab5-ad6a19fdb292</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>31457280</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199" id="6604e824-a911-4ce8-9225-feaeb1963199">
+            <actions>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>824929a3-d782-4660-8381-8948227c1c9d</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80" id="7c542c3c-586f-47e1-9deb-d0a742952f80">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>c8517c9e-584a-4ee0-a5df-c86da0946655</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
     </disks>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '993'
-    correlation-id: 94a38f58-3c1a-47d5-b7f4-bc38a16e8de2
+    content-length: '2920'
+    correlation-id: 2cbefbf2-6231-46f2-b0f9-47bb93851fad
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
 - :body: |
@@ -1372,12 +2626,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
     </vnic_profiles>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '348'
-    correlation-id: d95e0ed3-cdbf-4111-bf05-593bdfef5992
+    correlation-id: bd07b9d4-16c8-48de-badc-6bf5d4ecdfdc
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics{}GET:
 - :body: |
@@ -1386,9 +2640,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
         <host_nic href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94" id="02f40cac-50ae-4ea8-b70c-277fef97ea94">
             <actions/>
             <name>ens3</name>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/networkattachments" rel="networkattachments"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/networklabels" rel="networklabels"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/linklayerdiscoveryprotocolelements" rel="linklayerdiscoveryprotocolelements"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/networkattachments" rel="networkattachments"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/statistics" rel="statistics"/>
             <boot_protocol>dhcp</boot_protocol>
             <bridged>true</bridged>
@@ -1417,12 +2671,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
     </host_nics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '570'
-    correlation-id: 7de68469-a48c-4841-997b-8540a8efa72d
+    correlation-id: 2a5f6f67-f891-4418-b299-951e408201d7
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/statistics{}GET:
 - :body: |
@@ -1579,7 +2833,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>13</datum>
+                    <datum>2</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1592,7 +2846,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>3</datum>
+                    <datum>1</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1605,7 +2859,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>84</datum>
+                    <datum>97</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1618,7 +2872,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>0.22</datum>
+                    <datum>0.17</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1631,7 +2885,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>none</unit>
             <values>
                 <value>
-                    <datum>1575276739</datum>
+                    <datum>1576486724</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1663,12 +2917,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
     </statistics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '1231'
-    correlation-id: 4bbae87b-8925-4a62-9022-a359e6824509
+    correlation-id: 46d07f7b-9941-47b4-a724-b274b33c3b7f
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics{}GET:
 - :body: |
@@ -1677,9 +2931,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
         <host_nic href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7" id="5fd4e6be-4438-47e1-8e06-4705b40a21a7">
             <actions/>
             <name>ens3</name>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/networkattachments" rel="networkattachments"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/networklabels" rel="networklabels"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/linklayerdiscoveryprotocolelements" rel="linklayerdiscoveryprotocolelements"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/networkattachments" rel="networkattachments"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/statistics" rel="statistics"/>
             <boot_protocol>dhcp</boot_protocol>
             <bridged>true</bridged>
@@ -1708,12 +2962,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
     </host_nics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '572'
-    correlation-id: 569d5c68-65a1-4647-a3b0-3d8b72cbf017
+    correlation-id: 8eeaae85-9e61-4a33-9434-c1f1ace0625a
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/statistics{}GET:
 - :body: |
@@ -1870,7 +3124,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>0</datum>
+                    <datum>1</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab" id="9514170e-dde4-4c5c-b9ec-5a09db2115ab"/>
@@ -1883,7 +3137,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>0</datum>
+                    <datum>1</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab" id="9514170e-dde4-4c5c-b9ec-5a09db2115ab"/>
@@ -1909,7 +3163,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>0.070</datum>
+                    <datum>0.080</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab" id="9514170e-dde4-4c5c-b9ec-5a09db2115ab"/>
@@ -1922,7 +3176,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
             <unit>none</unit>
             <values>
                 <value>
-                    <datum>1575276741</datum>
+                    <datum>1576486724</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab" id="9514170e-dde4-4c5c-b9ec-5a09db2115ab"/>
@@ -1954,12 +3208,105 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
     </statistics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1222'
-    correlation-id: 2b9ae8c7-8606-424a-8c8d-34583c4a27c4
+    content-length: '1225'
+    correlation-id: d83ee8e3-d820-414f-9931-4d35e45c7b96
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e" id="37f40d91-612d-4d61-8c68-a22638da6b1e">
+            <actions>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696" id="022ce494-f739-40a3-a29a-d26ce125f696"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:85:ae:00:01</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/bd73ad67-17a7-434c-a661-8557add4e99f" id="bd73ad67-17a7-434c-a661-8557add4e99f"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    date: Mon, 16 Dec 2019 11:00:27 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '429'
+    correlation-id: 6756a431-e00a-4153-8e07-9de3b9767cf9
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    date: Mon, 16 Dec 2019 11:00:27 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '96'
+    correlation-id: 0da2001e-a535-481a-92c9-b9cf42297573
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/snapshots/1b04d198-81a4-4f9a-908c-cbb398d974e4" id="1b04d198-81a4-4f9a-908c-cbb398d974e4">
+            <actions>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/snapshots/1b04d198-81a4-4f9a-908c-cbb398d974e4/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2019-12-13T11:55:45.279+01:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    date: Mon, 16 Dec 2019 11:00:27 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '333'
+    correlation-id: 78ab87a8-3e96-44f5-85e9-8c383f336880
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/diskattachments/e7bef226-5566-4f84-bd1e-7766d0510c67" id="e7bef226-5566-4f84-bd1e-7766d0510c67">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <read_only>false</read_only>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67" id="e7bef226-5566-4f84-bd1e-7766d0510c67"/>
+            <vm href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696" id="022ce494-f739-40a3-a29a-d26ce125f696"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    date: Mon, 16 Dec 2019 11:00:27 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '320'
+    correlation-id: 9b465a7a-542a-4312-a6a9-1162b0ef3539
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics{}GET:
 - :body: |
@@ -2006,12 +3353,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </nics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '615'
-    correlation-id: '09e60fee-8db2-4a27-a1c9-8d9f665e87ff'
+    correlation-id: 90f8de5c-8382-428d-8254-621c16837dc6
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2057,12 +3404,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </nics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '615'
-    correlation-id: 6c6c2342-23a7-48cc-8124-e32cd21bbb54
+    correlation-id: f52eac7a-02b1-4bc7-98c0-fa71f50fdfb4
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices{}GET:
 - :body: |
@@ -2090,12 +3437,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </reported_devices>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '366'
-    correlation-id: cd118ea4-a3f4-491b-af4c-e07de3e024dc
+    correlation-id: aa03f2ff-3aab-440f-9713-a3733d5c47c2
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2122,12 +3469,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </reported_devices>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '366'
-    correlation-id: 9a350237-e445-4a24-a3c1-9908f7437407
+    correlation-id: 25af349e-9b65-4d71-926f-383b920b7378
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots{}GET:
 - :body: |
@@ -2146,12 +3493,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </snapshots>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '330'
-    correlation-id: 6bb63108-cdb1-4d9a-b2dc-d831bad0ed72
+    correlation-id: 10e3ecf0-cd8a-4762-8ee0-9bdce63ba249
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2169,12 +3516,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </snapshots>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '330'
-    correlation-id: 7bb50ba2-f90b-41ef-b27e-79d4c639c5b8
+    correlation-id: b808ed34-6638-4da1-bb12-c2e047377441
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments{}GET:
 - :body: |
@@ -2194,12 +3541,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </disk_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '342'
-    correlation-id: 7d3b2af2-4cc4-4e39-920d-6fa0e60d5f49
+    correlation-id: 83e4f924-d58c-47b1-9879-56eb2bfdc043
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2218,12 +3565,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </disk_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '342'
-    correlation-id: 6fdd0537-b5dd-4440-b644-98467007e7b3
+    correlation-id: 756e12d5-99b4-4c36-ac45-3876f510795e
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2242,12 +3589,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </disk_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '342'
-    correlation-id: 355c53ec-3eeb-4850-b545-3a0a6e96cbfa
+    correlation-id: a9c9ea30-f453-4329-af98-bc538d3393c6
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments{}GET:
 - :body: |
@@ -2255,12 +3602,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates/00000000-000
     <disk_attachments/>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '96'
-    correlation-id: 256a703b-8d97-4f07-93c4-186b573f7cac
+    correlation-id: 6dcbb8b3-d5dd-4000-b78e-aa85e9672bf2
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/storagedomains{}GET:
 - :body: |
@@ -2275,10 +3622,10 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
             <description></description>
             <comment></comment>
             <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
-            <available>517543559168</available>
+            <available>515396075520</available>
             <backup>false</backup>
             <block_size>512</block_size>
-            <committed>16106127360</committed>
+            <committed>25769803776</committed>
             <critical_space_action_blocker>5</critical_space_action_blocker>
             <discard_after_delete>false</discard_after_delete>
             <external_status>ok</external_status>
@@ -2294,7 +3641,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
             <supports_discard>false</supports_discard>
             <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
             <type>data</type>
-            <used>18253611008</used>
+            <used>20401094656</used>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <wipe_after_delete>false</wipe_after_delete>
             <data_center href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc" id="e57249a3-d28a-455f-b30c-4ac0979f2ccc"/>
@@ -2310,7 +3657,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
             <name>depot_iso</name>
             <description></description>
             <comment></comment>
-            <available>517543559168</available>
+            <available>515396075520</available>
             <backup>false</backup>
             <block_size>512</block_size>
             <committed>0</committed>
@@ -2329,7 +3676,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
             <supports_discard>false</supports_discard>
             <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
             <type>iso</type>
-            <used>18253611008</used>
+            <used>20401094656</used>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <wipe_after_delete>false</wipe_after_delete>
             <data_center href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc" id="e57249a3-d28a-455f-b30c-4ac0979f2ccc"/>
@@ -2340,12 +3687,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
     </storage_domains>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '730'
-    correlation-id: f318813c-a228-4e83-8cc1-de16a2f8a65d
+    content-length: '731'
+    correlation-id: a41420af-b345-48e7-8b21-aebe96809ebf
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/networkattachments{}GET:
 - :body: |
@@ -2421,12 +3768,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
     </network_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '619'
-    correlation-id: 93599ea8-7035-45a0-9d38-eadf196dba7c
+    correlation-id: 8b8fbbdd-9015-4154-aa14-a640eaf71bab
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/networkattachments{}GET:
 - :body: |
@@ -2502,33 +3849,33 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
     </network_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:14 GMT
+    date: Mon, 16 Dec 2019 11:00:27 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '616'
-    correlation-id: 98911dad-6bc8-483c-8ac0-d8b080b1395e
+    correlation-id: 82bcaa46-65b8-443a-818b-c3ef27b4e866
   :message: 
-https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{}GET:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{:all_content=>"true"}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
         <actions>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
@@ -2537,22 +3884,22 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <name>rhel7s</name>
         <description></description>
         <comment></comment>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
         <bios>
             <boot_menu>
@@ -2560,6 +3907,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
             </boot_menu>
             <type>i440fx_sea_bios</type>
         </bios>
+        <console>
+            <enabled>false</enabled>
+        </console>
         <cpu>
             <architecture>x86_64</architecture>
             <topology>
@@ -2614,6 +3964,10 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         </high_availability>
         <initialization>
             <authorized_ssh_keys></authorized_ssh_keys>
+            <configuration>
+                <data>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1/" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovf:version="4.1.0.0"&gt;&lt;References&gt;&lt;File ovf:href="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:id="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="2052321280" ovf:description="Active VM" ovf:disk_storage_type="IMAGE" ovf:cinder_volume_type=""&gt;&lt;/File&gt;&lt;/References&gt;&lt;NetworkSection&gt;&lt;Info&gt;List of networks&lt;/Info&gt;&lt;Network ovf:name="ovirtmgmt"&gt;&lt;/Network&gt;&lt;/NetworkSection&gt;&lt;Section xsi:type="ovf:DiskSection_Type"&gt;&lt;Info&gt;List of Virtual Disks&lt;/Info&gt;&lt;Disk ovf:diskId="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="15" ovf:actual_size="2" ovf:vm_snapshot_id="fc282c90-ded5-456b-ab99-2d2fe6abc262" ovf:parentRef="" ovf:fileRef="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:format="http://www.vmware.com/specifications/vmdk.html#sparse" ovf:volume-format="RAW" ovf:volume-type="Sparse" ovf:disk-interface="VirtIO_SCSI" ovf:read-only="false" ovf:shareable="false" ovf:boot="true" ovf:pass-discard="false" ovf:disk-alias="rhel7s_Disk1" ovf:disk-description="" ovf:wipe-after-delete="true"&gt;&lt;/Disk&gt;&lt;/Section&gt;&lt;Content ovf:id="out" xsi:type="ovf:VirtualSystem_Type"&gt;&lt;Name&gt;rhel7s&lt;/Name&gt;&lt;Description&gt;&lt;/Description&gt;&lt;Comment&gt;&lt;/Comment&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;ExportDate&gt;2019/12/16 11:00:30&lt;/ExportDate&gt;&lt;DeleteProtected&gt;false&lt;/DeleteProtected&gt;&lt;SsoMethod&gt;guest_agent&lt;/SsoMethod&gt;&lt;IsSmartcardEnabled&gt;false&lt;/IsSmartcardEnabled&gt;&lt;NumOfIoThreads&gt;1&lt;/NumOfIoThreads&gt;&lt;TimeZone&gt;Europe/Warsaw&lt;/TimeZone&gt;&lt;default_boot_sequence&gt;9&lt;/default_boot_sequence&gt;&lt;Generation&gt;1149&lt;/Generation&gt;&lt;ClusterCompatibilityVersion&gt;4.3&lt;/ClusterCompatibilityVersion&gt;&lt;VmType&gt;1&lt;/VmType&gt;&lt;ResumeBehavior&gt;AUTO_RESUME&lt;/ResumeBehavior&gt;&lt;MinAllocatedMem&gt;3072&lt;/MinAllocatedMem&gt;&lt;IsStateless&gt;false&lt;/IsStateless&gt;&lt;IsRunAndPause&gt;false&lt;/IsRunAndPause&gt;&lt;AutoStartup&gt;false&lt;/AutoStartup&gt;&lt;Priority&gt;1&lt;/Priority&gt;&lt;CreatedByUserId&gt;251a2aee-ee9b-11e9-a6be-5254005a3239&lt;/CreatedByUserId&gt;&lt;MigrationSupport&gt;0&lt;/MigrationSupport&gt;&lt;IsBootMenuEnabled&gt;false&lt;/IsBootMenuEnabled&gt;&lt;IsSpiceFileTransferEnabled&gt;true&lt;/IsSpiceFileTransferEnabled&gt;&lt;IsSpiceCopyPasteEnabled&gt;true&lt;/IsSpiceCopyPasteEnabled&gt;&lt;AllowConsoleReconnect&gt;true&lt;/AllowConsoleReconnect&gt;&lt;ConsoleDisconnectAction&gt;LOCK_SCREEN&lt;/ConsoleDisconnectAction&gt;&lt;CustomEmulatedMachine&gt;&lt;/CustomEmulatedMachine&gt;&lt;BiosType&gt;0&lt;/BiosType&gt;&lt;CustomCpuName&gt;&lt;/CustomCpuName&gt;&lt;PredefinedProperties&gt;&lt;/PredefinedProperties&gt;&lt;UserDefinedProperties&gt;&lt;/UserDefinedProperties&gt;&lt;MaxMemorySizeMb&gt;4096&lt;/MaxMemorySizeMb&gt;&lt;MultiQueuesEnabled&gt;true&lt;/MultiQueuesEnabled&gt;&lt;UseHostCpu&gt;false&lt;/UseHostCpu&gt;&lt;ClusterName&gt;depot_cl&lt;/ClusterName&gt;&lt;TemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/TemplateId&gt;&lt;TemplateName&gt;Blank&lt;/TemplateName&gt;&lt;IsInitilized&gt;true&lt;/IsInitilized&gt;&lt;Origin&gt;0&lt;/Origin&gt;&lt;app_list&gt;ovirt-guest-agent-common-1.0.16-1.el7ev,kernel-3.10.0-1062.el7&lt;/app_list&gt;&lt;quota_id&gt;5fa337c2-9eb4-4d83-9d6a-739cf88a2312&lt;/quota_id&gt;&lt;DefaultDisplayType&gt;1&lt;/DefaultDisplayType&gt;&lt;TrustedService&gt;false&lt;/TrustedService&gt;&lt;OriginalTemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/OriginalTemplateId&gt;&lt;OriginalTemplateName&gt;Blank&lt;/OriginalTemplateName&gt;&lt;UseLatestVersion&gt;false&lt;/UseLatestVersion&gt;&lt;StopTime&gt;2019/12/16 10:56:19&lt;/StopTime&gt;&lt;BootTime&gt;2019/12/16 10:56:20&lt;/BootTime&gt;&lt;Downtime&gt;0&lt;/Downtime&gt;&lt;Section ovf:id="17a94da8-3d02-430e-9b83-5e39f92907e8" ovf:required="false" xsi:type="ovf:OperatingSystemSection_Type"&gt;&lt;Info&gt;Guest Operating System&lt;/Info&gt;&lt;Description&gt;rhel_7x64&lt;/Description&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:VirtualHardwareSection_Type"&gt;&lt;Info&gt;2 CPU, 3072 Memory&lt;/Info&gt;&lt;System&gt;&lt;vssd:VirtualSystemType&gt;ENGINE 4.1.0.0&lt;/vssd:VirtualSystemType&gt;&lt;/System&gt;&lt;Item&gt;&lt;rasd:Caption&gt;2 virtual cpu&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Number of virtual CPU&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;1&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;3&lt;/rasd:ResourceType&gt;&lt;rasd:num_of_sockets&gt;2&lt;/rasd:num_of_sockets&gt;&lt;rasd:cpu_per_socket&gt;1&lt;/rasd:cpu_per_socket&gt;&lt;rasd:threads_per_cpu&gt;1&lt;/rasd:threads_per_cpu&gt;&lt;rasd:max_num_of_vcpus&gt;16&lt;/rasd:max_num_of_vcpus&gt;&lt;rasd:VirtualQuantity&gt;2&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;3072 MB of memory&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Memory Size&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;2&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;4&lt;/rasd:ResourceType&gt;&lt;rasd:AllocationUnits&gt;MegaBytes&lt;/rasd:AllocationUnits&gt;&lt;rasd:VirtualQuantity&gt;3072&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;rhel7s_Disk1&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;17&lt;/rasd:ResourceType&gt;&lt;rasd:HostResource&gt;f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:HostResource&gt;&lt;rasd:Parent&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Parent&gt;&lt;rasd:Template&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Template&gt;&lt;rasd:ApplicationList&gt;&lt;/rasd:ApplicationList&gt;&lt;rasd:StorageId&gt;cfbc93a1-17b7-4d03-a8ca-3b3bfef52729&lt;/rasd:StorageId&gt;&lt;rasd:StoragePoolId&gt;e57249a3-d28a-455f-b30c-4ac0979f2ccc&lt;/rasd:StoragePoolId&gt;&lt;rasd:CreationDate&gt;2019/10/15 10:13:29&lt;/rasd:CreationDate&gt;&lt;rasd:LastModified&gt;1970/01/01 00:00:00&lt;/rasd:LastModified&gt;&lt;rasd:last_modified_date&gt;2019/12/16 11:00:30&lt;/rasd:last_modified_date&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;disk&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=0, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;1&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-f6e4775b-53be-4136-9e30-f0be18b70668&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Ethernet adapter on ovirtmgmt&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;93159b67-49fe-4add-8b31-91be915a208b&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;10&lt;/rasd:ResourceType&gt;&lt;rasd:OtherResourceType&gt;ovirtmgmt&lt;/rasd:OtherResourceType&gt;&lt;rasd:ResourceSubType&gt;3&lt;/rasd:ResourceSubType&gt;&lt;rasd:Connection&gt;ovirtmgmt&lt;/rasd:Connection&gt;&lt;rasd:Linked&gt;true&lt;/rasd:Linked&gt;&lt;rasd:Name&gt;nic1&lt;/rasd:Name&gt;&lt;rasd:ElementName&gt;nic1&lt;/rasd:ElementName&gt;&lt;rasd:MACAddress&gt;56:6f:85:ae:00:00&lt;/rasd:MACAddress&gt;&lt;rasd:speed&gt;10000&lt;/rasd:speed&gt;&lt;Type&gt;interface&lt;/Type&gt;&lt;Device&gt;bridge&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x03, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-93159b67-49fe-4add-8b31-91be915a208b&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;USB Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;3&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;23&lt;/rasd:ResourceType&gt;&lt;rasd:UsbPolicy&gt;DISABLED&lt;/rasd:UsbPolicy&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;20&lt;/rasd:ResourceType&gt;&lt;rasd:VirtualQuantity&gt;1&lt;/rasd:VirtualQuantity&gt;&lt;rasd:SinglePciQxl&gt;false&lt;/rasd:SinglePciQxl&gt;&lt;Type&gt;video&lt;/Type&gt;&lt;Device&gt;qxl&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x02, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;vgamem&gt;16384&lt;/vgamem&gt;&lt;heads&gt;1&lt;/heads&gt;&lt;vram&gt;32768&lt;/vram&gt;&lt;ram&gt;65536&lt;/ram&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d835d395-f01c-4991-8643-b0578b2f3cf4&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;spice&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;393b1788-8d19-4f18-ac73-9984db012e59&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;vnc&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;CDROM&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;15&lt;/rasd:ResourceType&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;cdrom&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=1, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;2&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/Alias&gt;&lt;SpecParams&gt;&lt;path&gt;rhel-server-7.7-x86_64-dvd.iso&lt;/path&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;883eafad-4981-438d-8a50-097a76503006&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel1&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;beb53b7a-abd9-432f-90f2-3ec4c30998e7&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;spicevmc&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=3}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel2&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;0e988f54-ff5e-4f78-953a-1dfe1e813bb7&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;ide&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ide&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;70b1a7fd-a377-41e3-b0c0-f3b5a0241e23&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel0&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-serial&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x05, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;2ac4481d-2ce4-48ac-97fe-cf89a7118715&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-scsi&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x04, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-2ac4481d-2ce4-48ac-97fe-cf89a7118715&lt;/Alias&gt;&lt;SpecParams&gt;&lt;ioThreadId&gt;&lt;/ioThreadId&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;b8eed426-0eb3-4f95-9fb7-6c430490bf0e&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;usb&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;usb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;model&gt;piix3-uhci&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/rasd:InstanceId&gt;&lt;Type&gt;rng&lt;/Type&gt;&lt;Device&gt;virtio&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x07, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/Alias&gt;&lt;SpecParams&gt;&lt;source&gt;urandom&lt;/source&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/rasd:InstanceId&gt;&lt;Type&gt;balloon&lt;/Type&gt;&lt;Device&gt;memballoon&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x06, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/Alias&gt;&lt;SpecParams&gt;&lt;model&gt;virtio&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:SnapshotsSection_Type"&gt;&lt;Snapshot ovf:id="fc282c90-ded5-456b-ab99-2d2fe6abc262"&gt;&lt;Type&gt;ACTIVE&lt;/Type&gt;&lt;Description&gt;Active VM&lt;/Description&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;/Snapshot&gt;&lt;/Section&gt;&lt;/Content&gt;&lt;/ovf:Envelope&gt;</data>
+                <type>ovf</type>
+            </configuration>
             <custom_script></custom_script>
             <nic_configurations/>
             <regenerate_ssh_keys>false</regenerate_ssh_keys>
@@ -2647,7 +4001,11 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <placement_policy>
             <affinity>migratable</affinity>
         </placement_policy>
+        <rng_device>
+            <source>urandom</source>
+        </rng_device>
         <small_icon href="/ovirt-engine/api/icons/a029b4bf-5437-dae6-0cdf-3c9fb623cf1d" id="a029b4bf-5437-dae6-0cdf-3c9fb623cf1d"/>
+        <soundcard_enabled>false</soundcard_enabled>
         <sso>
             <methods>
                 <method id="guest_agent"/>
@@ -2663,6 +4021,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <usb>
             <enabled>false</enabled>
         </usb>
+        <virtio_scsi>
+            <enabled>true</enabled>
+        </virtio_scsi>
         <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde"/>
         <cpu_profile href="/ovirt-engine/api/cpuprofiles/c5926295-65ef-4dba-b234-26db503cb59d" id="c5926295-65ef-4dba-b234-26db503cb59d"/>
         <quota id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
@@ -2694,41 +4055,265 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <next_run_configuration_exists>false</next_run_configuration_exists>
         <numa_tune_mode>interleave</numa_tune_mode>
         <run_once>false</run_once>
-        <start_time>2019-12-02T12:31:18.745+01:00</start_time>
+        <start_time>2019-12-16T11:56:20.331+01:00</start_time>
         <status>up</status>
-        <stop_time>2019-12-02T12:31:18.018+01:00</stop_time>
+        <stop_time>2019-12-16T11:56:19.886+01:00</stop_time>
         <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
         <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
         <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
     </vm>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '3226'
-    correlation-id: 9b4e9eae-5c4c-4dd7-bbf5-77c9ef11b9d9
+    content-length: '6582'
+    correlation-id: 9175177f-1e26-4117-b370-f8fd7b92643c
   :message: 
+? |
+  https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{:next_run=>"false"}PUT<vm>
+    <cpu>
+      <topology>
+        <cores>1</cores>
+        <sockets>4</sockets>
+      </topology>
+    </cpu>
+  </vm>
+: - :body: |
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
+          <actions>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/suspend" rel="suspend"/>
+          </actions>
+          <name>rhel7s</name>
+          <description></description>
+          <comment></comment>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
+          <bios>
+              <boot_menu>
+                  <enabled>false</enabled>
+              </boot_menu>
+              <type>i440fx_sea_bios</type>
+          </bios>
+          <console>
+              <enabled>false</enabled>
+          </console>
+          <cpu>
+              <architecture>x86_64</architecture>
+              <topology>
+                  <cores>1</cores>
+                  <sockets>4</sockets>
+                  <threads>1</threads>
+              </topology>
+          </cpu>
+          <cpu_shares>0</cpu_shares>
+          <creation_time>2019-10-15T12:12:12.505+02:00</creation_time>
+          <delete_protected>false</delete_protected>
+          <display>
+              <address>192.168.178.48</address>
+              <allow_override>true</allow_override>
+              <certificate>
+                  <content>-----BEGIN CERTIFICATE-----
+      MIIDujCCAqKgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwRTELMAkGA1UEBhMCVVMxEjAQBgNVBAoM
+      CWZyaXR6LmJveDEiMCAGA1UEAwwZZW5naW5lLTQzLmZyaXR6LmJveC40MDczNzAeFw0xOTEwMTMx
+      NTU1MTJaFw0yOTEwMTExNTU1MTJaMEUxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlmcml0ei5ib3gx
+      IjAgBgNVBAMMGWVuZ2luZS00My5mcml0ei5ib3guNDA3MzcwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+      DwAwggEKAoIBAQDOBt7e2IGBsiRkzj/139dMZVOIiUr7d2O/6ECI284u/U/ENY3kJT5tKVbn7UAk
+      8MnEH92FMBN2fcaGAnk36I6ZnJBxbj59mVPNgu7bktViKZkvgHEbZuX3BctJJZDrh0D67zIRsSKd
+      5xsFFWIjUAUkmyKOuxD4xsqXop1Cw5cjSzadY6XZMi2vw0yFtOUQ/3FMpXkZ9yAMT+clzaUu3rgs
+      IUbnLSpfKdDUm5NzCksOo8gOjXmx0OkXna8nQvQGb3ycmTeS10MzeURtgkPlfR+nZWDDiUNOHLmZ
+      y1IoZxsq0MmZx42YqbQ1WjPzj55H7rXhYqATUBjvYYh+39WSP/pfAgMBAAGjgbMwgbAwHQYDVR0O
+      BBYEFD9mD6ChOc01EKwqT3PaF+jxY+1MMG4GA1UdIwRnMGWAFD9mD6ChOc01EKwqT3PaF+jxY+1M
+      oUmkRzBFMQswCQYDVQQGEwJVUzESMBAGA1UECgwJZnJpdHouYm94MSIwIAYDVQQDDBllbmdpbmUt
+      NDMuZnJpdHouYm94LjQwNzM3ggIQADAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAN
+      BgkqhkiG9w0BAQsFAAOCAQEAilO/2+J+etHnfkY5Zlw5fCi4f20fhA0C2k3pmyzEnk+02/cBr1XK
+      PfsDXCEmCiXpMTru3iflYee6L5MRZqDuu7dKaZVwYhdCpURHxkMuBT7gA0YvtC1TNnRDu2EDvjUh
+      /Mtqngojv4XdCM1aza0fw0pyE+mz+e+97KLGmtutj0W2JymsXcHtHlLJxjNXTie7qzsrMKGLfKmq
+      eBceTlpcGF98zFqlLEjRMuJ/I2AN2kDpK+e1zCFL1lYzb2MAN8Aol2Eqw6ZrezVT+5NLnJ/aw55S
+      HuXeUczWeCztAUiGYS9HD2kcdp9Y7mr4OMZi+IePz5mkn0TTkCgNcIQho3vH1Q==
+      -----END CERTIFICATE-----
+      </content>
+                  <organization>fritz.box</organization>
+                  <subject>O=fritz.box,CN=host01-43.fritz.box</subject>
+              </certificate>
+              <copy_paste_enabled>true</copy_paste_enabled>
+              <disconnect_action>LOCK_SCREEN</disconnect_action>
+              <file_transfer_enabled>true</file_transfer_enabled>
+              <monitors>1</monitors>
+              <port>5901</port>
+              <secure_port>5902</secure_port>
+              <single_qxl_pci>false</single_qxl_pci>
+              <smartcard_enabled>false</smartcard_enabled>
+              <type>spice</type>
+          </display>
+          <high_availability>
+              <enabled>false</enabled>
+              <priority>1</priority>
+          </high_availability>
+          <initialization>
+              <authorized_ssh_keys></authorized_ssh_keys>
+              <configuration>
+                  <data>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1/" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovf:version="4.1.0.0"&gt;&lt;References&gt;&lt;File ovf:href="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:id="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="2052321280" ovf:description="Active VM" ovf:disk_storage_type="IMAGE" ovf:cinder_volume_type=""&gt;&lt;/File&gt;&lt;/References&gt;&lt;NetworkSection&gt;&lt;Info&gt;List of networks&lt;/Info&gt;&lt;Network ovf:name="ovirtmgmt"&gt;&lt;/Network&gt;&lt;/NetworkSection&gt;&lt;Section xsi:type="ovf:DiskSection_Type"&gt;&lt;Info&gt;List of Virtual Disks&lt;/Info&gt;&lt;Disk ovf:diskId="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="15" ovf:actual_size="2" ovf:vm_snapshot_id="fc282c90-ded5-456b-ab99-2d2fe6abc262" ovf:parentRef="" ovf:fileRef="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:format="http://www.vmware.com/specifications/vmdk.html#sparse" ovf:volume-format="RAW" ovf:volume-type="Sparse" ovf:disk-interface="VirtIO_SCSI" ovf:read-only="false" ovf:shareable="false" ovf:boot="true" ovf:pass-discard="false" ovf:disk-alias="rhel7s_Disk1" ovf:disk-description="" ovf:wipe-after-delete="true"&gt;&lt;/Disk&gt;&lt;/Section&gt;&lt;Content ovf:id="out" xsi:type="ovf:VirtualSystem_Type"&gt;&lt;Name&gt;rhel7s&lt;/Name&gt;&lt;Description&gt;&lt;/Description&gt;&lt;Comment&gt;&lt;/Comment&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;ExportDate&gt;2019/12/16 11:00:30&lt;/ExportDate&gt;&lt;DeleteProtected&gt;false&lt;/DeleteProtected&gt;&lt;SsoMethod&gt;guest_agent&lt;/SsoMethod&gt;&lt;IsSmartcardEnabled&gt;false&lt;/IsSmartcardEnabled&gt;&lt;NumOfIoThreads&gt;1&lt;/NumOfIoThreads&gt;&lt;TimeZone&gt;Europe/Warsaw&lt;/TimeZone&gt;&lt;default_boot_sequence&gt;9&lt;/default_boot_sequence&gt;&lt;Generation&gt;1150&lt;/Generation&gt;&lt;ClusterCompatibilityVersion&gt;4.3&lt;/ClusterCompatibilityVersion&gt;&lt;VmType&gt;1&lt;/VmType&gt;&lt;ResumeBehavior&gt;AUTO_RESUME&lt;/ResumeBehavior&gt;&lt;MinAllocatedMem&gt;3072&lt;/MinAllocatedMem&gt;&lt;IsStateless&gt;false&lt;/IsStateless&gt;&lt;IsRunAndPause&gt;false&lt;/IsRunAndPause&gt;&lt;AutoStartup&gt;false&lt;/AutoStartup&gt;&lt;Priority&gt;1&lt;/Priority&gt;&lt;CreatedByUserId&gt;251a2aee-ee9b-11e9-a6be-5254005a3239&lt;/CreatedByUserId&gt;&lt;MigrationSupport&gt;0&lt;/MigrationSupport&gt;&lt;IsBootMenuEnabled&gt;false&lt;/IsBootMenuEnabled&gt;&lt;IsSpiceFileTransferEnabled&gt;true&lt;/IsSpiceFileTransferEnabled&gt;&lt;IsSpiceCopyPasteEnabled&gt;true&lt;/IsSpiceCopyPasteEnabled&gt;&lt;AllowConsoleReconnect&gt;true&lt;/AllowConsoleReconnect&gt;&lt;ConsoleDisconnectAction&gt;LOCK_SCREEN&lt;/ConsoleDisconnectAction&gt;&lt;CustomEmulatedMachine&gt;&lt;/CustomEmulatedMachine&gt;&lt;BiosType&gt;0&lt;/BiosType&gt;&lt;CustomCpuName&gt;&lt;/CustomCpuName&gt;&lt;PredefinedProperties&gt;&lt;/PredefinedProperties&gt;&lt;UserDefinedProperties&gt;&lt;/UserDefinedProperties&gt;&lt;MaxMemorySizeMb&gt;4096&lt;/MaxMemorySizeMb&gt;&lt;MultiQueuesEnabled&gt;true&lt;/MultiQueuesEnabled&gt;&lt;UseHostCpu&gt;false&lt;/UseHostCpu&gt;&lt;ClusterName&gt;depot_cl&lt;/ClusterName&gt;&lt;TemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/TemplateId&gt;&lt;TemplateName&gt;Blank&lt;/TemplateName&gt;&lt;IsInitilized&gt;true&lt;/IsInitilized&gt;&lt;Origin&gt;0&lt;/Origin&gt;&lt;app_list&gt;ovirt-guest-agent-common-1.0.16-1.el7ev,kernel-3.10.0-1062.el7&lt;/app_list&gt;&lt;quota_id&gt;5fa337c2-9eb4-4d83-9d6a-739cf88a2312&lt;/quota_id&gt;&lt;DefaultDisplayType&gt;1&lt;/DefaultDisplayType&gt;&lt;TrustedService&gt;false&lt;/TrustedService&gt;&lt;OriginalTemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/OriginalTemplateId&gt;&lt;OriginalTemplateName&gt;Blank&lt;/OriginalTemplateName&gt;&lt;UseLatestVersion&gt;false&lt;/UseLatestVersion&gt;&lt;StopTime&gt;2019/12/16 10:56:19&lt;/StopTime&gt;&lt;BootTime&gt;2019/12/16 10:56:20&lt;/BootTime&gt;&lt;Downtime&gt;0&lt;/Downtime&gt;&lt;Section ovf:id="17a94da8-3d02-430e-9b83-5e39f92907e8" ovf:required="false" xsi:type="ovf:OperatingSystemSection_Type"&gt;&lt;Info&gt;Guest Operating System&lt;/Info&gt;&lt;Description&gt;rhel_7x64&lt;/Description&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:VirtualHardwareSection_Type"&gt;&lt;Info&gt;4 CPU, 3072 Memory&lt;/Info&gt;&lt;System&gt;&lt;vssd:VirtualSystemType&gt;ENGINE 4.1.0.0&lt;/vssd:VirtualSystemType&gt;&lt;/System&gt;&lt;Item&gt;&lt;rasd:Caption&gt;4 virtual cpu&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Number of virtual CPU&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;1&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;3&lt;/rasd:ResourceType&gt;&lt;rasd:num_of_sockets&gt;4&lt;/rasd:num_of_sockets&gt;&lt;rasd:cpu_per_socket&gt;1&lt;/rasd:cpu_per_socket&gt;&lt;rasd:threads_per_cpu&gt;1&lt;/rasd:threads_per_cpu&gt;&lt;rasd:max_num_of_vcpus&gt;16&lt;/rasd:max_num_of_vcpus&gt;&lt;rasd:VirtualQuantity&gt;4&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;3072 MB of memory&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Memory Size&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;2&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;4&lt;/rasd:ResourceType&gt;&lt;rasd:AllocationUnits&gt;MegaBytes&lt;/rasd:AllocationUnits&gt;&lt;rasd:VirtualQuantity&gt;3072&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;rhel7s_Disk1&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;17&lt;/rasd:ResourceType&gt;&lt;rasd:HostResource&gt;f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:HostResource&gt;&lt;rasd:Parent&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Parent&gt;&lt;rasd:Template&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Template&gt;&lt;rasd:ApplicationList&gt;&lt;/rasd:ApplicationList&gt;&lt;rasd:StorageId&gt;cfbc93a1-17b7-4d03-a8ca-3b3bfef52729&lt;/rasd:StorageId&gt;&lt;rasd:StoragePoolId&gt;e57249a3-d28a-455f-b30c-4ac0979f2ccc&lt;/rasd:StoragePoolId&gt;&lt;rasd:CreationDate&gt;2019/10/15 10:13:29&lt;/rasd:CreationDate&gt;&lt;rasd:LastModified&gt;1970/01/01 00:00:00&lt;/rasd:LastModified&gt;&lt;rasd:last_modified_date&gt;2019/12/16 11:00:30&lt;/rasd:last_modified_date&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;disk&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=0, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;1&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-f6e4775b-53be-4136-9e30-f0be18b70668&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Ethernet adapter on ovirtmgmt&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;93159b67-49fe-4add-8b31-91be915a208b&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;10&lt;/rasd:ResourceType&gt;&lt;rasd:OtherResourceType&gt;ovirtmgmt&lt;/rasd:OtherResourceType&gt;&lt;rasd:ResourceSubType&gt;3&lt;/rasd:ResourceSubType&gt;&lt;rasd:Connection&gt;ovirtmgmt&lt;/rasd:Connection&gt;&lt;rasd:Linked&gt;true&lt;/rasd:Linked&gt;&lt;rasd:Name&gt;nic1&lt;/rasd:Name&gt;&lt;rasd:ElementName&gt;nic1&lt;/rasd:ElementName&gt;&lt;rasd:MACAddress&gt;56:6f:85:ae:00:00&lt;/rasd:MACAddress&gt;&lt;rasd:speed&gt;10000&lt;/rasd:speed&gt;&lt;Type&gt;interface&lt;/Type&gt;&lt;Device&gt;bridge&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x03, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-93159b67-49fe-4add-8b31-91be915a208b&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;USB Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;3&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;23&lt;/rasd:ResourceType&gt;&lt;rasd:UsbPolicy&gt;DISABLED&lt;/rasd:UsbPolicy&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;20&lt;/rasd:ResourceType&gt;&lt;rasd:VirtualQuantity&gt;1&lt;/rasd:VirtualQuantity&gt;&lt;rasd:SinglePciQxl&gt;false&lt;/rasd:SinglePciQxl&gt;&lt;Type&gt;video&lt;/Type&gt;&lt;Device&gt;qxl&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x02, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;vgamem&gt;16384&lt;/vgamem&gt;&lt;heads&gt;1&lt;/heads&gt;&lt;vram&gt;32768&lt;/vram&gt;&lt;ram&gt;65536&lt;/ram&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d835d395-f01c-4991-8643-b0578b2f3cf4&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;spice&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;393b1788-8d19-4f18-ac73-9984db012e59&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;vnc&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;CDROM&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;15&lt;/rasd:ResourceType&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;cdrom&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=1, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;2&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/Alias&gt;&lt;SpecParams&gt;&lt;path&gt;rhel-server-7.7-x86_64-dvd.iso&lt;/path&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;883eafad-4981-438d-8a50-097a76503006&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel1&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;beb53b7a-abd9-432f-90f2-3ec4c30998e7&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;spicevmc&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=3}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel2&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;0e988f54-ff5e-4f78-953a-1dfe1e813bb7&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;ide&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ide&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;70b1a7fd-a377-41e3-b0c0-f3b5a0241e23&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel0&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-serial&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x05, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;2ac4481d-2ce4-48ac-97fe-cf89a7118715&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-scsi&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x04, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-2ac4481d-2ce4-48ac-97fe-cf89a7118715&lt;/Alias&gt;&lt;SpecParams&gt;&lt;ioThreadId&gt;&lt;/ioThreadId&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;b8eed426-0eb3-4f95-9fb7-6c430490bf0e&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;usb&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;usb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;model&gt;piix3-uhci&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/rasd:InstanceId&gt;&lt;Type&gt;rng&lt;/Type&gt;&lt;Device&gt;virtio&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x07, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/Alias&gt;&lt;SpecParams&gt;&lt;source&gt;urandom&lt;/source&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/rasd:InstanceId&gt;&lt;Type&gt;balloon&lt;/Type&gt;&lt;Device&gt;memballoon&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x06, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/Alias&gt;&lt;SpecParams&gt;&lt;model&gt;virtio&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:SnapshotsSection_Type"&gt;&lt;Snapshot ovf:id="fc282c90-ded5-456b-ab99-2d2fe6abc262"&gt;&lt;Type&gt;ACTIVE&lt;/Type&gt;&lt;Description&gt;Active VM&lt;/Description&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;/Snapshot&gt;&lt;/Section&gt;&lt;/Content&gt;&lt;/ovf:Envelope&gt;</data>
+                  <type>ovf</type>
+              </configuration>
+              <custom_script></custom_script>
+              <nic_configurations/>
+              <regenerate_ssh_keys>false</regenerate_ssh_keys>
+          </initialization>
+          <io>
+              <threads>1</threads>
+          </io>
+          <large_icon href="/ovirt-engine/api/icons/286c4070-4374-12d6-af2d-ab35a7395e5f" id="286c4070-4374-12d6-af2d-ab35a7395e5f"/>
+          <memory>3221225472</memory>
+          <memory_policy>
+              <ballooning>true</ballooning>
+              <guaranteed>3221225472</guaranteed>
+              <max>4294967296</max>
+          </memory_policy>
+          <migration>
+              <auto_converge>inherit</auto_converge>
+              <compressed>inherit</compressed>
+          </migration>
+          <migration_downtime>-1</migration_downtime>
+          <multi_queues_enabled>true</multi_queues_enabled>
+          <origin>rhev</origin>
+          <os>
+              <boot>
+                  <devices>
+                      <device>hd</device>
+                      <device>cdrom</device>
+                  </devices>
+              </boot>
+              <type>rhel_7x64</type>
+          </os>
+          <placement_policy>
+              <affinity>migratable</affinity>
+          </placement_policy>
+          <rng_device>
+              <source>urandom</source>
+          </rng_device>
+          <small_icon href="/ovirt-engine/api/icons/a029b4bf-5437-dae6-0cdf-3c9fb623cf1d" id="a029b4bf-5437-dae6-0cdf-3c9fb623cf1d"/>
+          <soundcard_enabled>false</soundcard_enabled>
+          <sso>
+              <methods>
+                  <method id="guest_agent"/>
+              </methods>
+          </sso>
+          <start_paused>false</start_paused>
+          <stateless>false</stateless>
+          <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+          <time_zone>
+              <name>Europe/Warsaw</name>
+          </time_zone>
+          <type>server</type>
+          <usb>
+              <enabled>false</enabled>
+          </usb>
+          <virtio_scsi>
+              <enabled>true</enabled>
+          </virtio_scsi>
+          <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde"/>
+          <cpu_profile href="/ovirt-engine/api/cpuprofiles/c5926295-65ef-4dba-b234-26db503cb59d" id="c5926295-65ef-4dba-b234-26db503cb59d"/>
+          <quota id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+          <fqdn>rhels</fqdn>
+          <guest_operating_system>
+              <architecture>x86_64</architecture>
+              <codename>Server</codename>
+              <distribution>Red Hat Enterprise Linux Server</distribution>
+              <family>Linux</family>
+              <kernel>
+                  <version>
+                      <build>0</build>
+                      <full_version>3.10.0-1062.el7.x86_64</full_version>
+                      <major>3</major>
+                      <minor>10</minor>
+                      <revision>1062</revision>
+                  </version>
+              </kernel>
+              <version>
+                  <full_version>7.7</full_version>
+                  <major>7</major>
+                  <minor>7</minor>
+              </version>
+          </guest_operating_system>
+          <guest_time_zone>
+              <name>EST</name>
+              <utc_offset>-05:00</utc_offset>
+          </guest_time_zone>
+          <next_run_configuration_exists>false</next_run_configuration_exists>
+          <numa_tune_mode>interleave</numa_tune_mode>
+          <run_once>false</run_once>
+          <start_time>2019-12-16T11:56:20.331+01:00</start_time>
+          <status>up</status>
+          <stop_time>2019-12-16T11:56:19.886+01:00</stop_time>
+          <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
+          <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+          <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+      </vm>
+    :code: 200
+    :headers:
+      date: Mon, 16 Dec 2019 11:00:30 GMT
+      server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+      content-encoding: gzip
+      content-type: application/xml;charset=UTF-8
+      content-length: '6582'
+      correlation-id: 7c7e5776-85da-46c4-83f8-e46e8c899299
+    :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
         <actions>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
@@ -2737,22 +4322,22 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <name>rhel7s</name>
         <description></description>
         <comment></comment>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
         <bios>
             <boot_menu>
@@ -2894,266 +4479,43 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <next_run_configuration_exists>false</next_run_configuration_exists>
         <numa_tune_mode>interleave</numa_tune_mode>
         <run_once>false</run_once>
-        <start_time>2019-12-02T12:31:18.745+01:00</start_time>
+        <start_time>2019-12-16T11:56:20.331+01:00</start_time>
         <status>up</status>
-        <stop_time>2019-12-02T12:31:18.018+01:00</stop_time>
+        <stop_time>2019-12-16T11:56:19.886+01:00</stop_time>
         <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
         <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
         <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
     </vm>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '3226'
-    correlation-id: 66ccb59f-7e23-42e0-bc47-546068595d94
+    content-length: '3232'
+    correlation-id: 1ddd50a8-7ae3-4181-b637-50e77f72d531
   :message: 
-? |
-  https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{:next_run=>"false"}PUT<vm>
-    <cpu>
-      <topology>
-        <cores>1</cores>
-        <sockets>4</sockets>
-      </topology>
-    </cpu>
-  </vm>
-: - :body: |
-      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-      <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
-          <actions>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/suspend" rel="suspend"/>
-          </actions>
-          <name>rhel7s</name>
-          <description></description>
-          <comment></comment>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
-          <bios>
-              <boot_menu>
-                  <enabled>false</enabled>
-              </boot_menu>
-              <type>i440fx_sea_bios</type>
-          </bios>
-          <console>
-              <enabled>false</enabled>
-          </console>
-          <cpu>
-              <architecture>x86_64</architecture>
-              <topology>
-                  <cores>1</cores>
-                  <sockets>4</sockets>
-                  <threads>1</threads>
-              </topology>
-          </cpu>
-          <cpu_shares>0</cpu_shares>
-          <creation_time>2019-10-15T12:12:12.505+02:00</creation_time>
-          <delete_protected>false</delete_protected>
-          <display>
-              <address>192.168.178.48</address>
-              <allow_override>true</allow_override>
-              <certificate>
-                  <content>-----BEGIN CERTIFICATE-----
-      MIIDujCCAqKgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwRTELMAkGA1UEBhMCVVMxEjAQBgNVBAoM
-      CWZyaXR6LmJveDEiMCAGA1UEAwwZZW5naW5lLTQzLmZyaXR6LmJveC40MDczNzAeFw0xOTEwMTMx
-      NTU1MTJaFw0yOTEwMTExNTU1MTJaMEUxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlmcml0ei5ib3gx
-      IjAgBgNVBAMMGWVuZ2luZS00My5mcml0ei5ib3guNDA3MzcwggEiMA0GCSqGSIb3DQEBAQUAA4IB
-      DwAwggEKAoIBAQDOBt7e2IGBsiRkzj/139dMZVOIiUr7d2O/6ECI284u/U/ENY3kJT5tKVbn7UAk
-      8MnEH92FMBN2fcaGAnk36I6ZnJBxbj59mVPNgu7bktViKZkvgHEbZuX3BctJJZDrh0D67zIRsSKd
-      5xsFFWIjUAUkmyKOuxD4xsqXop1Cw5cjSzadY6XZMi2vw0yFtOUQ/3FMpXkZ9yAMT+clzaUu3rgs
-      IUbnLSpfKdDUm5NzCksOo8gOjXmx0OkXna8nQvQGb3ycmTeS10MzeURtgkPlfR+nZWDDiUNOHLmZ
-      y1IoZxsq0MmZx42YqbQ1WjPzj55H7rXhYqATUBjvYYh+39WSP/pfAgMBAAGjgbMwgbAwHQYDVR0O
-      BBYEFD9mD6ChOc01EKwqT3PaF+jxY+1MMG4GA1UdIwRnMGWAFD9mD6ChOc01EKwqT3PaF+jxY+1M
-      oUmkRzBFMQswCQYDVQQGEwJVUzESMBAGA1UECgwJZnJpdHouYm94MSIwIAYDVQQDDBllbmdpbmUt
-      NDMuZnJpdHouYm94LjQwNzM3ggIQADAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAN
-      BgkqhkiG9w0BAQsFAAOCAQEAilO/2+J+etHnfkY5Zlw5fCi4f20fhA0C2k3pmyzEnk+02/cBr1XK
-      PfsDXCEmCiXpMTru3iflYee6L5MRZqDuu7dKaZVwYhdCpURHxkMuBT7gA0YvtC1TNnRDu2EDvjUh
-      /Mtqngojv4XdCM1aza0fw0pyE+mz+e+97KLGmtutj0W2JymsXcHtHlLJxjNXTie7qzsrMKGLfKmq
-      eBceTlpcGF98zFqlLEjRMuJ/I2AN2kDpK+e1zCFL1lYzb2MAN8Aol2Eqw6ZrezVT+5NLnJ/aw55S
-      HuXeUczWeCztAUiGYS9HD2kcdp9Y7mr4OMZi+IePz5mkn0TTkCgNcIQho3vH1Q==
-      -----END CERTIFICATE-----
-      </content>
-                  <organization>fritz.box</organization>
-                  <subject>O=fritz.box,CN=host01-43.fritz.box</subject>
-              </certificate>
-              <copy_paste_enabled>true</copy_paste_enabled>
-              <disconnect_action>LOCK_SCREEN</disconnect_action>
-              <file_transfer_enabled>true</file_transfer_enabled>
-              <monitors>1</monitors>
-              <port>5901</port>
-              <secure_port>5902</secure_port>
-              <single_qxl_pci>false</single_qxl_pci>
-              <smartcard_enabled>false</smartcard_enabled>
-              <type>spice</type>
-          </display>
-          <high_availability>
-              <enabled>false</enabled>
-              <priority>1</priority>
-          </high_availability>
-          <initialization>
-              <authorized_ssh_keys></authorized_ssh_keys>
-              <configuration>
-                  <data>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1/" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovf:version="4.1.0.0"&gt;&lt;References&gt;&lt;File ovf:href="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:id="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="2052321280" ovf:description="Active VM" ovf:disk_storage_type="IMAGE" ovf:cinder_volume_type=""&gt;&lt;/File&gt;&lt;/References&gt;&lt;NetworkSection&gt;&lt;Info&gt;List of networks&lt;/Info&gt;&lt;Network ovf:name="ovirtmgmt"&gt;&lt;/Network&gt;&lt;/NetworkSection&gt;&lt;Section xsi:type="ovf:DiskSection_Type"&gt;&lt;Info&gt;List of Virtual Disks&lt;/Info&gt;&lt;Disk ovf:diskId="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="15" ovf:actual_size="2" ovf:vm_snapshot_id="fc282c90-ded5-456b-ab99-2d2fe6abc262" ovf:parentRef="" ovf:fileRef="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:format="http://www.vmware.com/specifications/vmdk.html#sparse" ovf:volume-format="RAW" ovf:volume-type="Sparse" ovf:disk-interface="VirtIO_SCSI" ovf:read-only="false" ovf:shareable="false" ovf:boot="true" ovf:pass-discard="false" ovf:disk-alias="rhel7s_Disk1" ovf:disk-description="" ovf:wipe-after-delete="true"&gt;&lt;/Disk&gt;&lt;/Section&gt;&lt;Content ovf:id="out" xsi:type="ovf:VirtualSystem_Type"&gt;&lt;Name&gt;rhel7s&lt;/Name&gt;&lt;Description&gt;&lt;/Description&gt;&lt;Comment&gt;&lt;/Comment&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;ExportDate&gt;2019/12/02 11:32:16&lt;/ExportDate&gt;&lt;DeleteProtected&gt;false&lt;/DeleteProtected&gt;&lt;SsoMethod&gt;guest_agent&lt;/SsoMethod&gt;&lt;IsSmartcardEnabled&gt;false&lt;/IsSmartcardEnabled&gt;&lt;NumOfIoThreads&gt;1&lt;/NumOfIoThreads&gt;&lt;TimeZone&gt;Europe/Warsaw&lt;/TimeZone&gt;&lt;default_boot_sequence&gt;9&lt;/default_boot_sequence&gt;&lt;Generation&gt;891&lt;/Generation&gt;&lt;ClusterCompatibilityVersion&gt;4.3&lt;/ClusterCompatibilityVersion&gt;&lt;VmType&gt;1&lt;/VmType&gt;&lt;ResumeBehavior&gt;AUTO_RESUME&lt;/ResumeBehavior&gt;&lt;MinAllocatedMem&gt;3072&lt;/MinAllocatedMem&gt;&lt;IsStateless&gt;false&lt;/IsStateless&gt;&lt;IsRunAndPause&gt;false&lt;/IsRunAndPause&gt;&lt;AutoStartup&gt;false&lt;/AutoStartup&gt;&lt;Priority&gt;1&lt;/Priority&gt;&lt;CreatedByUserId&gt;251a2aee-ee9b-11e9-a6be-5254005a3239&lt;/CreatedByUserId&gt;&lt;MigrationSupport&gt;0&lt;/MigrationSupport&gt;&lt;IsBootMenuEnabled&gt;false&lt;/IsBootMenuEnabled&gt;&lt;IsSpiceFileTransferEnabled&gt;true&lt;/IsSpiceFileTransferEnabled&gt;&lt;IsSpiceCopyPasteEnabled&gt;true&lt;/IsSpiceCopyPasteEnabled&gt;&lt;AllowConsoleReconnect&gt;true&lt;/AllowConsoleReconnect&gt;&lt;ConsoleDisconnectAction&gt;LOCK_SCREEN&lt;/ConsoleDisconnectAction&gt;&lt;CustomEmulatedMachine&gt;&lt;/CustomEmulatedMachine&gt;&lt;BiosType&gt;0&lt;/BiosType&gt;&lt;CustomCpuName&gt;&lt;/CustomCpuName&gt;&lt;PredefinedProperties&gt;&lt;/PredefinedProperties&gt;&lt;UserDefinedProperties&gt;&lt;/UserDefinedProperties&gt;&lt;MaxMemorySizeMb&gt;4096&lt;/MaxMemorySizeMb&gt;&lt;MultiQueuesEnabled&gt;true&lt;/MultiQueuesEnabled&gt;&lt;UseHostCpu&gt;false&lt;/UseHostCpu&gt;&lt;ClusterName&gt;depot_cl&lt;/ClusterName&gt;&lt;TemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/TemplateId&gt;&lt;TemplateName&gt;Blank&lt;/TemplateName&gt;&lt;IsInitilized&gt;true&lt;/IsInitilized&gt;&lt;Origin&gt;0&lt;/Origin&gt;&lt;app_list&gt;ovirt-guest-agent-common-1.0.16-1.el7ev,kernel-3.10.0-1062.el7,qemu-guest-agent-2.12.0&lt;/app_list&gt;&lt;quota_id&gt;5fa337c2-9eb4-4d83-9d6a-739cf88a2312&lt;/quota_id&gt;&lt;DefaultDisplayType&gt;1&lt;/DefaultDisplayType&gt;&lt;TrustedService&gt;false&lt;/TrustedService&gt;&lt;OriginalTemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/OriginalTemplateId&gt;&lt;OriginalTemplateName&gt;Blank&lt;/OriginalTemplateName&gt;&lt;UseLatestVersion&gt;false&lt;/UseLatestVersion&gt;&lt;StopTime&gt;2019/12/02 11:31:18&lt;/StopTime&gt;&lt;BootTime&gt;2019/12/02 11:31:18&lt;/BootTime&gt;&lt;Downtime&gt;0&lt;/Downtime&gt;&lt;Section ovf:id="17a94da8-3d02-430e-9b83-5e39f92907e8" ovf:required="false" xsi:type="ovf:OperatingSystemSection_Type"&gt;&lt;Info&gt;Guest Operating System&lt;/Info&gt;&lt;Description&gt;rhel_7x64&lt;/Description&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:VirtualHardwareSection_Type"&gt;&lt;Info&gt;4 CPU, 3072 Memory&lt;/Info&gt;&lt;System&gt;&lt;vssd:VirtualSystemType&gt;ENGINE 4.1.0.0&lt;/vssd:VirtualSystemType&gt;&lt;/System&gt;&lt;Item&gt;&lt;rasd:Caption&gt;4 virtual cpu&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Number of virtual CPU&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;1&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;3&lt;/rasd:ResourceType&gt;&lt;rasd:num_of_sockets&gt;4&lt;/rasd:num_of_sockets&gt;&lt;rasd:cpu_per_socket&gt;1&lt;/rasd:cpu_per_socket&gt;&lt;rasd:threads_per_cpu&gt;1&lt;/rasd:threads_per_cpu&gt;&lt;rasd:max_num_of_vcpus&gt;16&lt;/rasd:max_num_of_vcpus&gt;&lt;rasd:VirtualQuantity&gt;4&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;3072 MB of memory&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Memory Size&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;2&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;4&lt;/rasd:ResourceType&gt;&lt;rasd:AllocationUnits&gt;MegaBytes&lt;/rasd:AllocationUnits&gt;&lt;rasd:VirtualQuantity&gt;3072&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;rhel7s_Disk1&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;17&lt;/rasd:ResourceType&gt;&lt;rasd:HostResource&gt;f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:HostResource&gt;&lt;rasd:Parent&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Parent&gt;&lt;rasd:Template&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Template&gt;&lt;rasd:ApplicationList&gt;&lt;/rasd:ApplicationList&gt;&lt;rasd:StorageId&gt;cfbc93a1-17b7-4d03-a8ca-3b3bfef52729&lt;/rasd:StorageId&gt;&lt;rasd:StoragePoolId&gt;e57249a3-d28a-455f-b30c-4ac0979f2ccc&lt;/rasd:StoragePoolId&gt;&lt;rasd:CreationDate&gt;2019/10/15 10:13:29&lt;/rasd:CreationDate&gt;&lt;rasd:LastModified&gt;1970/01/01 00:00:00&lt;/rasd:LastModified&gt;&lt;rasd:last_modified_date&gt;2019/12/02 11:32:16&lt;/rasd:last_modified_date&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;disk&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=0, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;1&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-f6e4775b-53be-4136-9e30-f0be18b70668&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Ethernet adapter on ovirtmgmt&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;93159b67-49fe-4add-8b31-91be915a208b&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;10&lt;/rasd:ResourceType&gt;&lt;rasd:OtherResourceType&gt;ovirtmgmt&lt;/rasd:OtherResourceType&gt;&lt;rasd:ResourceSubType&gt;3&lt;/rasd:ResourceSubType&gt;&lt;rasd:Connection&gt;ovirtmgmt&lt;/rasd:Connection&gt;&lt;rasd:Linked&gt;true&lt;/rasd:Linked&gt;&lt;rasd:Name&gt;nic1&lt;/rasd:Name&gt;&lt;rasd:ElementName&gt;nic1&lt;/rasd:ElementName&gt;&lt;rasd:MACAddress&gt;56:6f:85:ae:00:00&lt;/rasd:MACAddress&gt;&lt;rasd:speed&gt;10000&lt;/rasd:speed&gt;&lt;Type&gt;interface&lt;/Type&gt;&lt;Device&gt;bridge&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x03, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-93159b67-49fe-4add-8b31-91be915a208b&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;USB Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;3&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;23&lt;/rasd:ResourceType&gt;&lt;rasd:UsbPolicy&gt;DISABLED&lt;/rasd:UsbPolicy&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;20&lt;/rasd:ResourceType&gt;&lt;rasd:VirtualQuantity&gt;1&lt;/rasd:VirtualQuantity&gt;&lt;rasd:SinglePciQxl&gt;false&lt;/rasd:SinglePciQxl&gt;&lt;Type&gt;video&lt;/Type&gt;&lt;Device&gt;qxl&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x02, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;vgamem&gt;16384&lt;/vgamem&gt;&lt;heads&gt;1&lt;/heads&gt;&lt;vram&gt;32768&lt;/vram&gt;&lt;ram&gt;65536&lt;/ram&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d835d395-f01c-4991-8643-b0578b2f3cf4&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;spice&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;393b1788-8d19-4f18-ac73-9984db012e59&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;vnc&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;CDROM&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;15&lt;/rasd:ResourceType&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;cdrom&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=1, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;2&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/Alias&gt;&lt;SpecParams&gt;&lt;path&gt;rhel-server-7.7-x86_64-dvd.iso&lt;/path&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;03b19568-7ba5-4db2-a014-e5584d18c54e&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel0&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;1dde7e51-d59d-4c42-adc0-2507abe70f52&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel1&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;3eda54d6-728d-49fc-b1cb-3787cdd92a36&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;spicevmc&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=3}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel2&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;0e988f54-ff5e-4f78-953a-1dfe1e813bb7&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;ide&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ide&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-serial&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x05, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;b8eed426-0eb3-4f95-9fb7-6c430490bf0e&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;usb&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;usb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;model&gt;piix3-uhci&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;b7cbfaac-6c0f-4d34-90b0-487f8248c580&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-scsi&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x04, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-b7cbfaac-6c0f-4d34-90b0-487f8248c580&lt;/Alias&gt;&lt;SpecParams&gt;&lt;ioThreadId&gt;&lt;/ioThreadId&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/rasd:InstanceId&gt;&lt;Type&gt;rng&lt;/Type&gt;&lt;Device&gt;virtio&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x07, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/Alias&gt;&lt;SpecParams&gt;&lt;source&gt;urandom&lt;/source&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/rasd:InstanceId&gt;&lt;Type&gt;balloon&lt;/Type&gt;&lt;Device&gt;memballoon&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x06, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/Alias&gt;&lt;SpecParams&gt;&lt;model&gt;virtio&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:SnapshotsSection_Type"&gt;&lt;Snapshot ovf:id="fc282c90-ded5-456b-ab99-2d2fe6abc262"&gt;&lt;Type&gt;ACTIVE&lt;/Type&gt;&lt;Description&gt;Active VM&lt;/Description&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;/Snapshot&gt;&lt;/Section&gt;&lt;/Content&gt;&lt;/ovf:Envelope&gt;</data>
-                  <type>ovf</type>
-              </configuration>
-              <custom_script></custom_script>
-              <nic_configurations/>
-              <regenerate_ssh_keys>false</regenerate_ssh_keys>
-          </initialization>
-          <io>
-              <threads>1</threads>
-          </io>
-          <large_icon href="/ovirt-engine/api/icons/286c4070-4374-12d6-af2d-ab35a7395e5f" id="286c4070-4374-12d6-af2d-ab35a7395e5f"/>
-          <memory>3221225472</memory>
-          <memory_policy>
-              <ballooning>true</ballooning>
-              <guaranteed>3221225472</guaranteed>
-              <max>4294967296</max>
-          </memory_policy>
-          <migration>
-              <auto_converge>inherit</auto_converge>
-              <compressed>inherit</compressed>
-          </migration>
-          <migration_downtime>-1</migration_downtime>
-          <multi_queues_enabled>true</multi_queues_enabled>
-          <origin>rhev</origin>
-          <os>
-              <boot>
-                  <devices>
-                      <device>hd</device>
-                      <device>cdrom</device>
-                  </devices>
-              </boot>
-              <type>rhel_7x64</type>
-          </os>
-          <placement_policy>
-              <affinity>migratable</affinity>
-          </placement_policy>
-          <rng_device>
-              <source>urandom</source>
-          </rng_device>
-          <small_icon href="/ovirt-engine/api/icons/a029b4bf-5437-dae6-0cdf-3c9fb623cf1d" id="a029b4bf-5437-dae6-0cdf-3c9fb623cf1d"/>
-          <soundcard_enabled>false</soundcard_enabled>
-          <sso>
-              <methods>
-                  <method id="guest_agent"/>
-              </methods>
-          </sso>
-          <start_paused>false</start_paused>
-          <stateless>false</stateless>
-          <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
-          <time_zone>
-              <name>Europe/Warsaw</name>
-          </time_zone>
-          <type>server</type>
-          <usb>
-              <enabled>false</enabled>
-          </usb>
-          <virtio_scsi>
-              <enabled>true</enabled>
-          </virtio_scsi>
-          <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde"/>
-          <cpu_profile href="/ovirt-engine/api/cpuprofiles/c5926295-65ef-4dba-b234-26db503cb59d" id="c5926295-65ef-4dba-b234-26db503cb59d"/>
-          <quota id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
-          <fqdn>rhels</fqdn>
-          <guest_operating_system>
-              <architecture>x86_64</architecture>
-              <codename>Server</codename>
-              <distribution>Red Hat Enterprise Linux Server</distribution>
-              <family>Linux</family>
-              <kernel>
-                  <version>
-                      <build>0</build>
-                      <full_version>3.10.0-1062.el7.x86_64</full_version>
-                      <major>3</major>
-                      <minor>10</minor>
-                      <revision>1062</revision>
-                  </version>
-              </kernel>
-              <version>
-                  <full_version>7.7</full_version>
-                  <major>7</major>
-                  <minor>7</minor>
-              </version>
-          </guest_operating_system>
-          <guest_time_zone>
-              <name>EST</name>
-              <utc_offset>-05:00</utc_offset>
-          </guest_time_zone>
-          <next_run_configuration_exists>false</next_run_configuration_exists>
-          <numa_tune_mode>interleave</numa_tune_mode>
-          <run_once>false</run_once>
-          <start_time>2019-12-02T12:31:18.745+01:00</start_time>
-          <status>up</status>
-          <stop_time>2019-12-02T12:31:18.018+01:00</stop_time>
-          <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
-          <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
-          <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
-      </vm>
-    :code: 200
-    :headers:
-      date: Mon, 02 Dec 2019 11:32:16 GMT
-      server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
-      content-encoding: gzip
-      content-type: application/xml;charset=UTF-8
-      content-length: '6579'
-      correlation-id: 7fd320af-0516-41f4-9650-3acf6b45d30d
-    :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <cluster href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239" id="112b9702-ee9b-11e9-9d7c-5254005a3239">
         <actions>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/upgrade" rel="upgrade"/>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/syncallnetworks" rel="syncallnetworks"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
         </actions>
         <name>Default</name>
         <description>The default server cluster</description>
         <comment></comment>
-        <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networkfilters" rel="networkfilters"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networks" rel="networks"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/cpuprofiles" rel="cpuprofiles"/>
-        <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
+        <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glusterhooks" rel="glusterhooks"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glustervolumes" rel="glustervolumes"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/enabledfeatures" rel="enabledfeatures"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/externalnetworkproviders" rel="externalnetworkproviders"/>
+        <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
         <ballooning_enabled>false</ballooning_enabled>
         <cpu>
             <architecture>x86_64</architecture>
@@ -3226,12 +4588,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/112b9702-ee9b
     </cluster>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '1205'
-    correlation-id: 5410e40f-f933-4f1e-beb8-05c296884a0c
+    correlation-id: f7a51595-66a9-48fd-bc46-e90a0c72fdd2
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde{}GET:
 - :body: |
@@ -3239,21 +4601,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/adf7976e-d94b
     <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde">
         <actions>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/upgrade" rel="upgrade"/>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/syncallnetworks" rel="syncallnetworks"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
         </actions>
         <name>depot_cl</name>
         <description></description>
         <comment></comment>
-        <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networkfilters" rel="networkfilters"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networks" rel="networks"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/cpuprofiles" rel="cpuprofiles"/>
-        <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
+        <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glusterhooks" rel="glusterhooks"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glustervolumes" rel="glustervolumes"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/enabledfeatures" rel="enabledfeatures"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/externalnetworkproviders" rel="externalnetworkproviders"/>
+        <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
         <ballooning_enabled>false</ballooning_enabled>
         <cpu>
             <architecture>x86_64</architecture>
@@ -3327,12 +4689,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/adf7976e-d94b
     </cluster>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1236'
-    correlation-id: fafdada4-81c6-454a-8969-92c3db444144
+    content-length: '1235'
+    correlation-id: ec9da2e9-20ee-4536-95e5-c8c1c5681d4f
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc{}GET:
 - :body: |
@@ -3340,12 +4702,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
     <data_center href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc" id="e57249a3-d28a-455f-b30c-4ac0979f2ccc">
         <name>depot_dc</name>
         <description>Datacenter on depot machine</description>
-        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/networks" rel="networks"/>
-        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas" rel="quotas"/>
-        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/qoss" rel="qoss"/>
         <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/iscsibonds" rel="iscsibonds"/>
-        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/clusters" rel="clusters"/>
+        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas" rel="quotas"/>
+        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/networks" rel="networks"/>
         <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/storagedomains" rel="storagedomains"/>
+        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/clusters" rel="clusters"/>
+        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/qoss" rel="qoss"/>
         <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/permissions" rel="permissions"/>
         <local>false</local>
         <quota_mode>disabled</quota_mode>
@@ -3365,12 +4727,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
     </data_center>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '447'
-    correlation-id: 4046f1e9-3295-468b-b13c-d84bfcbb2eb5
+    content-length: '448'
+    correlation-id: 2cd5f4b3-2b8d-4df5-8ebb-0b086a27d52f
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729{}GET:
 - :body: |
@@ -3385,17 +4747,17 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a
         <name>depot_one</name>
         <description></description>
         <comment></comment>
-        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disksnapshots" rel="disksnapshots"/>
-        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/templates" rel="templates"/>
-        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/vms" rel="vms"/>
-        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
         <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/diskprofiles" rel="diskprofiles"/>
+        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
         <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/storageconnections" rel="storageconnections"/>
         <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/permissions" rel="permissions"/>
-        <available>517543559168</available>
+        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/templates" rel="templates"/>
+        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/vms" rel="vms"/>
+        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disksnapshots" rel="disksnapshots"/>
+        <available>515396075520</available>
         <backup>false</backup>
         <block_size>512</block_size>
-        <committed>16106127360</committed>
+        <committed>25769803776</committed>
         <critical_space_action_blocker>5</critical_space_action_blocker>
         <discard_after_delete>false</discard_after_delete>
         <external_status>ok</external_status>
@@ -3410,7 +4772,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a
         <supports_discard>false</supports_discard>
         <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
         <type>data</type>
-        <used>18253611008</used>
+        <used>20401094656</used>
         <warning_low_space_indicator>10</warning_low_space_indicator>
         <wipe_after_delete>false</wipe_after_delete>
         <data_centers>
@@ -3419,10 +4781,10 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a
     </storage_domain>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:32:16 GMT
+    date: Mon, 16 Dec 2019 11:00:30 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '714'
-    correlation-id: 2255c4aa-f3d6-44b5-85d9-89d032981fec
+    content-length: '712'
+    correlation-id: 52d18d19-6577-4a92-aad6-833350790ad8
   :message: 

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_reconfigure_with_restart_needed_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_reconfigure_with_restart_needed_recording.yml
@@ -6,21 +6,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
         <cluster href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239" id="112b9702-ee9b-11e9-9d7c-5254005a3239">
             <actions>
                 <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/upgrade" rel="upgrade"/>
-                <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
                 <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
             </actions>
             <name>Default</name>
             <description>The default server cluster</description>
             <comment></comment>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networkfilters" rel="networkfilters"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networks" rel="networks"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glusterhooks" rel="glusterhooks"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glustervolumes" rel="glustervolumes"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/enabledfeatures" rel="enabledfeatures"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
             <ballooning_enabled>false</ballooning_enabled>
             <cpu>
                 <architecture>x86_64</architecture>
@@ -94,21 +94,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
         <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde">
             <actions>
                 <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/upgrade" rel="upgrade"/>
-                <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
                 <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
             </actions>
             <name>depot_cl</name>
             <description></description>
             <comment></comment>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networkfilters" rel="networkfilters"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networks" rel="networks"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glusterhooks" rel="glusterhooks"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glustervolumes" rel="glustervolumes"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/enabledfeatures" rel="enabledfeatures"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
             <ballooning_enabled>false</ballooning_enabled>
             <cpu>
                 <architecture>x86_64</architecture>
@@ -183,12 +183,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
     </clusters>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1453'
-    correlation-id: 780cbf8c-82f3-44f2-bd90-a36c8905558d
+    content-length: '1454'
+    correlation-id: 64fd0bea-a3e2-4886-b94e-80b380be6d09
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -196,21 +196,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
         <cluster href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239" id="112b9702-ee9b-11e9-9d7c-5254005a3239">
             <actions>
                 <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/upgrade" rel="upgrade"/>
-                <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
                 <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
             </actions>
             <name>Default</name>
             <description>The default server cluster</description>
             <comment></comment>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networkfilters" rel="networkfilters"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networks" rel="networks"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glusterhooks" rel="glusterhooks"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glustervolumes" rel="glustervolumes"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/enabledfeatures" rel="enabledfeatures"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
             <ballooning_enabled>false</ballooning_enabled>
             <cpu>
                 <architecture>x86_64</architecture>
@@ -284,21 +284,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
         <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde">
             <actions>
                 <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/upgrade" rel="upgrade"/>
-                <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
                 <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
             </actions>
             <name>depot_cl</name>
             <description></description>
             <comment></comment>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networkfilters" rel="networkfilters"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networks" rel="networks"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glusterhooks" rel="glusterhooks"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glustervolumes" rel="glustervolumes"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/enabledfeatures" rel="enabledfeatures"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
             <ballooning_enabled>false</ballooning_enabled>
             <cpu>
                 <architecture>x86_64</architecture>
@@ -373,12 +373,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
     </clusters>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1453'
-    correlation-id: dc6df4a5-6c6a-46b2-86f2-9fdeda904ca7
+    content-length: '1454'
+    correlation-id: 981aedcb-80e7-4fab-91fc-133efe83c879
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
 - :body: |
@@ -394,12 +394,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
             <name>depot_iso</name>
             <description></description>
             <comment></comment>
-            <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/disksnapshots" rel="disksnapshots"/>
-            <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/files" rel="files"/>
             <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/diskprofiles" rel="diskprofiles"/>
             <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/storageconnections" rel="storageconnections"/>
             <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/permissions" rel="permissions"/>
-            <available>517543559168</available>
+            <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/f67ec7bb-2022-4018-a1e9-4ec5fbd1a591/files" rel="files"/>
+            <available>515396075520</available>
             <backup>false</backup>
             <block_size>512</block_size>
             <committed>0</committed>
@@ -417,7 +417,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
             <supports_discard>false</supports_discard>
             <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
             <type>iso</type>
-            <used>18253611008</used>
+            <used>20401094656</used>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <wipe_after_delete>false</wipe_after_delete>
             <data_centers>
@@ -434,17 +434,17 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
             <name>depot_one</name>
             <description></description>
             <comment></comment>
-            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disksnapshots" rel="disksnapshots"/>
-            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/templates" rel="templates"/>
-            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/vms" rel="vms"/>
-            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
             <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
             <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/storageconnections" rel="storageconnections"/>
             <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/permissions" rel="permissions"/>
-            <available>517543559168</available>
+            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disksnapshots" rel="disksnapshots"/>
+            <available>515396075520</available>
             <backup>false</backup>
             <block_size>512</block_size>
-            <committed>16106127360</committed>
+            <committed>25769803776</committed>
             <critical_space_action_blocker>5</critical_space_action_blocker>
             <discard_after_delete>false</discard_after_delete>
             <external_status>ok</external_status>
@@ -459,7 +459,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
             <supports_discard>false</supports_discard>
             <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
             <type>data</type>
-            <used>18253611008</used>
+            <used>20401094656</used>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <wipe_after_delete>false</wipe_after_delete>
             <data_centers>
@@ -469,12 +469,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
     </storage_domains>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '856'
-    correlation-id: 812c34e1-24ba-43a7-a094-4066575c016b
+    content-length: '858'
+    correlation-id: c7038a3f-20c7-400a-a927-7122a42f2adc
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts{}GET:
 - :body: |
@@ -487,34 +487,34 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts{}GET:
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/deactivate" rel="deactivate"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/upgrade" rel="upgrade"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/activate" rel="activate"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/enrollcertificate" rel="enrollcertificate"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/setupnetworks" rel="setupnetworks"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/fence" rel="fence"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/approve" rel="approve"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/commitnetconfig" rel="commitnetconfig"/>
+                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/enrollcertificate" rel="enrollcertificate"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/forceselectspm" rel="forceselectspm"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/iscsidiscover" rel="iscsidiscover"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/iscsilogin" rel="iscsilogin"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/unregisteredstoragedomainsdiscover" rel="unregisteredstoragedomainsdiscover"/>
                 <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/upgradecheck" rel="upgradecheck"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/syncallnetworks" rel="syncallnetworks"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/approve" rel="approve"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/commitnetconfig" rel="commitnetconfig"/>
-                <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/setupnetworks" rel="setupnetworks"/>
             </actions>
             <name>H1</name>
             <comment></comment>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/storage" rel="storage"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/networkattachments" rel="networkattachments"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/storageconnectionextensions" rel="storageconnectionextensions"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/unmanagednetworks" rel="unmanagednetworks"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/tags" rel="tags"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/fenceagents" rel="fenceagents"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/devices" rel="devices"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/hooks" rel="hooks"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics" rel="nics"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/numanodes" rel="numanodes"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/katelloerrata" rel="katelloerrata"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/permissions" rel="permissions"/>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/storage" rel="storage"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/storageconnectionextensions" rel="storageconnectionextensions"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/unmanagednetworks" rel="unmanagednetworks"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/statistics" rel="statistics"/>
             <address>host01-43.fritz.box</address>
             <auto_numa_status>disable</auto_numa_status>
@@ -621,34 +621,34 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts{}GET:
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/deactivate" rel="deactivate"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/upgrade" rel="upgrade"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/activate" rel="activate"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/enrollcertificate" rel="enrollcertificate"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/setupnetworks" rel="setupnetworks"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/fence" rel="fence"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/approve" rel="approve"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/commitnetconfig" rel="commitnetconfig"/>
+                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/enrollcertificate" rel="enrollcertificate"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/forceselectspm" rel="forceselectspm"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/iscsidiscover" rel="iscsidiscover"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/iscsilogin" rel="iscsilogin"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/unregisteredstoragedomainsdiscover" rel="unregisteredstoragedomainsdiscover"/>
                 <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/upgradecheck" rel="upgradecheck"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/syncallnetworks" rel="syncallnetworks"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/approve" rel="approve"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/commitnetconfig" rel="commitnetconfig"/>
-                <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/setupnetworks" rel="setupnetworks"/>
             </actions>
             <name>H2</name>
             <comment></comment>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/storage" rel="storage"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/networkattachments" rel="networkattachments"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/storageconnectionextensions" rel="storageconnectionextensions"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/unmanagednetworks" rel="unmanagednetworks"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/tags" rel="tags"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/fenceagents" rel="fenceagents"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/devices" rel="devices"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/hooks" rel="hooks"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics" rel="nics"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/numanodes" rel="numanodes"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/katelloerrata" rel="katelloerrata"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/permissions" rel="permissions"/>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/storage" rel="storage"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/storageconnectionextensions" rel="storageconnectionextensions"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/unmanagednetworks" rel="unmanagednetworks"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/statistics" rel="statistics"/>
             <address>host02-43.fritz.box</address>
             <auto_numa_status>disable</auto_numa_status>
@@ -751,34 +751,166 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts{}GET:
     </hosts>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '2304'
-    correlation-id: 29d19258-5092-46b6-925f-93a838fba70f
+    content-length: '2305'
+    correlation-id: 298da3ef-02e3-48f1-9394-611f4cd1a9d6
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <vms>
+        <vm href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696" id="022ce494-f739-40a3-a29a-d26ce125f696">
+            <actions>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/suspend" rel="suspend"/>
+            </actions>
+            <name>deb10</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/backups" rel="backups"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+                <type>i440fx_sea_bios</type>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2019-12-13T11:55:45.246+01:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>true</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>1</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/e90b3fe6-5539-cb53-5631-a45511ae4be7" id="e90b3fe6-5539-cb53-5631-a45511ae4be7"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>2147483648</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <multi_queues_enabled>true</multi_queues_enabled>
+            <origin>rhev</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                        <device>cdrom</device>
+                    </devices>
+                </boot>
+                <type>debian_7</type>
+            </os>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <small_icon href="/ovirt-engine/api/icons/a172d76b-891a-c1c3-4d2c-0b8d578ee71b" id="a172d76b-891a-c1c3-4d2c-0b8d578ee71b"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>server</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/c5926295-65ef-4dba-b234-26db503cb59d" id="c5926295-65ef-4dba-b234-26db503cb59d"/>
+            <quota id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <status>down</status>
+            <stop_reason></stop_reason>
+            <stop_time>2019-12-13T19:37:05.960+01:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
         <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
             <actions>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
                 <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
@@ -787,22 +919,22 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms{}GET:
             <name>rhel7s</name>
             <description></description>
             <comment></comment>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
             <bios>
                 <boot_menu>
@@ -943,9 +1075,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms{}GET:
             <next_run_configuration_exists>false</next_run_configuration_exists>
             <numa_tune_mode>interleave</numa_tune_mode>
             <run_once>false</run_once>
-            <start_time>2019-12-02T12:25:51.513+01:00</start_time>
+            <start_time>2019-12-16T11:53:51.115+01:00</start_time>
             <status>up</status>
-            <stop_time>2019-12-02T12:25:50.959+01:00</stop_time>
+            <stop_time>2019-12-16T11:53:49.827+01:00</stop_time>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
             <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
             <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
@@ -953,12 +1085,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms{}GET:
     </vms>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '3243'
-    correlation-id: eb16c7e5-8e40-47a5-af39-a586998891e5
+    content-length: '3733'
+    correlation-id: 15295582-529e-4ff5-9ffd-647dd3187acc
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates{}GET:
 - :body: |
@@ -971,13 +1103,13 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates{}GET:
             <name>Blank</name>
             <description>Blank template</description>
             <comment></comment>
-            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/watchdogs" rel="watchdogs"/>
-            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/graphicsconsoles" rel="graphicsconsoles"/>
             <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/cdroms" rel="cdroms"/>
             <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments" rel="diskattachments"/>
-            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/graphicsconsoles" rel="graphicsconsoles"/>
             <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/permissions" rel="permissions"/>
             <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics" rel="nics"/>
             <bios>
                 <boot_menu>
                     <enabled>false</enabled>
@@ -1059,12 +1191,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates{}GET:
     </templates>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1118'
-    correlation-id: 7b02e344-262e-4487-b50d-7d4aea63b99d
+    content-length: '1117'
+    correlation-id: 55e09218-c1aa-44f7-9de5-f8565d5a4935
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/networks{}GET:
 - :body: |
@@ -1075,8 +1207,8 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/networks{}GET:
             <description>Default Management Network</description>
             <comment></comment>
             <link href="/ovirt-engine/api/networks/5a2457bc-b7bd-414f-852e-f92784600e21/networklabels" rel="networklabels"/>
-            <link href="/ovirt-engine/api/networks/5a2457bc-b7bd-414f-852e-f92784600e21/vnicprofiles" rel="vnicprofiles"/>
             <link href="/ovirt-engine/api/networks/5a2457bc-b7bd-414f-852e-f92784600e21/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/5a2457bc-b7bd-414f-852e-f92784600e21/vnicprofiles" rel="vnicprofiles"/>
             <mtu>0</mtu>
             <stp>false</stp>
             <usages>
@@ -1087,12 +1219,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/networks{}GET:
     </networks>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '357'
-    correlation-id: 8db2b36d-32d0-45e1-b6c7-05a6494f5776
+    correlation-id: fd7823fc-b0e0-46f0-8212-742e4f6d06c6
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{}GET:
 - :body: |
@@ -1101,12 +1233,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{}GET:
         <data_center href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc" id="e57249a3-d28a-455f-b30c-4ac0979f2ccc">
             <name>depot_dc</name>
             <description>Datacenter on depot machine</description>
-            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/networks" rel="networks"/>
-            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas" rel="quotas"/>
-            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/qoss" rel="qoss"/>
             <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/iscsibonds" rel="iscsibonds"/>
-            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/networks" rel="networks"/>
             <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/qoss" rel="qoss"/>
             <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/permissions" rel="permissions"/>
             <local>false</local>
             <quota_mode>disabled</quota_mode>
@@ -1127,57 +1259,25 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{}GET:
     </data_centers>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '461'
-    correlation-id: 5ba9843c-b286-4fd5-888c-64f060420e5d
+    content-length: '462'
+    correlation-id: 72476888-3114-49b2-8f58-02df125c55f5
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <disks>
-        <disk href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e" id="56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e">
-            <actions>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/refreshlun" rel="refreshlun"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/copy" rel="copy"/>
-            </actions>
-            <name>OVF_STORE</name>
-            <description>OVF_STORE</description>
-            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/permissions" rel="permissions"/>
-            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/statistics" rel="statistics"/>
-            <actual_size>134217728</actual_size>
-            <alias>OVF_STORE</alias>
-            <backup>none</backup>
-            <content_type>ovf_store</content_type>
-            <format>raw</format>
-            <image_id>dc123508-bab4-4f54-9466-3c15118d240b</image_id>
-            <propagate_errors>false</propagate_errors>
-            <provisioned_size>134217728</provisioned_size>
-            <shareable>true</shareable>
-            <sparse>false</sparse>
-            <status>ok</status>
-            <storage_type>image</storage_type>
-            <wipe_after_delete>false</wipe_after_delete>
-            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
-            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
-            <storage_domains>
-                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
-            </storage_domains>
-        </disk>
         <disk href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9" id="8b900d4d-81a1-4cbd-8006-8f22c8011ac9">
             <actions>
                 <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/refreshlun" rel="refreshlun"/>
                 <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/move" rel="move"/>
             </actions>
             <name>OVF_STORE</name>
             <description>OVF_STORE</description>
@@ -1202,14 +1302,244 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
                 <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
             </storage_domains>
         </disk>
+        <disk href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e" id="56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/move" rel="move"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>dc123508-bab4-4f54-9466-3c15118d240b</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f" id="b36b5649-225d-4a6d-9e04-c9af2c76666f">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>0cf4683a-f50c-4fb5-829f-0ecca92d9659</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e" id="e84216fc-a2b2-42ea-8d4a-dcd94aca411e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>9ed45f07-e665-45d3-a8a5-4ffd8884dac7</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565" id="8eb8be48-4379-4949-8bae-af5188bba565">
+            <actions>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>0c89dcb2-fb80-485c-ac65-36f1b2c9eb33</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>15728640</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76" id="7ebad349-5c61-441d-9e11-363a7291bd76">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>bfefd45d-087b-4922-87e2-b1c5d3fa41ca</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5" id="dbaf0588-6176-4440-b6fb-ddd3e6083dd5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>b8e87b8a-4786-44f2-b40f-a71fa629e276</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd" id="4756cf62-5bf5-4f8a-9cd1-c0f186636ccd">
+            <actions>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>667b60a3-c904-44db-a638-c8ae79e90e61</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
         <disk href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668" id="f6e4775b-53be-4136-9e30-f0be18b70668">
             <actions>
                 <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/refreshlun" rel="refreshlun"/>
                 <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/move" rel="move"/>
             </actions>
             <name>rhel7s_Disk1</name>
             <description></description>
@@ -1235,59 +1565,390 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
                 <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
             </storage_domains>
         </disk>
+        <disk href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9" id="eda59258-5aa0-460b-92c5-df61517cc7e9">
+            <actions>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>4acdce24-ed39-47dc-ae93-3ae35bbb8e71</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>52428800</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945" id="ca2c392f-e067-4b1a-ab1f-47dc75174945">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>e85bdff0-468e-476d-86a9-3204502d3b68</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>15728640</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf" id="b7ec93e0-1838-4706-b1d5-6561aa8b5adf">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk4</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk4</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>9a016e0c-7156-4451-bd82-33e34ae368b4</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>41943040</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67" id="e7bef226-5566-4f84-bd1e-7766d0510c67">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk1</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/statistics" rel="statistics"/>
+            <actual_size>1971261440</actual_size>
+            <alias>deb10_Disk1</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>a086eb2a-7086-4627-afcf-7eb258246349</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>8589934592</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>1971261440</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5" id="f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>3a53a19e-e66b-426c-ba2c-f7028818348e</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264" id="e5d385bd-2ebb-4024-8c82-35eda60f5264">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk4</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk4</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>49a02400-0600-42e7-acc7-ef774230d8b2</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>36700160</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309" id="307617bd-7c0b-477c-8f29-cfb75511f309">
+            <actions>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>6e1e2d81-d8bc-42cd-b639-fc0741a7853b</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b" id="ad5379a3-99ef-4fa7-a182-7941b61cff1b">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>476a0207-ee6c-4332-947b-d438c7d9eafd</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97" id="d3ab1baa-2c8a-4c34-8880-866443108e97">
+            <actions>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>68a7c6e9-b7f4-400e-bab5-ad6a19fdb292</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>31457280</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199" id="6604e824-a911-4ce8-9225-feaeb1963199">
+            <actions>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>824929a3-d782-4660-8381-8948227c1c9d</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80" id="7c542c3c-586f-47e1-9deb-d0a742952f80">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>c8517c9e-584a-4ee0-a5df-c86da0946655</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
     </disks>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '993'
-    correlation-id: 25068c97-4cc6-4fbc-b31d-fe4c6f878caf
+    content-length: '2920'
+    correlation-id: 5491cd6e-7430-4dfd-abc7-d91e4f5da83d
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <disks>
-        <disk href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e" id="56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e">
-            <actions>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/refreshlun" rel="refreshlun"/>
-                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/copy" rel="copy"/>
-            </actions>
-            <name>OVF_STORE</name>
-            <description>OVF_STORE</description>
-            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/permissions" rel="permissions"/>
-            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/statistics" rel="statistics"/>
-            <actual_size>134217728</actual_size>
-            <alias>OVF_STORE</alias>
-            <backup>none</backup>
-            <content_type>ovf_store</content_type>
-            <format>raw</format>
-            <image_id>dc123508-bab4-4f54-9466-3c15118d240b</image_id>
-            <propagate_errors>false</propagate_errors>
-            <provisioned_size>134217728</provisioned_size>
-            <shareable>true</shareable>
-            <sparse>false</sparse>
-            <status>ok</status>
-            <storage_type>image</storage_type>
-            <wipe_after_delete>false</wipe_after_delete>
-            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
-            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
-            <storage_domains>
-                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
-            </storage_domains>
-        </disk>
         <disk href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9" id="8b900d4d-81a1-4cbd-8006-8f22c8011ac9">
             <actions>
                 <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/refreshlun" rel="refreshlun"/>
                 <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/8b900d4d-81a1-4cbd-8006-8f22c8011ac9/move" rel="move"/>
             </actions>
             <name>OVF_STORE</name>
             <description>OVF_STORE</description>
@@ -1312,14 +1973,244 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
                 <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
             </storage_domains>
         </disk>
+        <disk href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e" id="56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/move" rel="move"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/56e9f3fd-6b7d-45bf-ab4d-9881f3e7f95e/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>dc123508-bab4-4f54-9466-3c15118d240b</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f" id="b36b5649-225d-4a6d-9e04-c9af2c76666f">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b36b5649-225d-4a6d-9e04-c9af2c76666f/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>0cf4683a-f50c-4fb5-829f-0ecca92d9659</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e" id="e84216fc-a2b2-42ea-8d4a-dcd94aca411e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e84216fc-a2b2-42ea-8d4a-dcd94aca411e/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>9ed45f07-e665-45d3-a8a5-4ffd8884dac7</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565" id="8eb8be48-4379-4949-8bae-af5188bba565">
+            <actions>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/8eb8be48-4379-4949-8bae-af5188bba565/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>0c89dcb2-fb80-485c-ac65-36f1b2c9eb33</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>15728640</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76" id="7ebad349-5c61-441d-9e11-363a7291bd76">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7ebad349-5c61-441d-9e11-363a7291bd76/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>bfefd45d-087b-4922-87e2-b1c5d3fa41ca</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5" id="dbaf0588-6176-4440-b6fb-ddd3e6083dd5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/dbaf0588-6176-4440-b6fb-ddd3e6083dd5/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>b8e87b8a-4786-44f2-b40f-a71fa629e276</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd" id="4756cf62-5bf5-4f8a-9cd1-c0f186636ccd">
+            <actions>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/4756cf62-5bf5-4f8a-9cd1-c0f186636ccd/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>667b60a3-c904-44db-a638-c8ae79e90e61</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
         <disk href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668" id="f6e4775b-53be-4136-9e30-f0be18b70668">
             <actions>
                 <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/reduce" rel="reduce"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/move" rel="move"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/sparsify" rel="sparsify"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/export" rel="export"/>
-                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/refreshlun" rel="refreshlun"/>
                 <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f6e4775b-53be-4136-9e30-f0be18b70668/move" rel="move"/>
             </actions>
             <name>rhel7s_Disk1</name>
             <description></description>
@@ -1345,15 +2236,378 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
                 <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
             </storage_domains>
         </disk>
+        <disk href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9" id="eda59258-5aa0-460b-92c5-df61517cc7e9">
+            <actions>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/eda59258-5aa0-460b-92c5-df61517cc7e9/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>4acdce24-ed39-47dc-ae93-3ae35bbb8e71</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>52428800</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945" id="ca2c392f-e067-4b1a-ab1f-47dc75174945">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ca2c392f-e067-4b1a-ab1f-47dc75174945/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>e85bdff0-468e-476d-86a9-3204502d3b68</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>15728640</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf" id="b7ec93e0-1838-4706-b1d5-6561aa8b5adf">
+            <actions>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk4</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/b7ec93e0-1838-4706-b1d5-6561aa8b5adf/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>deb10_Disk4</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>9a016e0c-7156-4451-bd82-33e34ae368b4</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>41943040</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67" id="e7bef226-5566-4f84-bd1e-7766d0510c67">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/move" rel="move"/>
+            </actions>
+            <name>deb10_Disk1</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67/statistics" rel="statistics"/>
+            <actual_size>1971261440</actual_size>
+            <alias>deb10_Disk1</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>a086eb2a-7086-4627-afcf-7eb258246349</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>8589934592</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>1971261440</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5" id="f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5">
+            <actions>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/f3eb1cf1-4b4a-48b0-8f38-1a300dc927f5/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>3a53a19e-e66b-426c-ba2c-f7028818348e</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264" id="e5d385bd-2ebb-4024-8c82-35eda60f5264">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk4</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e5d385bd-2ebb-4024-8c82-35eda60f5264/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk4</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>49a02400-0600-42e7-acc7-ef774230d8b2</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>36700160</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309" id="307617bd-7c0b-477c-8f29-cfb75511f309">
+            <actions>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/307617bd-7c0b-477c-8f29-cfb75511f309/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>6e1e2d81-d8bc-42cd-b639-fc0741a7853b</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10485760</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b" id="ad5379a3-99ef-4fa7-a182-7941b61cff1b">
+            <actions>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/ad5379a3-99ef-4fa7-a182-7941b61cff1b/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>476a0207-ee6c-4332-947b-d438c7d9eafd</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97" id="d3ab1baa-2c8a-4c34-8880-866443108e97">
+            <actions>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/d3ab1baa-2c8a-4c34-8880-866443108e97/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>68a7c6e9-b7f4-400e-bab5-ad6a19fdb292</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>31457280</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199" id="6604e824-a911-4ce8-9225-feaeb1963199">
+            <actions>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/6604e824-a911-4ce8-9225-feaeb1963199/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>824929a3-d782-4660-8381-8948227c1c9d</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>20971520</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80" id="7c542c3c-586f-47e1-9deb-d0a742952f80">
+            <actions>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/sparsify" rel="sparsify"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/move" rel="move"/>
+            </actions>
+            <name>rhel7s_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/7c542c3c-586f-47e1-9deb-d0a742952f80/statistics" rel="statistics"/>
+            <actual_size>0</actual_size>
+            <alias>rhel7s_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>c8517c9e-584a-4ee0-a5df-c86da0946655</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>26214400</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>0</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/7a0067b5-2ad5-4a88-ae10-05d2041da8aa" id="7a0067b5-2ad5-4a88-ae10-05d2041da8aa"/>
+            <quota href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas/5fa337c2-9eb4-4d83-9d6a-739cf88a2312" id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729" id="cfbc93a1-17b7-4d03-a8ca-3b3bfef52729"/>
+            </storage_domains>
+        </disk>
     </disks>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '993'
-    correlation-id: 98f478ce-fc5f-4591-aa14-8c12c32d83b7
+    content-length: '2920'
+    correlation-id: d5af83a2-a968-4abc-88c7-1c095dc98b43
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
 - :body: |
@@ -1372,12 +2626,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
     </vnic_profiles>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '348'
-    correlation-id: 41688691-9999-4254-b3cb-9904674dfd35
+    correlation-id: 1feb1ec9-80aa-40a7-9332-06a3148948d7
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics{}GET:
 - :body: |
@@ -1386,9 +2640,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
         <host_nic href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94" id="02f40cac-50ae-4ea8-b70c-277fef97ea94">
             <actions/>
             <name>ens3</name>
-            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/networkattachments" rel="networkattachments"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/networklabels" rel="networklabels"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/linklayerdiscoveryprotocolelements" rel="linklayerdiscoveryprotocolelements"/>
+            <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/networkattachments" rel="networkattachments"/>
             <link href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/nics/02f40cac-50ae-4ea8-b70c-277fef97ea94/statistics" rel="statistics"/>
             <boot_protocol>dhcp</boot_protocol>
             <bridged>true</bridged>
@@ -1417,12 +2671,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
     </host_nics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '570'
-    correlation-id: d881272d-4d18-4349-af5c-a8cb6bdc13a3
+    correlation-id: f3d627a6-95a3-4ab3-9917-e8c85f3069ae
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/statistics{}GET:
 - :body: |
@@ -1449,7 +2703,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>bytes</unit>
             <values>
                 <value>
-                    <datum>1312146063</datum>
+                    <datum>1394155192</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1462,7 +2716,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>bytes</unit>
             <values>
                 <value>
-                    <datum>6888766833</datum>
+                    <datum>6806757704</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1579,7 +2833,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>18</datum>
+                    <datum>2</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1592,7 +2846,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>4</datum>
+                    <datum>1</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1605,7 +2859,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>78</datum>
+                    <datum>98</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1618,7 +2872,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>0.30</datum>
+                    <datum>0.21</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1631,7 +2885,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
             <unit>none</unit>
             <values>
                 <value>
-                    <datum>1575276739</datum>
+                    <datum>1576486724</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
@@ -1663,12 +2917,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
     </statistics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1230'
-    correlation-id: 1fab3bc5-ef6a-4766-b48a-76288d347094
+    content-length: '1231'
+    correlation-id: fbad3730-4050-4514-b2df-42ee1ddbb7cf
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics{}GET:
 - :body: |
@@ -1677,9 +2931,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
         <host_nic href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7" id="5fd4e6be-4438-47e1-8e06-4705b40a21a7">
             <actions/>
             <name>ens3</name>
-            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/networkattachments" rel="networkattachments"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/networklabels" rel="networklabels"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/linklayerdiscoveryprotocolelements" rel="linklayerdiscoveryprotocolelements"/>
+            <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/networkattachments" rel="networkattachments"/>
             <link href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/nics/5fd4e6be-4438-47e1-8e06-4705b40a21a7/statistics" rel="statistics"/>
             <boot_protocol>dhcp</boot_protocol>
             <bridged>true</bridged>
@@ -1708,12 +2962,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
     </host_nics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '572'
-    correlation-id: f6ae2bef-079c-427c-9ad4-c01ed6c62cb7
+    correlation-id: 585b959f-debd-4629-8b06-1203a2ff7409
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/statistics{}GET:
 - :body: |
@@ -1870,7 +3124,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>0</datum>
+                    <datum>1</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab" id="9514170e-dde4-4c5c-b9ec-5a09db2115ab"/>
@@ -1883,7 +3137,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>0</datum>
+                    <datum>1</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab" id="9514170e-dde4-4c5c-b9ec-5a09db2115ab"/>
@@ -1909,7 +3163,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
             <unit>percent</unit>
             <values>
                 <value>
-                    <datum>0.080</datum>
+                    <datum>0.040</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab" id="9514170e-dde4-4c5c-b9ec-5a09db2115ab"/>
@@ -1922,7 +3176,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
             <unit>none</unit>
             <values>
                 <value>
-                    <datum>1575276741</datum>
+                    <datum>1576486724</datum>
                 </value>
             </values>
             <host href="/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab" id="9514170e-dde4-4c5c-b9ec-5a09db2115ab"/>
@@ -1954,12 +3208,105 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
     </statistics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1222'
-    correlation-id: b1454d6d-fd06-476c-8eae-977602d9ee8b
+    content-length: '1225'
+    correlation-id: c32c1b64-506c-4717-86de-58d741f74379
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e" id="37f40d91-612d-4d61-8c68-a22638da6b1e">
+            <actions>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/nics/37f40d91-612d-4d61-8c68-a22638da6b1e/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696" id="022ce494-f739-40a3-a29a-d26ce125f696"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:85:ae:00:01</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/bd73ad67-17a7-434c-a661-8557add4e99f" id="bd73ad67-17a7-434c-a661-8557add4e99f"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    date: Mon, 16 Dec 2019 10:55:52 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '429'
+    correlation-id: b62dfa8a-f3fc-45c0-b962-ffa4bdeeef14
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    date: Mon, 16 Dec 2019 10:55:52 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '96'
+    correlation-id: 9680cba7-a195-4801-b184-3decbb9fde45
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/snapshots/1b04d198-81a4-4f9a-908c-cbb398d974e4" id="1b04d198-81a4-4f9a-908c-cbb398d974e4">
+            <actions>
+                <link href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/snapshots/1b04d198-81a4-4f9a-908c-cbb398d974e4/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2019-12-13T11:55:45.279+01:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    date: Mon, 16 Dec 2019 10:55:52 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '333'
+    correlation-id: 174ba0a2-2e59-4049-8338-59f9cfd767e4
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696/diskattachments/e7bef226-5566-4f84-bd1e-7766d0510c67" id="e7bef226-5566-4f84-bd1e-7766d0510c67">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <read_only>false</read_only>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/e7bef226-5566-4f84-bd1e-7766d0510c67" id="e7bef226-5566-4f84-bd1e-7766d0510c67"/>
+            <vm href="/ovirt-engine/api/vms/022ce494-f739-40a3-a29a-d26ce125f696" id="022ce494-f739-40a3-a29a-d26ce125f696"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    date: Mon, 16 Dec 2019 10:55:52 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '320'
+    correlation-id: 6910ef98-e118-4151-b17b-dcd15bac3daf
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics{}GET:
 - :body: |
@@ -2006,12 +3353,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </nics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '615'
-    correlation-id: e08a0874-1e9b-4044-adab-a298debf4ece
+    correlation-id: cda0624f-f010-4e20-84e8-d691f9a17274
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2057,12 +3404,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </nics>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:47 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '615'
-    correlation-id: 7deaa2d1-656b-4f50-bb2d-65d7b868ddfd
+    correlation-id: f3def09c-2222-489f-a503-effe00bf2e80
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices{}GET:
 - :body: |
@@ -2090,12 +3437,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </reported_devices>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '366'
-    correlation-id: 7c218d9c-3163-4e67-b329-94390b48b100
+    correlation-id: 7aa03d94-e05a-4505-9502-8366a929b667
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2122,12 +3469,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </reported_devices>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '366'
-    correlation-id: 1d465d24-a440-4a83-ba9d-e32e0e4f41cd
+    correlation-id: 2d81a3f9-b58c-4bb0-8e0c-02aa1f56f2de
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots{}GET:
 - :body: |
@@ -2146,12 +3493,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </snapshots>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '330'
-    correlation-id: e65cd105-c059-4b92-8ee8-5e39a4caa863
+    correlation-id: b5dfb270-f7ae-4ed5-9bc1-a706766d307a
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2166,15 +3513,15 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
             <snapshot_status>ok</snapshot_status>
             <snapshot_type>active</snapshot_type>
         </snapshot>
-        <snapshot href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/d8afa763-8249-4473-9558-e5431cb76e8e" id="d8afa763-8249-4473-9558-e5431cb76e8e">
+        <snapshot href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/fb82cee1-39d6-4733-8c12-8c878ffd79ae" id="fb82cee1-39d6-4733-8c12-8c878ffd79ae">
             <actions>
-                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/d8afa763-8249-4473-9558-e5431cb76e8e/restore" rel="restore"/>
+                <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/fb82cee1-39d6-4733-8c12-8c878ffd79ae/restore" rel="restore"/>
             </actions>
             <description>Next Run configuration snapshot</description>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/d8afa763-8249-4473-9558-e5431cb76e8e/cdroms" rel="cdroms"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/d8afa763-8249-4473-9558-e5431cb76e8e/nics" rel="nics"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/d8afa763-8249-4473-9558-e5431cb76e8e/disks" rel="disks"/>
-            <date>2019-12-02T12:26:44.242+01:00</date>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/fb82cee1-39d6-4733-8c12-8c878ffd79ae/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/fb82cee1-39d6-4733-8c12-8c878ffd79ae/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/fb82cee1-39d6-4733-8c12-8c878ffd79ae/nics" rel="nics"/>
+            <date>2019-12-16T11:55:55.669+01:00</date>
             <persist_memorystate>false</persist_memorystate>
             <snapshot_status>ok</snapshot_status>
             <vm id="17a94da8-3d02-430e-9b83-5e39f92907e8">
@@ -2296,9 +3643,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
                 <next_run_configuration_exists>true</next_run_configuration_exists>
                 <numa_tune_mode>interleave</numa_tune_mode>
                 <run_once>false</run_once>
-                <start_time>2019-12-02T12:25:51.513+01:00</start_time>
+                <start_time>2019-12-16T11:53:51.115+01:00</start_time>
                 <status>up</status>
-                <stop_time>2019-12-02T12:25:50.959+01:00</stop_time>
+                <stop_time>2019-12-16T11:53:49.827+01:00</stop_time>
                 <host id="72bce52e-c060-4907-a459-f5cfea517b30"/>
                 <original_template id="00000000-0000-0000-0000-000000000000"/>
                 <template id="00000000-0000-0000-0000-000000000000"/>
@@ -2307,12 +3654,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </snapshots>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1868'
-    correlation-id: c9a7ac6d-7f96-4a8f-905a-9deca4dfc588
+    content-length: '1866'
+    correlation-id: 8284d635-d9f0-4e6c-b8f6-ed064b1078b4
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments{}GET:
 - :body: |
@@ -2332,12 +3679,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </disk_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '342'
-    correlation-id: 4624e791-017f-4560-9fb8-078cff6d6255
+    correlation-id: 9c607027-7cb1-4e50-8e2d-0820896ba1ef
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2356,12 +3703,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </disk_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '342'
-    correlation-id: fe79f76c-fe0b-466f-90b7-396ac4376772
+    correlation-id: b1908bc0-85cc-43df-92ac-e08e29c0a4b7
   :message: 
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -2380,12 +3727,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
     </disk_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '342'
-    correlation-id: 36c07b62-b1f5-4828-9921-06b12dadd73d
+    correlation-id: 80d621e3-13a6-4367-ba8f-d6aab9bbf11e
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments{}GET:
 - :body: |
@@ -2393,12 +3740,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates/00000000-000
     <disk_attachments/>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '96'
-    correlation-id: 344b08a0-57c0-4f8b-ab42-4e3f243cdabd
+    correlation-id: 33f44f26-1f41-4df9-98a1-60b9d7c8693a
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/storagedomains{}GET:
 - :body: |
@@ -2413,10 +3760,10 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
             <description></description>
             <comment></comment>
             <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
-            <available>517543559168</available>
+            <available>515396075520</available>
             <backup>false</backup>
             <block_size>512</block_size>
-            <committed>16106127360</committed>
+            <committed>25769803776</committed>
             <critical_space_action_blocker>5</critical_space_action_blocker>
             <discard_after_delete>false</discard_after_delete>
             <external_status>ok</external_status>
@@ -2432,7 +3779,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
             <supports_discard>false</supports_discard>
             <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
             <type>data</type>
-            <used>18253611008</used>
+            <used>20401094656</used>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <wipe_after_delete>false</wipe_after_delete>
             <data_center href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc" id="e57249a3-d28a-455f-b30c-4ac0979f2ccc"/>
@@ -2448,7 +3795,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
             <name>depot_iso</name>
             <description></description>
             <comment></comment>
-            <available>517543559168</available>
+            <available>515396075520</available>
             <backup>false</backup>
             <block_size>512</block_size>
             <committed>0</committed>
@@ -2467,7 +3814,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
             <supports_discard>false</supports_discard>
             <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
             <type>iso</type>
-            <used>18253611008</used>
+            <used>20401094656</used>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <wipe_after_delete>false</wipe_after_delete>
             <data_center href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc" id="e57249a3-d28a-455f-b30c-4ac0979f2ccc"/>
@@ -2478,12 +3825,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
     </storage_domains>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '730'
-    correlation-id: 26f39287-004b-431e-b562-fc340730c6e3
+    content-length: '731'
+    correlation-id: 2bf04787-f389-4e52-a694-0d45f4d2ed82
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30/networkattachments{}GET:
 - :body: |
@@ -2559,12 +3906,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72bce52e-c060-49
     </network_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '619'
-    correlation-id: b8ea1d77-6e54-4f4c-909c-19a3d0477887
+    correlation-id: 03bb26b3-f468-4264-903a-289c528b8424
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c5c-b9ec-5a09db2115ab/networkattachments{}GET:
 - :body: |
@@ -2640,33 +3987,33 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/9514170e-dde4-4c
     </network_attachments>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:42 GMT
+    date: Mon, 16 Dec 2019 10:55:52 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '616'
-    correlation-id: 1fe1c2b5-dc82-4ca7-9651-6c741b99ba9f
+    correlation-id: 4f0f0656-6fc0-446b-9768-2c23d51a8c7e
   :message: 
-https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{}GET:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{:all_content=>"true"}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
         <actions>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
@@ -2675,22 +4022,22 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <name>rhel7s</name>
         <description></description>
         <comment></comment>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
         <bios>
             <boot_menu>
@@ -2698,6 +4045,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
             </boot_menu>
             <type>i440fx_sea_bios</type>
         </bios>
+        <console>
+            <enabled>false</enabled>
+        </console>
         <cpu>
             <architecture>x86_64</architecture>
             <topology>
@@ -2752,6 +4102,10 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         </high_availability>
         <initialization>
             <authorized_ssh_keys></authorized_ssh_keys>
+            <configuration>
+                <data>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1/" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovf:version="4.1.0.0"&gt;&lt;References&gt;&lt;File ovf:href="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:id="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="2052321280" ovf:description="Active VM" ovf:disk_storage_type="IMAGE" ovf:cinder_volume_type=""&gt;&lt;/File&gt;&lt;/References&gt;&lt;NetworkSection&gt;&lt;Info&gt;List of networks&lt;/Info&gt;&lt;Network ovf:name="ovirtmgmt"&gt;&lt;/Network&gt;&lt;/NetworkSection&gt;&lt;Section xsi:type="ovf:DiskSection_Type"&gt;&lt;Info&gt;List of Virtual Disks&lt;/Info&gt;&lt;Disk ovf:diskId="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="15" ovf:actual_size="2" ovf:vm_snapshot_id="fc282c90-ded5-456b-ab99-2d2fe6abc262" ovf:parentRef="" ovf:fileRef="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:format="http://www.vmware.com/specifications/vmdk.html#sparse" ovf:volume-format="RAW" ovf:volume-type="Sparse" ovf:disk-interface="VirtIO_SCSI" ovf:read-only="false" ovf:shareable="false" ovf:boot="true" ovf:pass-discard="false" ovf:disk-alias="rhel7s_Disk1" ovf:disk-description="" ovf:wipe-after-delete="true"&gt;&lt;/Disk&gt;&lt;/Section&gt;&lt;Content ovf:id="out" xsi:type="ovf:VirtualSystem_Type"&gt;&lt;Name&gt;rhel7s&lt;/Name&gt;&lt;Description&gt;&lt;/Description&gt;&lt;Comment&gt;&lt;/Comment&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;ExportDate&gt;2019/12/16 10:55:55&lt;/ExportDate&gt;&lt;DeleteProtected&gt;false&lt;/DeleteProtected&gt;&lt;SsoMethod&gt;guest_agent&lt;/SsoMethod&gt;&lt;IsSmartcardEnabled&gt;false&lt;/IsSmartcardEnabled&gt;&lt;NumOfIoThreads&gt;1&lt;/NumOfIoThreads&gt;&lt;TimeZone&gt;Europe/Warsaw&lt;/TimeZone&gt;&lt;default_boot_sequence&gt;9&lt;/default_boot_sequence&gt;&lt;Generation&gt;1142&lt;/Generation&gt;&lt;ClusterCompatibilityVersion&gt;4.3&lt;/ClusterCompatibilityVersion&gt;&lt;VmType&gt;1&lt;/VmType&gt;&lt;ResumeBehavior&gt;AUTO_RESUME&lt;/ResumeBehavior&gt;&lt;MinAllocatedMem&gt;3072&lt;/MinAllocatedMem&gt;&lt;IsStateless&gt;false&lt;/IsStateless&gt;&lt;IsRunAndPause&gt;false&lt;/IsRunAndPause&gt;&lt;AutoStartup&gt;false&lt;/AutoStartup&gt;&lt;Priority&gt;1&lt;/Priority&gt;&lt;CreatedByUserId&gt;251a2aee-ee9b-11e9-a6be-5254005a3239&lt;/CreatedByUserId&gt;&lt;MigrationSupport&gt;0&lt;/MigrationSupport&gt;&lt;IsBootMenuEnabled&gt;false&lt;/IsBootMenuEnabled&gt;&lt;IsSpiceFileTransferEnabled&gt;true&lt;/IsSpiceFileTransferEnabled&gt;&lt;IsSpiceCopyPasteEnabled&gt;true&lt;/IsSpiceCopyPasteEnabled&gt;&lt;AllowConsoleReconnect&gt;true&lt;/AllowConsoleReconnect&gt;&lt;ConsoleDisconnectAction&gt;LOCK_SCREEN&lt;/ConsoleDisconnectAction&gt;&lt;CustomEmulatedMachine&gt;&lt;/CustomEmulatedMachine&gt;&lt;BiosType&gt;0&lt;/BiosType&gt;&lt;CustomCpuName&gt;&lt;/CustomCpuName&gt;&lt;PredefinedProperties&gt;&lt;/PredefinedProperties&gt;&lt;UserDefinedProperties&gt;&lt;/UserDefinedProperties&gt;&lt;MaxMemorySizeMb&gt;4096&lt;/MaxMemorySizeMb&gt;&lt;MultiQueuesEnabled&gt;true&lt;/MultiQueuesEnabled&gt;&lt;UseHostCpu&gt;false&lt;/UseHostCpu&gt;&lt;ClusterName&gt;depot_cl&lt;/ClusterName&gt;&lt;TemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/TemplateId&gt;&lt;TemplateName&gt;Blank&lt;/TemplateName&gt;&lt;IsInitilized&gt;true&lt;/IsInitilized&gt;&lt;Origin&gt;0&lt;/Origin&gt;&lt;app_list&gt;ovirt-guest-agent-common-1.0.16-1.el7ev,kernel-3.10.0-1062.el7&lt;/app_list&gt;&lt;quota_id&gt;5fa337c2-9eb4-4d83-9d6a-739cf88a2312&lt;/quota_id&gt;&lt;DefaultDisplayType&gt;1&lt;/DefaultDisplayType&gt;&lt;TrustedService&gt;false&lt;/TrustedService&gt;&lt;OriginalTemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/OriginalTemplateId&gt;&lt;OriginalTemplateName&gt;Blank&lt;/OriginalTemplateName&gt;&lt;UseLatestVersion&gt;false&lt;/UseLatestVersion&gt;&lt;StopTime&gt;2019/12/16 10:53:49&lt;/StopTime&gt;&lt;BootTime&gt;2019/12/16 10:53:51&lt;/BootTime&gt;&lt;Downtime&gt;0&lt;/Downtime&gt;&lt;Section ovf:id="17a94da8-3d02-430e-9b83-5e39f92907e8" ovf:required="false" xsi:type="ovf:OperatingSystemSection_Type"&gt;&lt;Info&gt;Guest Operating System&lt;/Info&gt;&lt;Description&gt;rhel_7x64&lt;/Description&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:VirtualHardwareSection_Type"&gt;&lt;Info&gt;4 CPU, 3072 Memory&lt;/Info&gt;&lt;System&gt;&lt;vssd:VirtualSystemType&gt;ENGINE 4.1.0.0&lt;/vssd:VirtualSystemType&gt;&lt;/System&gt;&lt;Item&gt;&lt;rasd:Caption&gt;4 virtual cpu&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Number of virtual CPU&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;1&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;3&lt;/rasd:ResourceType&gt;&lt;rasd:num_of_sockets&gt;2&lt;/rasd:num_of_sockets&gt;&lt;rasd:cpu_per_socket&gt;2&lt;/rasd:cpu_per_socket&gt;&lt;rasd:threads_per_cpu&gt;1&lt;/rasd:threads_per_cpu&gt;&lt;rasd:max_num_of_vcpus&gt;32&lt;/rasd:max_num_of_vcpus&gt;&lt;rasd:VirtualQuantity&gt;4&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;3072 MB of memory&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Memory Size&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;2&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;4&lt;/rasd:ResourceType&gt;&lt;rasd:AllocationUnits&gt;MegaBytes&lt;/rasd:AllocationUnits&gt;&lt;rasd:VirtualQuantity&gt;3072&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;rhel7s_Disk1&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;17&lt;/rasd:ResourceType&gt;&lt;rasd:HostResource&gt;f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:HostResource&gt;&lt;rasd:Parent&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Parent&gt;&lt;rasd:Template&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Template&gt;&lt;rasd:ApplicationList&gt;&lt;/rasd:ApplicationList&gt;&lt;rasd:StorageId&gt;cfbc93a1-17b7-4d03-a8ca-3b3bfef52729&lt;/rasd:StorageId&gt;&lt;rasd:StoragePoolId&gt;e57249a3-d28a-455f-b30c-4ac0979f2ccc&lt;/rasd:StoragePoolId&gt;&lt;rasd:CreationDate&gt;2019/10/15 10:13:29&lt;/rasd:CreationDate&gt;&lt;rasd:LastModified&gt;1970/01/01 00:00:00&lt;/rasd:LastModified&gt;&lt;rasd:last_modified_date&gt;2019/12/16 10:55:55&lt;/rasd:last_modified_date&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;disk&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=0, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;1&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-f6e4775b-53be-4136-9e30-f0be18b70668&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Ethernet adapter on ovirtmgmt&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;93159b67-49fe-4add-8b31-91be915a208b&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;10&lt;/rasd:ResourceType&gt;&lt;rasd:OtherResourceType&gt;ovirtmgmt&lt;/rasd:OtherResourceType&gt;&lt;rasd:ResourceSubType&gt;3&lt;/rasd:ResourceSubType&gt;&lt;rasd:Connection&gt;ovirtmgmt&lt;/rasd:Connection&gt;&lt;rasd:Linked&gt;true&lt;/rasd:Linked&gt;&lt;rasd:Name&gt;nic1&lt;/rasd:Name&gt;&lt;rasd:ElementName&gt;nic1&lt;/rasd:ElementName&gt;&lt;rasd:MACAddress&gt;56:6f:85:ae:00:00&lt;/rasd:MACAddress&gt;&lt;rasd:speed&gt;10000&lt;/rasd:speed&gt;&lt;Type&gt;interface&lt;/Type&gt;&lt;Device&gt;bridge&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x03, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-93159b67-49fe-4add-8b31-91be915a208b&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;USB Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;3&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;23&lt;/rasd:ResourceType&gt;&lt;rasd:UsbPolicy&gt;DISABLED&lt;/rasd:UsbPolicy&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;20&lt;/rasd:ResourceType&gt;&lt;rasd:VirtualQuantity&gt;1&lt;/rasd:VirtualQuantity&gt;&lt;rasd:SinglePciQxl&gt;false&lt;/rasd:SinglePciQxl&gt;&lt;Type&gt;video&lt;/Type&gt;&lt;Device&gt;qxl&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x02, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;vgamem&gt;16384&lt;/vgamem&gt;&lt;heads&gt;1&lt;/heads&gt;&lt;vram&gt;32768&lt;/vram&gt;&lt;ram&gt;65536&lt;/ram&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d835d395-f01c-4991-8643-b0578b2f3cf4&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;spice&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;393b1788-8d19-4f18-ac73-9984db012e59&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;vnc&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;CDROM&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;15&lt;/rasd:ResourceType&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;cdrom&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=1, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;2&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/Alias&gt;&lt;SpecParams&gt;&lt;path&gt;rhel-server-7.7-x86_64-dvd.iso&lt;/path&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;56980ab4-4fbd-4b12-911e-534ce16dc4d4&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;spicevmc&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=3}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel2&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;8614413b-a1c9-482e-92f9-aad255e34b33&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel1&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;7d493d38-9770-4569-a213-4cc830b48b7b&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel0&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;0e988f54-ff5e-4f78-953a-1dfe1e813bb7&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;ide&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ide&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-serial&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x05, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;b8eed426-0eb3-4f95-9fb7-6c430490bf0e&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;usb&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;usb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;model&gt;piix3-uhci&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;3d7a7589-28a7-49c0-bf1b-65bf5213ba5b&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-scsi&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x04, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-3d7a7589-28a7-49c0-bf1b-65bf5213ba5b&lt;/Alias&gt;&lt;SpecParams&gt;&lt;ioThreadId&gt;&lt;/ioThreadId&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/rasd:InstanceId&gt;&lt;Type&gt;rng&lt;/Type&gt;&lt;Device&gt;virtio&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x07, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/Alias&gt;&lt;SpecParams&gt;&lt;source&gt;urandom&lt;/source&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/rasd:InstanceId&gt;&lt;Type&gt;balloon&lt;/Type&gt;&lt;Device&gt;memballoon&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x06, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/Alias&gt;&lt;SpecParams&gt;&lt;model&gt;virtio&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:SnapshotsSection_Type"&gt;&lt;Snapshot ovf:id="fc282c90-ded5-456b-ab99-2d2fe6abc262"&gt;&lt;Type&gt;ACTIVE&lt;/Type&gt;&lt;Description&gt;Active VM&lt;/Description&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;/Snapshot&gt;&lt;/Section&gt;&lt;/Content&gt;&lt;/ovf:Envelope&gt;</data>
+                <type>ovf</type>
+            </configuration>
             <custom_script></custom_script>
             <nic_configurations/>
             <regenerate_ssh_keys>false</regenerate_ssh_keys>
@@ -2785,7 +4139,11 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <placement_policy>
             <affinity>migratable</affinity>
         </placement_policy>
+        <rng_device>
+            <source>urandom</source>
+        </rng_device>
         <small_icon href="/ovirt-engine/api/icons/a029b4bf-5437-dae6-0cdf-3c9fb623cf1d" id="a029b4bf-5437-dae6-0cdf-3c9fb623cf1d"/>
+        <soundcard_enabled>false</soundcard_enabled>
         <sso>
             <methods>
                 <method id="guest_agent"/>
@@ -2801,6 +4159,9 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <usb>
             <enabled>false</enabled>
         </usb>
+        <virtio_scsi>
+            <enabled>true</enabled>
+        </virtio_scsi>
         <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde"/>
         <cpu_profile href="/ovirt-engine/api/cpuprofiles/c5926295-65ef-4dba-b234-26db503cb59d" id="c5926295-65ef-4dba-b234-26db503cb59d"/>
         <quota id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
@@ -2832,41 +4193,265 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <next_run_configuration_exists>false</next_run_configuration_exists>
         <numa_tune_mode>interleave</numa_tune_mode>
         <run_once>false</run_once>
-        <start_time>2019-12-02T12:25:51.513+01:00</start_time>
+        <start_time>2019-12-16T11:53:51.115+01:00</start_time>
         <status>up</status>
-        <stop_time>2019-12-02T12:25:50.959+01:00</stop_time>
+        <stop_time>2019-12-16T11:53:49.827+01:00</stop_time>
         <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
         <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
         <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
     </vm>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:44 GMT
+    date: Mon, 16 Dec 2019 10:55:55 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '3228'
-    correlation-id: '08571037-aa7b-48f0-8a89-c47f087bc030'
+    content-length: '6570'
+    correlation-id: 236cd566-2402-4fd7-a870-2ac832ecf80f
   :message: 
+? |
+  https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{:next_run=>"false"}PUT<vm>
+    <cpu>
+      <topology>
+        <cores>1</cores>
+        <sockets>2</sockets>
+      </topology>
+    </cpu>
+  </vm>
+: - :body: |
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
+          <actions>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
+              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/suspend" rel="suspend"/>
+          </actions>
+          <name>rhel7s</name>
+          <description></description>
+          <comment></comment>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
+          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
+          <bios>
+              <boot_menu>
+                  <enabled>false</enabled>
+              </boot_menu>
+              <type>i440fx_sea_bios</type>
+          </bios>
+          <console>
+              <enabled>false</enabled>
+          </console>
+          <cpu>
+              <architecture>x86_64</architecture>
+              <topology>
+                  <cores>2</cores>
+                  <sockets>2</sockets>
+                  <threads>1</threads>
+              </topology>
+          </cpu>
+          <cpu_shares>0</cpu_shares>
+          <creation_time>2019-10-15T12:12:12.505+02:00</creation_time>
+          <delete_protected>false</delete_protected>
+          <display>
+              <address>192.168.178.48</address>
+              <allow_override>true</allow_override>
+              <certificate>
+                  <content>-----BEGIN CERTIFICATE-----
+      MIIDujCCAqKgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwRTELMAkGA1UEBhMCVVMxEjAQBgNVBAoM
+      CWZyaXR6LmJveDEiMCAGA1UEAwwZZW5naW5lLTQzLmZyaXR6LmJveC40MDczNzAeFw0xOTEwMTMx
+      NTU1MTJaFw0yOTEwMTExNTU1MTJaMEUxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlmcml0ei5ib3gx
+      IjAgBgNVBAMMGWVuZ2luZS00My5mcml0ei5ib3guNDA3MzcwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+      DwAwggEKAoIBAQDOBt7e2IGBsiRkzj/139dMZVOIiUr7d2O/6ECI284u/U/ENY3kJT5tKVbn7UAk
+      8MnEH92FMBN2fcaGAnk36I6ZnJBxbj59mVPNgu7bktViKZkvgHEbZuX3BctJJZDrh0D67zIRsSKd
+      5xsFFWIjUAUkmyKOuxD4xsqXop1Cw5cjSzadY6XZMi2vw0yFtOUQ/3FMpXkZ9yAMT+clzaUu3rgs
+      IUbnLSpfKdDUm5NzCksOo8gOjXmx0OkXna8nQvQGb3ycmTeS10MzeURtgkPlfR+nZWDDiUNOHLmZ
+      y1IoZxsq0MmZx42YqbQ1WjPzj55H7rXhYqATUBjvYYh+39WSP/pfAgMBAAGjgbMwgbAwHQYDVR0O
+      BBYEFD9mD6ChOc01EKwqT3PaF+jxY+1MMG4GA1UdIwRnMGWAFD9mD6ChOc01EKwqT3PaF+jxY+1M
+      oUmkRzBFMQswCQYDVQQGEwJVUzESMBAGA1UECgwJZnJpdHouYm94MSIwIAYDVQQDDBllbmdpbmUt
+      NDMuZnJpdHouYm94LjQwNzM3ggIQADAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAN
+      BgkqhkiG9w0BAQsFAAOCAQEAilO/2+J+etHnfkY5Zlw5fCi4f20fhA0C2k3pmyzEnk+02/cBr1XK
+      PfsDXCEmCiXpMTru3iflYee6L5MRZqDuu7dKaZVwYhdCpURHxkMuBT7gA0YvtC1TNnRDu2EDvjUh
+      /Mtqngojv4XdCM1aza0fw0pyE+mz+e+97KLGmtutj0W2JymsXcHtHlLJxjNXTie7qzsrMKGLfKmq
+      eBceTlpcGF98zFqlLEjRMuJ/I2AN2kDpK+e1zCFL1lYzb2MAN8Aol2Eqw6ZrezVT+5NLnJ/aw55S
+      HuXeUczWeCztAUiGYS9HD2kcdp9Y7mr4OMZi+IePz5mkn0TTkCgNcIQho3vH1Q==
+      -----END CERTIFICATE-----
+      </content>
+                  <organization>fritz.box</organization>
+                  <subject>O=fritz.box,CN=host01-43.fritz.box</subject>
+              </certificate>
+              <copy_paste_enabled>true</copy_paste_enabled>
+              <disconnect_action>LOCK_SCREEN</disconnect_action>
+              <file_transfer_enabled>true</file_transfer_enabled>
+              <monitors>1</monitors>
+              <port>5901</port>
+              <secure_port>5902</secure_port>
+              <single_qxl_pci>false</single_qxl_pci>
+              <smartcard_enabled>false</smartcard_enabled>
+              <type>spice</type>
+          </display>
+          <high_availability>
+              <enabled>false</enabled>
+              <priority>1</priority>
+          </high_availability>
+          <initialization>
+              <authorized_ssh_keys></authorized_ssh_keys>
+              <configuration>
+                  <data>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1/" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovf:version="4.1.0.0"&gt;&lt;References&gt;&lt;File ovf:href="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:id="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="2052321280" ovf:description="Active VM" ovf:disk_storage_type="IMAGE" ovf:cinder_volume_type=""&gt;&lt;/File&gt;&lt;/References&gt;&lt;NetworkSection&gt;&lt;Info&gt;List of networks&lt;/Info&gt;&lt;Network ovf:name="ovirtmgmt"&gt;&lt;/Network&gt;&lt;/NetworkSection&gt;&lt;Section xsi:type="ovf:DiskSection_Type"&gt;&lt;Info&gt;List of Virtual Disks&lt;/Info&gt;&lt;Disk ovf:diskId="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="15" ovf:actual_size="2" ovf:vm_snapshot_id="fc282c90-ded5-456b-ab99-2d2fe6abc262" ovf:parentRef="" ovf:fileRef="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:format="http://www.vmware.com/specifications/vmdk.html#sparse" ovf:volume-format="RAW" ovf:volume-type="Sparse" ovf:disk-interface="VirtIO_SCSI" ovf:read-only="false" ovf:shareable="false" ovf:boot="true" ovf:pass-discard="false" ovf:disk-alias="rhel7s_Disk1" ovf:disk-description="" ovf:wipe-after-delete="true"&gt;&lt;/Disk&gt;&lt;/Section&gt;&lt;Content ovf:id="out" xsi:type="ovf:VirtualSystem_Type"&gt;&lt;Name&gt;rhel7s&lt;/Name&gt;&lt;Description&gt;&lt;/Description&gt;&lt;Comment&gt;&lt;/Comment&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;ExportDate&gt;2019/12/16 10:55:55&lt;/ExportDate&gt;&lt;DeleteProtected&gt;false&lt;/DeleteProtected&gt;&lt;SsoMethod&gt;guest_agent&lt;/SsoMethod&gt;&lt;IsSmartcardEnabled&gt;false&lt;/IsSmartcardEnabled&gt;&lt;NumOfIoThreads&gt;1&lt;/NumOfIoThreads&gt;&lt;TimeZone&gt;Europe/Warsaw&lt;/TimeZone&gt;&lt;default_boot_sequence&gt;9&lt;/default_boot_sequence&gt;&lt;Generation&gt;1143&lt;/Generation&gt;&lt;ClusterCompatibilityVersion&gt;4.3&lt;/ClusterCompatibilityVersion&gt;&lt;VmType&gt;1&lt;/VmType&gt;&lt;ResumeBehavior&gt;AUTO_RESUME&lt;/ResumeBehavior&gt;&lt;MinAllocatedMem&gt;3072&lt;/MinAllocatedMem&gt;&lt;IsStateless&gt;false&lt;/IsStateless&gt;&lt;IsRunAndPause&gt;false&lt;/IsRunAndPause&gt;&lt;AutoStartup&gt;false&lt;/AutoStartup&gt;&lt;Priority&gt;1&lt;/Priority&gt;&lt;CreatedByUserId&gt;251a2aee-ee9b-11e9-a6be-5254005a3239&lt;/CreatedByUserId&gt;&lt;MigrationSupport&gt;0&lt;/MigrationSupport&gt;&lt;IsBootMenuEnabled&gt;false&lt;/IsBootMenuEnabled&gt;&lt;IsSpiceFileTransferEnabled&gt;true&lt;/IsSpiceFileTransferEnabled&gt;&lt;IsSpiceCopyPasteEnabled&gt;true&lt;/IsSpiceCopyPasteEnabled&gt;&lt;AllowConsoleReconnect&gt;true&lt;/AllowConsoleReconnect&gt;&lt;ConsoleDisconnectAction&gt;LOCK_SCREEN&lt;/ConsoleDisconnectAction&gt;&lt;CustomEmulatedMachine&gt;&lt;/CustomEmulatedMachine&gt;&lt;BiosType&gt;0&lt;/BiosType&gt;&lt;CustomCpuName&gt;&lt;/CustomCpuName&gt;&lt;PredefinedProperties&gt;&lt;/PredefinedProperties&gt;&lt;UserDefinedProperties&gt;&lt;/UserDefinedProperties&gt;&lt;MaxMemorySizeMb&gt;4096&lt;/MaxMemorySizeMb&gt;&lt;MultiQueuesEnabled&gt;true&lt;/MultiQueuesEnabled&gt;&lt;UseHostCpu&gt;false&lt;/UseHostCpu&gt;&lt;ClusterName&gt;depot_cl&lt;/ClusterName&gt;&lt;TemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/TemplateId&gt;&lt;TemplateName&gt;Blank&lt;/TemplateName&gt;&lt;IsInitilized&gt;true&lt;/IsInitilized&gt;&lt;Origin&gt;0&lt;/Origin&gt;&lt;app_list&gt;ovirt-guest-agent-common-1.0.16-1.el7ev,kernel-3.10.0-1062.el7&lt;/app_list&gt;&lt;quota_id&gt;5fa337c2-9eb4-4d83-9d6a-739cf88a2312&lt;/quota_id&gt;&lt;DefaultDisplayType&gt;1&lt;/DefaultDisplayType&gt;&lt;TrustedService&gt;false&lt;/TrustedService&gt;&lt;OriginalTemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/OriginalTemplateId&gt;&lt;OriginalTemplateName&gt;Blank&lt;/OriginalTemplateName&gt;&lt;UseLatestVersion&gt;false&lt;/UseLatestVersion&gt;&lt;StopTime&gt;2019/12/16 10:53:49&lt;/StopTime&gt;&lt;BootTime&gt;2019/12/16 10:53:51&lt;/BootTime&gt;&lt;Downtime&gt;0&lt;/Downtime&gt;&lt;Section ovf:id="17a94da8-3d02-430e-9b83-5e39f92907e8" ovf:required="false" xsi:type="ovf:OperatingSystemSection_Type"&gt;&lt;Info&gt;Guest Operating System&lt;/Info&gt;&lt;Description&gt;rhel_7x64&lt;/Description&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:VirtualHardwareSection_Type"&gt;&lt;Info&gt;4 CPU, 3072 Memory&lt;/Info&gt;&lt;System&gt;&lt;vssd:VirtualSystemType&gt;ENGINE 4.1.0.0&lt;/vssd:VirtualSystemType&gt;&lt;/System&gt;&lt;Item&gt;&lt;rasd:Caption&gt;4 virtual cpu&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Number of virtual CPU&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;1&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;3&lt;/rasd:ResourceType&gt;&lt;rasd:num_of_sockets&gt;2&lt;/rasd:num_of_sockets&gt;&lt;rasd:cpu_per_socket&gt;2&lt;/rasd:cpu_per_socket&gt;&lt;rasd:threads_per_cpu&gt;1&lt;/rasd:threads_per_cpu&gt;&lt;rasd:max_num_of_vcpus&gt;32&lt;/rasd:max_num_of_vcpus&gt;&lt;rasd:VirtualQuantity&gt;4&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;3072 MB of memory&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Memory Size&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;2&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;4&lt;/rasd:ResourceType&gt;&lt;rasd:AllocationUnits&gt;MegaBytes&lt;/rasd:AllocationUnits&gt;&lt;rasd:VirtualQuantity&gt;3072&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;rhel7s_Disk1&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;17&lt;/rasd:ResourceType&gt;&lt;rasd:HostResource&gt;f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:HostResource&gt;&lt;rasd:Parent&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Parent&gt;&lt;rasd:Template&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Template&gt;&lt;rasd:ApplicationList&gt;&lt;/rasd:ApplicationList&gt;&lt;rasd:StorageId&gt;cfbc93a1-17b7-4d03-a8ca-3b3bfef52729&lt;/rasd:StorageId&gt;&lt;rasd:StoragePoolId&gt;e57249a3-d28a-455f-b30c-4ac0979f2ccc&lt;/rasd:StoragePoolId&gt;&lt;rasd:CreationDate&gt;2019/10/15 10:13:29&lt;/rasd:CreationDate&gt;&lt;rasd:LastModified&gt;1970/01/01 00:00:00&lt;/rasd:LastModified&gt;&lt;rasd:last_modified_date&gt;2019/12/16 10:55:55&lt;/rasd:last_modified_date&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;disk&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=0, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;1&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-f6e4775b-53be-4136-9e30-f0be18b70668&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Ethernet adapter on ovirtmgmt&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;93159b67-49fe-4add-8b31-91be915a208b&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;10&lt;/rasd:ResourceType&gt;&lt;rasd:OtherResourceType&gt;ovirtmgmt&lt;/rasd:OtherResourceType&gt;&lt;rasd:ResourceSubType&gt;3&lt;/rasd:ResourceSubType&gt;&lt;rasd:Connection&gt;ovirtmgmt&lt;/rasd:Connection&gt;&lt;rasd:Linked&gt;true&lt;/rasd:Linked&gt;&lt;rasd:Name&gt;nic1&lt;/rasd:Name&gt;&lt;rasd:ElementName&gt;nic1&lt;/rasd:ElementName&gt;&lt;rasd:MACAddress&gt;56:6f:85:ae:00:00&lt;/rasd:MACAddress&gt;&lt;rasd:speed&gt;10000&lt;/rasd:speed&gt;&lt;Type&gt;interface&lt;/Type&gt;&lt;Device&gt;bridge&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x03, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-93159b67-49fe-4add-8b31-91be915a208b&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;USB Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;3&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;23&lt;/rasd:ResourceType&gt;&lt;rasd:UsbPolicy&gt;DISABLED&lt;/rasd:UsbPolicy&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;20&lt;/rasd:ResourceType&gt;&lt;rasd:VirtualQuantity&gt;1&lt;/rasd:VirtualQuantity&gt;&lt;rasd:SinglePciQxl&gt;false&lt;/rasd:SinglePciQxl&gt;&lt;Type&gt;video&lt;/Type&gt;&lt;Device&gt;qxl&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x02, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;vgamem&gt;16384&lt;/vgamem&gt;&lt;heads&gt;1&lt;/heads&gt;&lt;vram&gt;32768&lt;/vram&gt;&lt;ram&gt;65536&lt;/ram&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d835d395-f01c-4991-8643-b0578b2f3cf4&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;spice&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;393b1788-8d19-4f18-ac73-9984db012e59&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;vnc&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;CDROM&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;15&lt;/rasd:ResourceType&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;cdrom&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=1, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;2&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/Alias&gt;&lt;SpecParams&gt;&lt;path&gt;rhel-server-7.7-x86_64-dvd.iso&lt;/path&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;56980ab4-4fbd-4b12-911e-534ce16dc4d4&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;spicevmc&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=3}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel2&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;8614413b-a1c9-482e-92f9-aad255e34b33&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel1&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;7d493d38-9770-4569-a213-4cc830b48b7b&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel0&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;0e988f54-ff5e-4f78-953a-1dfe1e813bb7&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;ide&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ide&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-serial&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x05, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;b8eed426-0eb3-4f95-9fb7-6c430490bf0e&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;usb&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;usb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;model&gt;piix3-uhci&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;3d7a7589-28a7-49c0-bf1b-65bf5213ba5b&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-scsi&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x04, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-3d7a7589-28a7-49c0-bf1b-65bf5213ba5b&lt;/Alias&gt;&lt;SpecParams&gt;&lt;ioThreadId&gt;&lt;/ioThreadId&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/rasd:InstanceId&gt;&lt;Type&gt;rng&lt;/Type&gt;&lt;Device&gt;virtio&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x07, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/Alias&gt;&lt;SpecParams&gt;&lt;source&gt;urandom&lt;/source&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/rasd:InstanceId&gt;&lt;Type&gt;balloon&lt;/Type&gt;&lt;Device&gt;memballoon&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x06, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/Alias&gt;&lt;SpecParams&gt;&lt;model&gt;virtio&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:SnapshotsSection_Type"&gt;&lt;Snapshot ovf:id="fc282c90-ded5-456b-ab99-2d2fe6abc262"&gt;&lt;Type&gt;ACTIVE&lt;/Type&gt;&lt;Description&gt;Active VM&lt;/Description&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;/Snapshot&gt;&lt;Snapshot ovf:id="fb82cee1-39d6-4733-8c12-8c878ffd79ae"&gt;&lt;Type&gt;NEXT_RUN&lt;/Type&gt;&lt;Description&gt;Next Run configuration snapshot&lt;/Description&gt;&lt;CreationDate&gt;2019/12/16 10:55:55&lt;/CreationDate&gt;&lt;VmConfiguration&gt;PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48b3ZmOkVudmVsb3BlIHhtbG5zOm92Zj0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEvIiB4bWxuczpyYXNkPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy93YmVtL3dzY2ltLzEvY2ltLXNjaGVtYS8yL0NJTV9SZXNvdXJjZUFsbG9jYXRpb25TZXR0aW5nRGF0YSIgeG1sbnM6dnNzZD0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fVmlydHVhbFN5c3RlbVNldHRpbmdEYXRhIiB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiBvdmY6dmVyc2lvbj0iNC4xLjAuMCI+PFJlZmVyZW5jZXM+PC9SZWZlcmVuY2VzPjxOZXR3b3JrU2VjdGlvbj48SW5mbz5MaXN0IG9mIG5ldHdvcmtzPC9JbmZvPjxOZXR3b3JrIG92ZjpuYW1lPSJvdmlydG1nbXQiPjwvTmV0d29yaz48L05ldHdvcmtTZWN0aW9uPjxTZWN0aW9uIHhzaTp0eXBlPSJvdmY6RGlza1NlY3Rpb25fVHlwZSI+PEluZm8+TGlzdCBvZiBWaXJ0dWFsIERpc2tzPC9JbmZvPjwvU2VjdGlvbj48Q29udGVudCBvdmY6aWQ9Im91dCIgeHNpOnR5cGU9Im92ZjpWaXJ0dWFsU3lzdGVtX1R5cGUiPjxOYW1lPnJoZWw3czwvTmFtZT48RGVzY3JpcHRpb24+PC9EZXNjcmlwdGlvbj48Q29tbWVudD48L0NvbW1lbnQ+PENyZWF0aW9uRGF0ZT4yMDE5LzEwLzE1IDEwOjEyOjEyPC9DcmVhdGlvbkRhdGU+PEV4cG9ydERhdGU+MjAxOS8xMi8xNiAxMDo1NTo1NTwvRXhwb3J0RGF0ZT48RGVsZXRlUHJvdGVjdGVkPmZhbHNlPC9EZWxldGVQcm90ZWN0ZWQ+PFNzb01ldGhvZD5ndWVzdF9hZ2VudDwvU3NvTWV0aG9kPjxJc1NtYXJ0Y2FyZEVuYWJsZWQ+ZmFsc2U8L0lzU21hcnRjYXJkRW5hYmxlZD48TnVtT2ZJb1RocmVhZHM+MTwvTnVtT2ZJb1RocmVhZHM+PFRpbWVab25lPkV1cm9wZS9XYXJzYXc8L1RpbWVab25lPjxkZWZhdWx0X2Jvb3Rfc2VxdWVuY2U+OTwvZGVmYXVsdF9ib290X3NlcXVlbmNlPjxHZW5lcmF0aW9uPjExNDI8L0dlbmVyYXRpb24+PENsdXN0ZXJDb21wYXRpYmlsaXR5VmVyc2lvbj40LjM8L0NsdXN0ZXJDb21wYXRpYmlsaXR5VmVyc2lvbj48Vm1UeXBlPjE8L1ZtVHlwZT48UmVzdW1lQmVoYXZpb3I+QVVUT19SRVNVTUU8L1Jlc3VtZUJlaGF2aW9yPjxNaW5BbGxvY2F0ZWRNZW0+MzA3MjwvTWluQWxsb2NhdGVkTWVtPjxJc1N0YXRlbGVzcz5mYWxzZTwvSXNTdGF0ZWxlc3M+PElzUnVuQW5kUGF1c2U+ZmFsc2U8L0lzUnVuQW5kUGF1c2U+PEF1dG9TdGFydHVwPmZhbHNlPC9BdXRvU3RhcnR1cD48UHJpb3JpdHk+MTwvUHJpb3JpdHk+PENyZWF0ZWRCeVVzZXJJZD4yNTFhMmFlZS1lZTliLTExZTktYTZiZS01MjU0MDA1YTMyMzk8L0NyZWF0ZWRCeVVzZXJJZD48Vm1Jbml0IG92ZjphdXRob3JpemVkS2V5cz0iIiBvdmY6cmVnZW5lcmF0ZUtleXM9ImZhbHNlIiBvdmY6bmV0d29ya3M9IlsgXSIgb3ZmOmN1c3RvbVNjcmlwdD0iIj48L1ZtSW5pdD48TWlncmF0aW9uU3VwcG9ydD4wPC9NaWdyYXRpb25TdXBwb3J0PjxJc0Jvb3RNZW51RW5hYmxlZD5mYWxzZTwvSXNCb290TWVudUVuYWJsZWQ+PElzU3BpY2VGaWxlVHJhbnNmZXJFbmFibGVkPnRydWU8L0lzU3BpY2VGaWxlVHJhbnNmZXJFbmFibGVkPjxJc1NwaWNlQ29weVBhc3RlRW5hYmxlZD50cnVlPC9Jc1NwaWNlQ29weVBhc3RlRW5hYmxlZD48QWxsb3dDb25zb2xlUmVjb25uZWN0PnRydWU8L0FsbG93Q29uc29sZVJlY29ubmVjdD48Q29uc29sZURpc2Nvbm5lY3RBY3Rpb24+TE9DS19TQ1JFRU48L0NvbnNvbGVEaXNjb25uZWN0QWN0aW9uPjxDdXN0b21FbXVsYXRlZE1hY2hpbmU+PC9DdXN0b21FbXVsYXRlZE1hY2hpbmU+PEJpb3NUeXBlPjA8L0Jpb3NUeXBlPjxDdXN0b21DcHVOYW1lPjwvQ3VzdG9tQ3B1TmFtZT48UHJlZGVmaW5lZFByb3BlcnRpZXM+PC9QcmVkZWZpbmVkUHJvcGVydGllcz48VXNlckRlZmluZWRQcm9wZXJ0aWVzPjwvVXNlckRlZmluZWRQcm9wZXJ0aWVzPjxNYXhNZW1vcnlTaXplTWI+NDA5NjwvTWF4TWVtb3J5U2l6ZU1iPjxNdWx0aVF1ZXVlc0VuYWJsZWQ+dHJ1ZTwvTXVsdGlRdWV1ZXNFbmFibGVkPjxVc2VIb3N0Q3B1PmZhbHNlPC9Vc2VIb3N0Q3B1PjxDbHVzdGVyTmFtZT48L0NsdXN0ZXJOYW1lPjxUZW1wbGF0ZUlkPjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMDwvVGVtcGxhdGVJZD48VGVtcGxhdGVOYW1lPkJsYW5rPC9UZW1wbGF0ZU5hbWU+PElzSW5pdGlsaXplZD50cnVlPC9Jc0luaXRpbGl6ZWQ+PE9yaWdpbj4wPC9PcmlnaW4+PHF1b3RhX2lkPjVmYTMzN2MyLTllYjQtNGQ4My05ZDZhLTczOWNmODhhMjMxMjwvcXVvdGFfaWQ+PERlZmF1bHREaXNwbGF5VHlwZT4xPC9EZWZhdWx0RGlzcGxheVR5cGU+PFRydXN0ZWRTZXJ2aWNlPmZhbHNlPC9UcnVzdGVkU2VydmljZT48T3JpZ2luYWxUZW1wbGF0ZUlkPjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMDwvT3JpZ2luYWxUZW1wbGF0ZUlkPjxPcmlnaW5hbFRlbXBsYXRlTmFtZT5CbGFuazwvT3JpZ2luYWxUZW1wbGF0ZU5hbWU+PFVzZUxhdGVzdFZlcnNpb24+ZmFsc2U8L1VzZUxhdGVzdFZlcnNpb24+PFNlY3Rpb24gb3ZmOmlkPSIxN2E5NGRhOC0zZDAyLTQzMGUtOWI4My01ZTM5ZjkyOTA3ZTgiIG92ZjpyZXF1aXJlZD0iZmFsc2UiIHhzaTp0eXBlPSJvdmY6T3BlcmF0aW5nU3lzdGVtU2VjdGlvbl9UeXBlIj48SW5mbz5HdWVzdCBPcGVyYXRpbmcgU3lzdGVtPC9JbmZvPjxEZXNjcmlwdGlvbj5yaGVsXzd4NjQ8L0Rlc2NyaXB0aW9uPjwvU2VjdGlvbj48U2VjdGlvbiB4c2k6dHlwZT0ib3ZmOlZpcnR1YWxIYXJkd2FyZVNlY3Rpb25fVHlwZSI+PEluZm8+MiBDUFUsIDMwNzIgTWVtb3J5PC9JbmZvPjxTeXN0ZW0+PHZzc2Q6VmlydHVhbFN5c3RlbVR5cGU+RU5HSU5FIDQuMS4wLjA8L3Zzc2Q6VmlydHVhbFN5c3RlbVR5cGU+PC9TeXN0ZW0+PEl0ZW0+PHJhc2Q6Q2FwdGlvbj4yIHZpcnR1YWwgY3B1PC9yYXNkOkNhcHRpb24+PHJhc2Q6RGVzY3JpcHRpb24+TnVtYmVyIG9mIHZpcnR1YWwgQ1BVPC9yYXNkOkRlc2NyaXB0aW9uPjxyYXNkOkluc3RhbmNlSWQ+MTwvcmFzZDpJbnN0YW5jZUlkPjxyYXNkOlJlc291cmNlVHlwZT4zPC9yYXNkOlJlc291cmNlVHlwZT48cmFzZDpudW1fb2Zfc29ja2V0cz4yPC9yYXNkOm51bV9vZl9zb2NrZXRzPjxyYXNkOmNwdV9wZXJfc29ja2V0PjE8L3Jhc2Q6Y3B1X3Blcl9zb2NrZXQ+PHJhc2Q6dGhyZWFkc19wZXJfY3B1PjE8L3Jhc2Q6dGhyZWFkc19wZXJfY3B1PjxyYXNkOm1heF9udW1fb2ZfdmNwdXM+MTY8L3Jhc2Q6bWF4X251bV9vZl92Y3B1cz48cmFzZDpWaXJ0dWFsUXVhbnRpdHk+MjwvcmFzZDpWaXJ0dWFsUXVhbnRpdHk+PC9JdGVtPjxJdGVtPjxyYXNkOkNhcHRpb24+MzA3MiBNQiBvZiBtZW1vcnk8L3Jhc2Q6Q2FwdGlvbj48cmFzZDpEZXNjcmlwdGlvbj5NZW1vcnkgU2l6ZTwvcmFzZDpEZXNjcmlwdGlvbj48cmFzZDpJbnN0YW5jZUlkPjI8L3Jhc2Q6SW5zdGFuY2VJZD48cmFzZDpSZXNvdXJjZVR5cGU+NDwvcmFzZDpSZXNvdXJjZVR5cGU+PHJhc2Q6QWxsb2NhdGlvblVuaXRzPk1lZ2FCeXRlczwvcmFzZDpBbGxvY2F0aW9uVW5pdHM+PHJhc2Q6VmlydHVhbFF1YW50aXR5PjMwNzI8L3Jhc2Q6VmlydHVhbFF1YW50aXR5PjwvSXRlbT48SXRlbT48cmFzZDpDYXB0aW9uPkV0aGVybmV0IGFkYXB0ZXIgb24gb3ZpcnRtZ210PC9yYXNkOkNhcHRpb24+PHJhc2Q6SW5zdGFuY2VJZD45MzE1OWI2Ny00OWZlLTRhZGQtOGIzMS05MWJlOTE1YTIwOGI8L3Jhc2Q6SW5zdGFuY2VJZD48cmFzZDpSZXNvdXJjZVR5cGU+MTA8L3Jhc2Q6UmVzb3VyY2VUeXBlPjxyYXNkOk90aGVyUmVzb3VyY2VUeXBlPm92aXJ0bWdtdDwvcmFzZDpPdGhlclJlc291cmNlVHlwZT48cmFzZDpSZXNvdXJjZVN1YlR5cGU+MzwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+PHJhc2Q6Q29ubmVjdGlvbj5vdmlydG1nbXQ8L3Jhc2Q6Q29ubmVjdGlvbj48cmFzZDpMaW5rZWQ+dHJ1ZTwvcmFzZDpMaW5rZWQ+PHJhc2Q6TmFtZT5uaWMxPC9yYXNkOk5hbWU+PHJhc2Q6RWxlbWVudE5hbWU+bmljMTwvcmFzZDpFbGVtZW50TmFtZT48cmFzZDpNQUNBZGRyZXNzPjU2OjZmOjg1OmFlOjAwOjAwPC9yYXNkOk1BQ0FkZHJlc3M+PHJhc2Q6c3BlZWQ+MTAwMDA8L3Jhc2Q6c3BlZWQ+PFR5cGU+aW50ZXJmYWNlPC9UeXBlPjxEZXZpY2U+YnJpZGdlPC9EZXZpY2U+PHJhc2Q6QWRkcmVzcz57dHlwZT1wY2ksIHNsb3Q9MHgwMywgYnVzPTB4MDAsIGRvbWFpbj0weDAwMDAsIGZ1bmN0aW9uPTB4MH08L3Jhc2Q6QWRkcmVzcz48Qm9vdE9yZGVyPjA8L0Jvb3RPcmRlcj48SXNQbHVnZ2VkPnRydWU8L0lzUGx1Z2dlZD48SXNSZWFkT25seT5mYWxzZTwvSXNSZWFkT25seT48QWxpYXM+dWEtOTMxNTliNjctNDlmZS00YWRkLThiMzEtOTFiZTkxNWEyMDhiPC9BbGlhcz48L0l0ZW0+PEl0ZW0+PHJhc2Q6Q2FwdGlvbj5VU0IgQ29udHJvbGxlcjwvcmFzZDpDYXB0aW9uPjxyYXNkOkluc3RhbmNlSWQ+MzwvcmFzZDpJbnN0YW5jZUlkPjxyYXNkOlJlc291cmNlVHlwZT4yMzwvcmFzZDpSZXNvdXJjZVR5cGU+PHJhc2Q6VXNiUG9saWN5PkRJU0FCTEVEPC9yYXNkOlVzYlBvbGljeT48L0l0ZW0+PEl0ZW0+PHJhc2Q6Q2FwdGlvbj5HcmFwaGljYWwgQ29udHJvbGxlcjwvcmFzZDpDYXB0aW9uPjxyYXNkOkluc3RhbmNlSWQ+NmM0NDU2ZmYtZGU3MC00ZDAxLTljZjAtNGIyZTQ5YmNmYmJiPC9yYXNkOkluc3RhbmNlSWQ+PHJhc2Q6UmVzb3VyY2VUeXBlPjIwPC9yYXNkOlJlc291cmNlVHlwZT48cmFzZDpWaXJ0dWFsUXVhbnRpdHk+MTwvcmFzZDpWaXJ0dWFsUXVhbnRpdHk+PHJhc2Q6U2luZ2xlUGNpUXhsPmZhbHNlPC9yYXNkOlNpbmdsZVBjaVF4bD48VHlwZT52aWRlbzwvVHlwZT48RGV2aWNlPnF4bDwvRGV2aWNlPjxyYXNkOkFkZHJlc3M+e3R5cGU9cGNpLCBzbG90PTB4MDIsIGJ1cz0weDAwLCBkb21haW49MHgwMDAwLCBmdW5jdGlvbj0weDB9PC9yYXNkOkFkZHJlc3M+PEJvb3RPcmRlcj4wPC9Cb290T3JkZXI+PElzUGx1Z2dlZD50cnVlPC9Jc1BsdWdnZWQ+PElzUmVhZE9ubHk+ZmFsc2U8L0lzUmVhZE9ubHk+PEFsaWFzPnVhLTZjNDQ1NmZmLWRlNzAtNGQwMS05Y2YwLTRiMmU0OWJjZmJiYjwvQWxpYXM+PFNwZWNQYXJhbXM+PHZnYW1lbT4xNjM4NDwvdmdhbWVtPjxoZWFkcz4xPC9oZWFkcz48dnJhbT4zMjc2ODwvdnJhbT48cmFtPjY1NTM2PC9yYW0+PC9TcGVjUGFyYW1zPjwvSXRlbT48SXRlbT48cmFzZDpDYXB0aW9uPkdyYXBoaWNhbCBGcmFtZWJ1ZmZlcjwvcmFzZDpDYXB0aW9uPjxyYXNkOkluc3RhbmNlSWQ+ZDgzNWQzOTUtZjAxYy00OTkxLTg2NDMtYjA1NzhiMmYzY2Y0PC9yYXNkOkluc3RhbmNlSWQ+PHJhc2Q6UmVzb3VyY2VUeXBlPjI2PC9yYXNkOlJlc291cmNlVHlwZT48VHlwZT5ncmFwaGljczwvVHlwZT48RGV2aWNlPnNwaWNlPC9EZXZpY2U+PHJhc2Q6QWRkcmVzcz48L3Jhc2Q6QWRkcmVzcz48Qm9vdE9yZGVyPjA8L0Jvb3RPcmRlcj48SXNQbHVnZ2VkPnRydWU8L0lzUGx1Z2dlZD48SXNSZWFkT25seT5mYWxzZTwvSXNSZWFkT25seT48QWxpYXM+PC9BbGlhcz48L0l0ZW0+PEl0ZW0+PHJhc2Q6Q2FwdGlvbj5HcmFwaGljYWwgRnJhbWVidWZmZXI8L3Jhc2Q6Q2FwdGlvbj48cmFzZDpJbnN0YW5jZUlkPjM5M2IxNzg4LThkMTktNGYxOC1hYzczLTk5ODRkYjAxMmU1OTwvcmFzZDpJbnN0YW5jZUlkPjxyYXNkOlJlc291cmNlVHlwZT4yNjwvcmFzZDpSZXNvdXJjZVR5cGU+PFR5cGU+Z3JhcGhpY3M8L1R5cGU+PERldmljZT52bmM8L0RldmljZT48cmFzZDpBZGRyZXNzPjwvcmFzZDpBZGRyZXNzPjxCb290T3JkZXI+MDwvQm9vdE9yZGVyPjxJc1BsdWdnZWQ+dHJ1ZTwvSXNQbHVnZ2VkPjxJc1JlYWRPbmx5PmZhbHNlPC9Jc1JlYWRPbmx5PjxBbGlhcz48L0FsaWFzPjwvSXRlbT48SXRlbT48cmFzZDpDYXB0aW9uPkNEUk9NPC9yYXNkOkNhcHRpb24+PHJhc2Q6SW5zdGFuY2VJZD5kMjBkMTQ3ZS0yZWNkLTRhMDQtYTg3MS1mOWYxYTJiOGZjMWU8L3Jhc2Q6SW5zdGFuY2VJZD48cmFzZDpSZXNvdXJjZVR5cGU+MTU8L3Jhc2Q6UmVzb3VyY2VUeXBlPjxUeXBlPmRpc2s8L1R5cGU+PERldmljZT5jZHJvbTwvRGV2aWNlPjxyYXNkOkFkZHJlc3M+e3R5cGU9ZHJpdmUsIGJ1cz0xLCBjb250cm9sbGVyPTAsIHRhcmdldD0wLCB1bml0PTB9PC9yYXNkOkFkZHJlc3M+PEJvb3RPcmRlcj4yPC9Cb290T3JkZXI+PElzUGx1Z2dlZD50cnVlPC9Jc1BsdWdnZWQ+PElzUmVhZE9ubHk+dHJ1ZTwvSXNSZWFkT25seT48QWxpYXM+dWEtZDIwZDE0N2UtMmVjZC00YTA0LWE4NzEtZjlmMWEyYjhmYzFlPC9BbGlhcz48U3BlY1BhcmFtcz48cGF0aD5yaGVsLXNlcnZlci03LjcteDg2XzY0LWR2ZC5pc288L3BhdGg+PC9TcGVjUGFyYW1zPjwvSXRlbT48SXRlbT48cmFzZDpSZXNvdXJjZVR5cGU+MDwvcmFzZDpSZXNvdXJjZVR5cGU+PHJhc2Q6SW5zdGFuY2VJZD44NjVlNmEwYy0zYzAyLTQ1ZWQtOGZjYi1hMzJmMzAwNTRmN2M8L3Jhc2Q6SW5zdGFuY2VJZD48VHlwZT5jb250cm9sbGVyPC9UeXBlPjxEZXZpY2U+dmlydGlvLXNlcmlhbDwvRGV2aWNlPjxyYXNkOkFkZHJlc3M+e3R5cGU9cGNpLCBzbG90PTB4MDUsIGJ1cz0weDAwLCBkb21haW49MHgwMDAwLCBmdW5jdGlvbj0weDB9PC9yYXNkOkFkZHJlc3M+PEJvb3RPcmRlcj4wPC9Cb290T3JkZXI+PElzUGx1Z2dlZD50cnVlPC9Jc1BsdWdnZWQ+PElzUmVhZE9ubHk+ZmFsc2U8L0lzUmVhZE9ubHk+PEFsaWFzPnVhLTg2NWU2YTBjLTNjMDItNDVlZC04ZmNiLWEzMmYzMDA1NGY3YzwvQWxpYXM+PC9JdGVtPjxJdGVtPjxyYXNkOlJlc291cmNlVHlwZT4wPC9yYXNkOlJlc291cmNlVHlwZT48cmFzZDpJbnN0YW5jZUlkPmI4ZWVkNDI2LTBlYjMtNGY5NS05ZmI3LTZjNDMwNDkwYmYwZTwvcmFzZDpJbnN0YW5jZUlkPjxUeXBlPmNvbnRyb2xsZXI8L1R5cGU+PERldmljZT51c2I8L0RldmljZT48cmFzZDpBZGRyZXNzPnt0eXBlPXBjaSwgc2xvdD0weDAxLCBidXM9MHgwMCwgZG9tYWluPTB4MDAwMCwgZnVuY3Rpb249MHgyfTwvcmFzZDpBZGRyZXNzPjxCb290T3JkZXI+MDwvQm9vdE9yZGVyPjxJc1BsdWdnZWQ+dHJ1ZTwvSXNQbHVnZ2VkPjxJc1JlYWRPbmx5PmZhbHNlPC9Jc1JlYWRPbmx5PjxBbGlhcz51c2I8L0FsaWFzPjxTcGVjUGFyYW1zPjxpbmRleD4wPC9pbmRleD48bW9kZWw+cGlpeDMtdWhjaTwvbW9kZWw+PC9TcGVjUGFyYW1zPjwvSXRlbT48SXRlbT48cmFzZDpSZXNvdXJjZVR5cGU+MDwvcmFzZDpSZXNvdXJjZVR5cGU+PHJhc2Q6SW5zdGFuY2VJZD4zZDdhNzU4OS0yOGE3LTQ5YzAtYmYxYi02NWJmNTIxM2JhNWI8L3Jhc2Q6SW5zdGFuY2VJZD48VHlwZT5jb250cm9sbGVyPC9UeXBlPjxEZXZpY2U+dmlydGlvLXNjc2k8L0RldmljZT48cmFzZDpBZGRyZXNzPnt0eXBlPXBjaSwgc2xvdD0weDA0LCBidXM9MHgwMCwgZG9tYWluPTB4MDAwMCwgZnVuY3Rpb249MHgwfTwvcmFzZDpBZGRyZXNzPjxCb290T3JkZXI+MDwvQm9vdE9yZGVyPjxJc1BsdWdnZWQ+dHJ1ZTwvSXNQbHVnZ2VkPjxJc1JlYWRPbmx5PmZhbHNlPC9Jc1JlYWRPbmx5PjxBbGlhcz51YS0zZDdhNzU4OS0yOGE3LTQ5YzAtYmYxYi02NWJmNTIxM2JhNWI8L0FsaWFzPjxTcGVjUGFyYW1zPjxpb1RocmVhZElkPjwvaW9UaHJlYWRJZD48L1NwZWNQYXJhbXM+PC9JdGVtPjxJdGVtPjxyYXNkOlJlc291cmNlVHlwZT4wPC9yYXNkOlJlc291cmNlVHlwZT48cmFzZDpJbnN0YW5jZUlkPjUxYzIyOGFlLTQyMGEtNDY3OS1hNmU4LWU5YmJlYzFhMzA2YTwvcmFzZDpJbnN0YW5jZUlkPjxUeXBlPnJuZzwvVHlwZT48RGV2aWNlPnZpcnRpbzwvRGV2aWNlPjxyYXNkOkFkZHJlc3M+e3R5cGU9cGNpLCBzbG90PTB4MDcsIGJ1cz0weDAwLCBkb21haW49MHgwMDAwLCBmdW5jdGlvbj0weDB9PC9yYXNkOkFkZHJlc3M+PEJvb3RPcmRlcj4wPC9Cb290T3JkZXI+PElzUGx1Z2dlZD50cnVlPC9Jc1BsdWdnZWQ+PElzUmVhZE9ubHk+ZmFsc2U8L0lzUmVhZE9ubHk+PEFsaWFzPnVhLTUxYzIyOGFlLTQyMGEtNDY3OS1hNmU4LWU5YmJlYzFhMzA2YTwvQWxpYXM+PFNwZWNQYXJhbXM+PHNvdXJjZT51cmFuZG9tPC9zb3VyY2U+PC9TcGVjUGFyYW1zPjwvSXRlbT48SXRlbT48cmFzZDpSZXNvdXJjZVR5cGU+MDwvcmFzZDpSZXNvdXJjZVR5cGU+PHJhc2Q6SW5zdGFuY2VJZD43OGVkNTNhYi1jNTkxLTRlYzktOTUwYS01MGEwNWM0MThkOWI8L3Jhc2Q6SW5zdGFuY2VJZD48VHlwZT5iYWxsb29uPC9UeXBlPjxEZXZpY2U+bWVtYmFsbG9vbjwvRGV2aWNlPjxyYXNkOkFkZHJlc3M+e3R5cGU9cGNpLCBzbG90PTB4MDYsIGJ1cz0weDAwLCBkb21haW49MHgwMDAwLCBmdW5jdGlvbj0weDB9PC9yYXNkOkFkZHJlc3M+PEJvb3RPcmRlcj4wPC9Cb290T3JkZXI+PElzUGx1Z2dlZD50cnVlPC9Jc1BsdWdnZWQ+PElzUmVhZE9ubHk+dHJ1ZTwvSXNSZWFkT25seT48QWxpYXM+dWEtNzhlZDUzYWItYzU5MS00ZWM5LTk1MGEtNTBhMDVjNDE4ZDliPC9BbGlhcz48U3BlY1BhcmFtcz48bW9kZWw+dmlydGlvPC9tb2RlbD48L1NwZWNQYXJhbXM+PC9JdGVtPjwvU2VjdGlvbj48L0NvbnRlbnQ+PC9vdmY6RW52ZWxvcGU+&lt;/VmConfiguration&gt;&lt;/Snapshot&gt;&lt;/Section&gt;&lt;/Content&gt;&lt;/ovf:Envelope&gt;</data>
+                  <type>ovf</type>
+              </configuration>
+              <custom_script></custom_script>
+              <nic_configurations/>
+              <regenerate_ssh_keys>false</regenerate_ssh_keys>
+          </initialization>
+          <io>
+              <threads>1</threads>
+          </io>
+          <large_icon href="/ovirt-engine/api/icons/286c4070-4374-12d6-af2d-ab35a7395e5f" id="286c4070-4374-12d6-af2d-ab35a7395e5f"/>
+          <memory>3221225472</memory>
+          <memory_policy>
+              <ballooning>true</ballooning>
+              <guaranteed>3221225472</guaranteed>
+              <max>4294967296</max>
+          </memory_policy>
+          <migration>
+              <auto_converge>inherit</auto_converge>
+              <compressed>inherit</compressed>
+          </migration>
+          <migration_downtime>-1</migration_downtime>
+          <multi_queues_enabled>true</multi_queues_enabled>
+          <origin>rhev</origin>
+          <os>
+              <boot>
+                  <devices>
+                      <device>hd</device>
+                      <device>cdrom</device>
+                  </devices>
+              </boot>
+              <type>rhel_7x64</type>
+          </os>
+          <placement_policy>
+              <affinity>migratable</affinity>
+          </placement_policy>
+          <rng_device>
+              <source>urandom</source>
+          </rng_device>
+          <small_icon href="/ovirt-engine/api/icons/a029b4bf-5437-dae6-0cdf-3c9fb623cf1d" id="a029b4bf-5437-dae6-0cdf-3c9fb623cf1d"/>
+          <soundcard_enabled>false</soundcard_enabled>
+          <sso>
+              <methods>
+                  <method id="guest_agent"/>
+              </methods>
+          </sso>
+          <start_paused>false</start_paused>
+          <stateless>false</stateless>
+          <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+          <time_zone>
+              <name>Europe/Warsaw</name>
+          </time_zone>
+          <type>server</type>
+          <usb>
+              <enabled>false</enabled>
+          </usb>
+          <virtio_scsi>
+              <enabled>true</enabled>
+          </virtio_scsi>
+          <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde"/>
+          <cpu_profile href="/ovirt-engine/api/cpuprofiles/c5926295-65ef-4dba-b234-26db503cb59d" id="c5926295-65ef-4dba-b234-26db503cb59d"/>
+          <quota id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
+          <fqdn>rhels</fqdn>
+          <guest_operating_system>
+              <architecture>x86_64</architecture>
+              <codename>Server</codename>
+              <distribution>Red Hat Enterprise Linux Server</distribution>
+              <family>Linux</family>
+              <kernel>
+                  <version>
+                      <build>0</build>
+                      <full_version>3.10.0-1062.el7.x86_64</full_version>
+                      <major>3</major>
+                      <minor>10</minor>
+                      <revision>1062</revision>
+                  </version>
+              </kernel>
+              <version>
+                  <full_version>7.7</full_version>
+                  <major>7</major>
+                  <minor>7</minor>
+              </version>
+          </guest_operating_system>
+          <guest_time_zone>
+              <name>EST</name>
+              <utc_offset>-05:00</utc_offset>
+          </guest_time_zone>
+          <next_run_configuration_exists>true</next_run_configuration_exists>
+          <numa_tune_mode>interleave</numa_tune_mode>
+          <run_once>false</run_once>
+          <start_time>2019-12-16T11:53:51.115+01:00</start_time>
+          <status>up</status>
+          <stop_time>2019-12-16T11:53:49.827+01:00</stop_time>
+          <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
+          <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+          <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+      </vm>
+    :code: 200
+    :headers:
+      date: Mon, 16 Dec 2019 10:55:55 GMT
+      server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+      content-encoding: gzip
+      content-type: application/xml;charset=UTF-8
+      content-length: '11121'
+      correlation-id: 2eabed7d-4dab-4644-b72d-f787d30648b8
+    :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
         <actions>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
+            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
-            <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
             <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
@@ -2875,22 +4460,22 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <name>rhel7s</name>
         <description></description>
         <comment></comment>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
-        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
+        <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
         <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
         <bios>
             <boot_menu>
@@ -3032,266 +4617,43 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e
         <next_run_configuration_exists>true</next_run_configuration_exists>
         <numa_tune_mode>interleave</numa_tune_mode>
         <run_once>false</run_once>
-        <start_time>2019-12-02T12:25:51.513+01:00</start_time>
+        <start_time>2019-12-16T11:53:51.115+01:00</start_time>
         <status>up</status>
-        <stop_time>2019-12-02T12:25:50.959+01:00</stop_time>
+        <stop_time>2019-12-16T11:53:49.827+01:00</stop_time>
         <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
         <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
         <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
     </vm>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:55 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '3229'
-    correlation-id: 17780aa0-854f-4f90-9330-26d93d0fa282
+    content-length: '3233'
+    correlation-id: 0b110b66-5fb1-4101-9420-90b38979687b
   :message: 
-? |
-  https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8{:next_run=>"false"}PUT<vm>
-    <cpu>
-      <topology>
-        <cores>1</cores>
-        <sockets>2</sockets>
-      </topology>
-    </cpu>
-  </vm>
-: - :body: |
-      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-      <vm href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8" id="17a94da8-3d02-430e-9b83-5e39f92907e8">
-          <actions>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/detach" rel="detach"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/export" rel="export"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cancelmigration" rel="cancelmigration"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/commitsnapshot" rel="commitsnapshot"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/clone" rel="clone"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/freezefilesystems" rel="freezefilesystems"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/logon" rel="logon"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/maintenance" rel="maintenance"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/previewsnapshot" rel="previewsnapshot"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reordermacaddresses" rel="reordermacaddresses"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/thawfilesystems" rel="thawfilesystems"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/undosnapshot" rel="undosnapshot"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/ticket" rel="ticket"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/migrate" rel="migrate"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reboot" rel="reboot"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/shutdown" rel="shutdown"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/start" rel="start"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/stop" rel="stop"/>
-              <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/suspend" rel="suspend"/>
-          </actions>
-          <name>rhel7s</name>
-          <description></description>
-          <comment></comment>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots" rel="snapshots"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/applications" rel="applications"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/hostdevices" rel="hostdevices"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/reporteddevices" rel="reporteddevices"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/sessions" rel="sessions"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/backups" rel="backups"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/watchdogs" rel="watchdogs"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/graphicsconsoles" rel="graphicsconsoles"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/cdroms" rel="cdroms"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/diskattachments" rel="diskattachments"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/affinitylabels" rel="affinitylabels"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/nics" rel="nics"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/numanodes" rel="numanodes"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/katelloerrata" rel="katelloerrata"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/permissions" rel="permissions"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/tags" rel="tags"/>
-          <link href="/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/statistics" rel="statistics"/>
-          <bios>
-              <boot_menu>
-                  <enabled>false</enabled>
-              </boot_menu>
-              <type>i440fx_sea_bios</type>
-          </bios>
-          <console>
-              <enabled>false</enabled>
-          </console>
-          <cpu>
-              <architecture>x86_64</architecture>
-              <topology>
-                  <cores>2</cores>
-                  <sockets>2</sockets>
-                  <threads>1</threads>
-              </topology>
-          </cpu>
-          <cpu_shares>0</cpu_shares>
-          <creation_time>2019-10-15T12:12:12.505+02:00</creation_time>
-          <delete_protected>false</delete_protected>
-          <display>
-              <address>192.168.178.48</address>
-              <allow_override>true</allow_override>
-              <certificate>
-                  <content>-----BEGIN CERTIFICATE-----
-      MIIDujCCAqKgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwRTELMAkGA1UEBhMCVVMxEjAQBgNVBAoM
-      CWZyaXR6LmJveDEiMCAGA1UEAwwZZW5naW5lLTQzLmZyaXR6LmJveC40MDczNzAeFw0xOTEwMTMx
-      NTU1MTJaFw0yOTEwMTExNTU1MTJaMEUxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlmcml0ei5ib3gx
-      IjAgBgNVBAMMGWVuZ2luZS00My5mcml0ei5ib3guNDA3MzcwggEiMA0GCSqGSIb3DQEBAQUAA4IB
-      DwAwggEKAoIBAQDOBt7e2IGBsiRkzj/139dMZVOIiUr7d2O/6ECI284u/U/ENY3kJT5tKVbn7UAk
-      8MnEH92FMBN2fcaGAnk36I6ZnJBxbj59mVPNgu7bktViKZkvgHEbZuX3BctJJZDrh0D67zIRsSKd
-      5xsFFWIjUAUkmyKOuxD4xsqXop1Cw5cjSzadY6XZMi2vw0yFtOUQ/3FMpXkZ9yAMT+clzaUu3rgs
-      IUbnLSpfKdDUm5NzCksOo8gOjXmx0OkXna8nQvQGb3ycmTeS10MzeURtgkPlfR+nZWDDiUNOHLmZ
-      y1IoZxsq0MmZx42YqbQ1WjPzj55H7rXhYqATUBjvYYh+39WSP/pfAgMBAAGjgbMwgbAwHQYDVR0O
-      BBYEFD9mD6ChOc01EKwqT3PaF+jxY+1MMG4GA1UdIwRnMGWAFD9mD6ChOc01EKwqT3PaF+jxY+1M
-      oUmkRzBFMQswCQYDVQQGEwJVUzESMBAGA1UECgwJZnJpdHouYm94MSIwIAYDVQQDDBllbmdpbmUt
-      NDMuZnJpdHouYm94LjQwNzM3ggIQADAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAN
-      BgkqhkiG9w0BAQsFAAOCAQEAilO/2+J+etHnfkY5Zlw5fCi4f20fhA0C2k3pmyzEnk+02/cBr1XK
-      PfsDXCEmCiXpMTru3iflYee6L5MRZqDuu7dKaZVwYhdCpURHxkMuBT7gA0YvtC1TNnRDu2EDvjUh
-      /Mtqngojv4XdCM1aza0fw0pyE+mz+e+97KLGmtutj0W2JymsXcHtHlLJxjNXTie7qzsrMKGLfKmq
-      eBceTlpcGF98zFqlLEjRMuJ/I2AN2kDpK+e1zCFL1lYzb2MAN8Aol2Eqw6ZrezVT+5NLnJ/aw55S
-      HuXeUczWeCztAUiGYS9HD2kcdp9Y7mr4OMZi+IePz5mkn0TTkCgNcIQho3vH1Q==
-      -----END CERTIFICATE-----
-      </content>
-                  <organization>fritz.box</organization>
-                  <subject>O=fritz.box,CN=host01-43.fritz.box</subject>
-              </certificate>
-              <copy_paste_enabled>true</copy_paste_enabled>
-              <disconnect_action>LOCK_SCREEN</disconnect_action>
-              <file_transfer_enabled>true</file_transfer_enabled>
-              <monitors>1</monitors>
-              <port>5901</port>
-              <secure_port>5902</secure_port>
-              <single_qxl_pci>false</single_qxl_pci>
-              <smartcard_enabled>false</smartcard_enabled>
-              <type>spice</type>
-          </display>
-          <high_availability>
-              <enabled>false</enabled>
-              <priority>1</priority>
-          </high_availability>
-          <initialization>
-              <authorized_ssh_keys></authorized_ssh_keys>
-              <configuration>
-                  <data>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1/" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovf:version="4.1.0.0"&gt;&lt;References&gt;&lt;File ovf:href="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:id="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="2052321280" ovf:description="Active VM" ovf:disk_storage_type="IMAGE" ovf:cinder_volume_type=""&gt;&lt;/File&gt;&lt;/References&gt;&lt;NetworkSection&gt;&lt;Info&gt;List of networks&lt;/Info&gt;&lt;Network ovf:name="ovirtmgmt"&gt;&lt;/Network&gt;&lt;/NetworkSection&gt;&lt;Section xsi:type="ovf:DiskSection_Type"&gt;&lt;Info&gt;List of Virtual Disks&lt;/Info&gt;&lt;Disk ovf:diskId="13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:size="15" ovf:actual_size="2" ovf:vm_snapshot_id="fc282c90-ded5-456b-ab99-2d2fe6abc262" ovf:parentRef="" ovf:fileRef="f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a" ovf:format="http://www.vmware.com/specifications/vmdk.html#sparse" ovf:volume-format="RAW" ovf:volume-type="Sparse" ovf:disk-interface="VirtIO_SCSI" ovf:read-only="false" ovf:shareable="false" ovf:boot="true" ovf:pass-discard="false" ovf:disk-alias="rhel7s_Disk1" ovf:disk-description="" ovf:wipe-after-delete="true"&gt;&lt;/Disk&gt;&lt;/Section&gt;&lt;Content ovf:id="out" xsi:type="ovf:VirtualSystem_Type"&gt;&lt;Name&gt;rhel7s&lt;/Name&gt;&lt;Description&gt;&lt;/Description&gt;&lt;Comment&gt;&lt;/Comment&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;ExportDate&gt;2019/12/02 11:26:44&lt;/ExportDate&gt;&lt;DeleteProtected&gt;false&lt;/DeleteProtected&gt;&lt;SsoMethod&gt;guest_agent&lt;/SsoMethod&gt;&lt;IsSmartcardEnabled&gt;false&lt;/IsSmartcardEnabled&gt;&lt;NumOfIoThreads&gt;1&lt;/NumOfIoThreads&gt;&lt;TimeZone&gt;Europe/Warsaw&lt;/TimeZone&gt;&lt;default_boot_sequence&gt;9&lt;/default_boot_sequence&gt;&lt;Generation&gt;884&lt;/Generation&gt;&lt;ClusterCompatibilityVersion&gt;4.3&lt;/ClusterCompatibilityVersion&gt;&lt;VmType&gt;1&lt;/VmType&gt;&lt;ResumeBehavior&gt;AUTO_RESUME&lt;/ResumeBehavior&gt;&lt;MinAllocatedMem&gt;3072&lt;/MinAllocatedMem&gt;&lt;IsStateless&gt;false&lt;/IsStateless&gt;&lt;IsRunAndPause&gt;false&lt;/IsRunAndPause&gt;&lt;AutoStartup&gt;false&lt;/AutoStartup&gt;&lt;Priority&gt;1&lt;/Priority&gt;&lt;CreatedByUserId&gt;251a2aee-ee9b-11e9-a6be-5254005a3239&lt;/CreatedByUserId&gt;&lt;MigrationSupport&gt;0&lt;/MigrationSupport&gt;&lt;IsBootMenuEnabled&gt;false&lt;/IsBootMenuEnabled&gt;&lt;IsSpiceFileTransferEnabled&gt;true&lt;/IsSpiceFileTransferEnabled&gt;&lt;IsSpiceCopyPasteEnabled&gt;true&lt;/IsSpiceCopyPasteEnabled&gt;&lt;AllowConsoleReconnect&gt;true&lt;/AllowConsoleReconnect&gt;&lt;ConsoleDisconnectAction&gt;LOCK_SCREEN&lt;/ConsoleDisconnectAction&gt;&lt;CustomEmulatedMachine&gt;&lt;/CustomEmulatedMachine&gt;&lt;BiosType&gt;0&lt;/BiosType&gt;&lt;CustomCpuName&gt;&lt;/CustomCpuName&gt;&lt;PredefinedProperties&gt;&lt;/PredefinedProperties&gt;&lt;UserDefinedProperties&gt;&lt;/UserDefinedProperties&gt;&lt;MaxMemorySizeMb&gt;4096&lt;/MaxMemorySizeMb&gt;&lt;MultiQueuesEnabled&gt;true&lt;/MultiQueuesEnabled&gt;&lt;UseHostCpu&gt;false&lt;/UseHostCpu&gt;&lt;ClusterName&gt;depot_cl&lt;/ClusterName&gt;&lt;TemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/TemplateId&gt;&lt;TemplateName&gt;Blank&lt;/TemplateName&gt;&lt;IsInitilized&gt;true&lt;/IsInitilized&gt;&lt;Origin&gt;0&lt;/Origin&gt;&lt;app_list&gt;ovirt-guest-agent-common-1.0.16-1.el7ev,kernel-3.10.0-1062.el7,qemu-guest-agent-2.12.0&lt;/app_list&gt;&lt;quota_id&gt;5fa337c2-9eb4-4d83-9d6a-739cf88a2312&lt;/quota_id&gt;&lt;DefaultDisplayType&gt;1&lt;/DefaultDisplayType&gt;&lt;TrustedService&gt;false&lt;/TrustedService&gt;&lt;OriginalTemplateId&gt;00000000-0000-0000-0000-000000000000&lt;/OriginalTemplateId&gt;&lt;OriginalTemplateName&gt;Blank&lt;/OriginalTemplateName&gt;&lt;UseLatestVersion&gt;false&lt;/UseLatestVersion&gt;&lt;StopTime&gt;2019/12/02 11:25:50&lt;/StopTime&gt;&lt;BootTime&gt;2019/12/02 11:25:51&lt;/BootTime&gt;&lt;Downtime&gt;0&lt;/Downtime&gt;&lt;Section ovf:id="17a94da8-3d02-430e-9b83-5e39f92907e8" ovf:required="false" xsi:type="ovf:OperatingSystemSection_Type"&gt;&lt;Info&gt;Guest Operating System&lt;/Info&gt;&lt;Description&gt;rhel_7x64&lt;/Description&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:VirtualHardwareSection_Type"&gt;&lt;Info&gt;4 CPU, 3072 Memory&lt;/Info&gt;&lt;System&gt;&lt;vssd:VirtualSystemType&gt;ENGINE 4.1.0.0&lt;/vssd:VirtualSystemType&gt;&lt;/System&gt;&lt;Item&gt;&lt;rasd:Caption&gt;4 virtual cpu&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Number of virtual CPU&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;1&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;3&lt;/rasd:ResourceType&gt;&lt;rasd:num_of_sockets&gt;2&lt;/rasd:num_of_sockets&gt;&lt;rasd:cpu_per_socket&gt;2&lt;/rasd:cpu_per_socket&gt;&lt;rasd:threads_per_cpu&gt;1&lt;/rasd:threads_per_cpu&gt;&lt;rasd:max_num_of_vcpus&gt;32&lt;/rasd:max_num_of_vcpus&gt;&lt;rasd:VirtualQuantity&gt;4&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;3072 MB of memory&lt;/rasd:Caption&gt;&lt;rasd:Description&gt;Memory Size&lt;/rasd:Description&gt;&lt;rasd:InstanceId&gt;2&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;4&lt;/rasd:ResourceType&gt;&lt;rasd:AllocationUnits&gt;MegaBytes&lt;/rasd:AllocationUnits&gt;&lt;rasd:VirtualQuantity&gt;3072&lt;/rasd:VirtualQuantity&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;rhel7s_Disk1&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;17&lt;/rasd:ResourceType&gt;&lt;rasd:HostResource&gt;f6e4775b-53be-4136-9e30-f0be18b70668/13b96488-ccf7-4eb6-9e08-a0c2f195278a&lt;/rasd:HostResource&gt;&lt;rasd:Parent&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Parent&gt;&lt;rasd:Template&gt;00000000-0000-0000-0000-000000000000&lt;/rasd:Template&gt;&lt;rasd:ApplicationList&gt;&lt;/rasd:ApplicationList&gt;&lt;rasd:StorageId&gt;cfbc93a1-17b7-4d03-a8ca-3b3bfef52729&lt;/rasd:StorageId&gt;&lt;rasd:StoragePoolId&gt;e57249a3-d28a-455f-b30c-4ac0979f2ccc&lt;/rasd:StoragePoolId&gt;&lt;rasd:CreationDate&gt;2019/10/15 10:13:29&lt;/rasd:CreationDate&gt;&lt;rasd:LastModified&gt;1970/01/01 00:00:00&lt;/rasd:LastModified&gt;&lt;rasd:last_modified_date&gt;2019/12/02 11:26:44&lt;/rasd:last_modified_date&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;disk&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=0, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;1&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-f6e4775b-53be-4136-9e30-f0be18b70668&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Ethernet adapter on ovirtmgmt&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;93159b67-49fe-4add-8b31-91be915a208b&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;10&lt;/rasd:ResourceType&gt;&lt;rasd:OtherResourceType&gt;ovirtmgmt&lt;/rasd:OtherResourceType&gt;&lt;rasd:ResourceSubType&gt;3&lt;/rasd:ResourceSubType&gt;&lt;rasd:Connection&gt;ovirtmgmt&lt;/rasd:Connection&gt;&lt;rasd:Linked&gt;true&lt;/rasd:Linked&gt;&lt;rasd:Name&gt;nic1&lt;/rasd:Name&gt;&lt;rasd:ElementName&gt;nic1&lt;/rasd:ElementName&gt;&lt;rasd:MACAddress&gt;56:6f:85:ae:00:00&lt;/rasd:MACAddress&gt;&lt;rasd:speed&gt;10000&lt;/rasd:speed&gt;&lt;Type&gt;interface&lt;/Type&gt;&lt;Device&gt;bridge&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x03, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-93159b67-49fe-4add-8b31-91be915a208b&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;USB Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;3&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;23&lt;/rasd:ResourceType&gt;&lt;rasd:UsbPolicy&gt;DISABLED&lt;/rasd:UsbPolicy&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Controller&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;20&lt;/rasd:ResourceType&gt;&lt;rasd:VirtualQuantity&gt;1&lt;/rasd:VirtualQuantity&gt;&lt;rasd:SinglePciQxl&gt;false&lt;/rasd:SinglePciQxl&gt;&lt;Type&gt;video&lt;/Type&gt;&lt;Device&gt;qxl&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x02, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-6c4456ff-de70-4d01-9cf0-4b2e49bcfbbb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;vgamem&gt;16384&lt;/vgamem&gt;&lt;heads&gt;1&lt;/heads&gt;&lt;vram&gt;32768&lt;/vram&gt;&lt;ram&gt;65536&lt;/ram&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d835d395-f01c-4991-8643-b0578b2f3cf4&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;spice&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;Graphical Framebuffer&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;393b1788-8d19-4f18-ac73-9984db012e59&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;26&lt;/rasd:ResourceType&gt;&lt;Type&gt;graphics&lt;/Type&gt;&lt;Device&gt;vnc&lt;/Device&gt;&lt;rasd:Address&gt;&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:Caption&gt;CDROM&lt;/rasd:Caption&gt;&lt;rasd:InstanceId&gt;d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/rasd:InstanceId&gt;&lt;rasd:ResourceType&gt;15&lt;/rasd:ResourceType&gt;&lt;Type&gt;disk&lt;/Type&gt;&lt;Device&gt;cdrom&lt;/Device&gt;&lt;rasd:Address&gt;{type=drive, bus=1, controller=0, target=0, unit=0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;2&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-d20d147e-2ecd-4a04-a871-f9f1a2b8fc1e&lt;/Alias&gt;&lt;SpecParams&gt;&lt;path&gt;rhel-server-7.7-x86_64-dvd.iso&lt;/path&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;03b19568-7ba5-4db2-a014-e5584d18c54e&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel0&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;1dde7e51-d59d-4c42-adc0-2507abe70f52&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;unix&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel1&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;3eda54d6-728d-49fc-b1cb-3787cdd92a36&lt;/rasd:InstanceId&gt;&lt;Type&gt;channel&lt;/Type&gt;&lt;Device&gt;spicevmc&lt;/Device&gt;&lt;rasd:Address&gt;{type=virtio-serial, bus=0, controller=0, port=3}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;channel2&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;0e988f54-ff5e-4f78-953a-1dfe1e813bb7&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;ide&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x1}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ide&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-serial&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x05, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-865e6a0c-3c02-45ed-8fcb-a32f30054f7c&lt;/Alias&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;b8eed426-0eb3-4f95-9fb7-6c430490bf0e&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;usb&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x01, bus=0x00, domain=0x0000, function=0x2}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;usb&lt;/Alias&gt;&lt;SpecParams&gt;&lt;index&gt;0&lt;/index&gt;&lt;model&gt;piix3-uhci&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;d6183c89-27c8-4164-949f-052e9d7651b2&lt;/rasd:InstanceId&gt;&lt;Type&gt;controller&lt;/Type&gt;&lt;Device&gt;virtio-scsi&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x04, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-d6183c89-27c8-4164-949f-052e9d7651b2&lt;/Alias&gt;&lt;SpecParams&gt;&lt;ioThreadId&gt;&lt;/ioThreadId&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/rasd:InstanceId&gt;&lt;Type&gt;rng&lt;/Type&gt;&lt;Device&gt;virtio&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x07, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;false&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-51c228ae-420a-4679-a6e8-e9bbec1a306a&lt;/Alias&gt;&lt;SpecParams&gt;&lt;source&gt;urandom&lt;/source&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;Item&gt;&lt;rasd:ResourceType&gt;0&lt;/rasd:ResourceType&gt;&lt;rasd:InstanceId&gt;78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/rasd:InstanceId&gt;&lt;Type&gt;balloon&lt;/Type&gt;&lt;Device&gt;memballoon&lt;/Device&gt;&lt;rasd:Address&gt;{type=pci, slot=0x06, bus=0x00, domain=0x0000, function=0x0}&lt;/rasd:Address&gt;&lt;BootOrder&gt;0&lt;/BootOrder&gt;&lt;IsPlugged&gt;true&lt;/IsPlugged&gt;&lt;IsReadOnly&gt;true&lt;/IsReadOnly&gt;&lt;Alias&gt;ua-78ed53ab-c591-4ec9-950a-50a05c418d9b&lt;/Alias&gt;&lt;SpecParams&gt;&lt;model&gt;virtio&lt;/model&gt;&lt;/SpecParams&gt;&lt;/Item&gt;&lt;/Section&gt;&lt;Section xsi:type="ovf:SnapshotsSection_Type"&gt;&lt;Snapshot ovf:id="fc282c90-ded5-456b-ab99-2d2fe6abc262"&gt;&lt;Type&gt;ACTIVE&lt;/Type&gt;&lt;Description&gt;Active VM&lt;/Description&gt;&lt;CreationDate&gt;2019/10/15 10:12:12&lt;/CreationDate&gt;&lt;/Snapshot&gt;&lt;Snapshot ovf:id="d8afa763-8249-4473-9558-e5431cb76e8e"&gt;&lt;Type&gt;NEXT_RUN&lt;/Type&gt;&lt;Description&gt;Next Run configuration snapshot&lt;/Description&gt;&lt;CreationDate&gt;2019/12/02 11:26:44&lt;/CreationDate&gt;&lt;VmConfiguration&gt;PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48b3ZmOkVudmVsb3BlIHhtbG5zOm92Zj0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEvIiB4bWxuczpyYXNkPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy93YmVtL3dzY2ltLzEvY2ltLXNjaGVtYS8yL0NJTV9SZXNvdXJjZUFsbG9jYXRpb25TZXR0aW5nRGF0YSIgeG1sbnM6dnNzZD0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fVmlydHVhbFN5c3RlbVNldHRpbmdEYXRhIiB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiBvdmY6dmVyc2lvbj0iNC4xLjAuMCI+PFJlZmVyZW5jZXM+PC9SZWZlcmVuY2VzPjxOZXR3b3JrU2VjdGlvbj48SW5mbz5MaXN0IG9mIG5ldHdvcmtzPC9JbmZvPjxOZXR3b3JrIG92ZjpuYW1lPSJvdmlydG1nbXQiPjwvTmV0d29yaz48L05ldHdvcmtTZWN0aW9uPjxTZWN0aW9uIHhzaTp0eXBlPSJvdmY6RGlza1NlY3Rpb25fVHlwZSI+PEluZm8+TGlzdCBvZiBWaXJ0dWFsIERpc2tzPC9JbmZvPjwvU2VjdGlvbj48Q29udGVudCBvdmY6aWQ9Im91dCIgeHNpOnR5cGU9Im92ZjpWaXJ0dWFsU3lzdGVtX1R5cGUiPjxOYW1lPnJoZWw3czwvTmFtZT48RGVzY3JpcHRpb24+PC9EZXNjcmlwdGlvbj48Q29tbWVudD48L0NvbW1lbnQ+PENyZWF0aW9uRGF0ZT4yMDE5LzEwLzE1IDEwOjEyOjEyPC9DcmVhdGlvbkRhdGU+PEV4cG9ydERhdGU+MjAxOS8xMi8wMiAxMToyNjo0NDwvRXhwb3J0RGF0ZT48RGVsZXRlUHJvdGVjdGVkPmZhbHNlPC9EZWxldGVQcm90ZWN0ZWQ+PFNzb01ldGhvZD5ndWVzdF9hZ2VudDwvU3NvTWV0aG9kPjxJc1NtYXJ0Y2FyZEVuYWJsZWQ+ZmFsc2U8L0lzU21hcnRjYXJkRW5hYmxlZD48TnVtT2ZJb1RocmVhZHM+MTwvTnVtT2ZJb1RocmVhZHM+PFRpbWVab25lPkV1cm9wZS9XYXJzYXc8L1RpbWVab25lPjxkZWZhdWx0X2Jvb3Rfc2VxdWVuY2U+OTwvZGVmYXVsdF9ib290X3NlcXVlbmNlPjxHZW5lcmF0aW9uPjg4MzwvR2VuZXJhdGlvbj48Q2x1c3RlckNvbXBhdGliaWxpdHlWZXJzaW9uPjQuMzwvQ2x1c3RlckNvbXBhdGliaWxpdHlWZXJzaW9uPjxWbVR5cGU+MTwvVm1UeXBlPjxSZXN1bWVCZWhhdmlvcj5BVVRPX1JFU1VNRTwvUmVzdW1lQmVoYXZpb3I+PE1pbkFsbG9jYXRlZE1lbT4zMDcyPC9NaW5BbGxvY2F0ZWRNZW0+PElzU3RhdGVsZXNzPmZhbHNlPC9Jc1N0YXRlbGVzcz48SXNSdW5BbmRQYXVzZT5mYWxzZTwvSXNSdW5BbmRQYXVzZT48QXV0b1N0YXJ0dXA+ZmFsc2U8L0F1dG9TdGFydHVwPjxQcmlvcml0eT4xPC9Qcmlvcml0eT48Q3JlYXRlZEJ5VXNlcklkPjI1MWEyYWVlLWVlOWItMTFlOS1hNmJlLTUyNTQwMDVhMzIzOTwvQ3JlYXRlZEJ5VXNlcklkPjxWbUluaXQgb3ZmOmF1dGhvcml6ZWRLZXlzPSIiIG92ZjpyZWdlbmVyYXRlS2V5cz0iZmFsc2UiIG92ZjpuZXR3b3Jrcz0iWyBdIiBvdmY6Y3VzdG9tU2NyaXB0PSIiPjwvVm1Jbml0PjxNaWdyYXRpb25TdXBwb3J0PjA8L01pZ3JhdGlvblN1cHBvcnQ+PElzQm9vdE1lbnVFbmFibGVkPmZhbHNlPC9Jc0Jvb3RNZW51RW5hYmxlZD48SXNTcGljZUZpbGVUcmFuc2ZlckVuYWJsZWQ+dHJ1ZTwvSXNTcGljZUZpbGVUcmFuc2ZlckVuYWJsZWQ+PElzU3BpY2VDb3B5UGFzdGVFbmFibGVkPnRydWU8L0lzU3BpY2VDb3B5UGFzdGVFbmFibGVkPjxBbGxvd0NvbnNvbGVSZWNvbm5lY3Q+dHJ1ZTwvQWxsb3dDb25zb2xlUmVjb25uZWN0PjxDb25zb2xlRGlzY29ubmVjdEFjdGlvbj5MT0NLX1NDUkVFTjwvQ29uc29sZURpc2Nvbm5lY3RBY3Rpb24+PEN1c3RvbUVtdWxhdGVkTWFjaGluZT48L0N1c3RvbUVtdWxhdGVkTWFjaGluZT48Qmlvc1R5cGU+MDwvQmlvc1R5cGU+PEN1c3RvbUNwdU5hbWU+PC9DdXN0b21DcHVOYW1lPjxQcmVkZWZpbmVkUHJvcGVydGllcz48L1ByZWRlZmluZWRQcm9wZXJ0aWVzPjxVc2VyRGVmaW5lZFByb3BlcnRpZXM+PC9Vc2VyRGVmaW5lZFByb3BlcnRpZXM+PE1heE1lbW9yeVNpemVNYj40MDk2PC9NYXhNZW1vcnlTaXplTWI+PE11bHRpUXVldWVzRW5hYmxlZD50cnVlPC9NdWx0aVF1ZXVlc0VuYWJsZWQ+PFVzZUhvc3RDcHU+ZmFsc2U8L1VzZUhvc3RDcHU+PENsdXN0ZXJOYW1lPjwvQ2x1c3Rlck5hbWU+PFRlbXBsYXRlSWQ+MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwPC9UZW1wbGF0ZUlkPjxUZW1wbGF0ZU5hbWU+Qmxhbms8L1RlbXBsYXRlTmFtZT48SXNJbml0aWxpemVkPnRydWU8L0lzSW5pdGlsaXplZD48T3JpZ2luPjA8L09yaWdpbj48cXVvdGFfaWQ+NWZhMzM3YzItOWViNC00ZDgzLTlkNmEtNzM5Y2Y4OGEyMzEyPC9xdW90YV9pZD48RGVmYXVsdERpc3BsYXlUeXBlPjE8L0RlZmF1bHREaXNwbGF5VHlwZT48VHJ1c3RlZFNlcnZpY2U+ZmFsc2U8L1RydXN0ZWRTZXJ2aWNlPjxPcmlnaW5hbFRlbXBsYXRlSWQ+MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwPC9PcmlnaW5hbFRlbXBsYXRlSWQ+PE9yaWdpbmFsVGVtcGxhdGVOYW1lPkJsYW5rPC9PcmlnaW5hbFRlbXBsYXRlTmFtZT48VXNlTGF0ZXN0VmVyc2lvbj5mYWxzZTwvVXNlTGF0ZXN0VmVyc2lvbj48U2VjdGlvbiBvdmY6aWQ9IjE3YTk0ZGE4LTNkMDItNDMwZS05YjgzLTVlMzlmOTI5MDdlOCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSIgeHNpOnR5cGU9Im92ZjpPcGVyYXRpbmdTeXN0ZW1TZWN0aW9uX1R5cGUiPjxJbmZvPkd1ZXN0IE9wZXJhdGluZyBTeXN0ZW08L0luZm8+PERlc2NyaXB0aW9uPnJoZWxfN3g2NDwvRGVzY3JpcHRpb24+PC9TZWN0aW9uPjxTZWN0aW9uIHhzaTp0eXBlPSJvdmY6VmlydHVhbEhhcmR3YXJlU2VjdGlvbl9UeXBlIj48SW5mbz4yIENQVSwgMzA3MiBNZW1vcnk8L0luZm8+PFN5c3RlbT48dnNzZDpWaXJ0dWFsU3lzdGVtVHlwZT5FTkdJTkUgNC4xLjAuMDwvdnNzZDpWaXJ0dWFsU3lzdGVtVHlwZT48L1N5c3RlbT48SXRlbT48cmFzZDpDYXB0aW9uPjIgdmlydHVhbCBjcHU8L3Jhc2Q6Q2FwdGlvbj48cmFzZDpEZXNjcmlwdGlvbj5OdW1iZXIgb2YgdmlydHVhbCBDUFU8L3Jhc2Q6RGVzY3JpcHRpb24+PHJhc2Q6SW5zdGFuY2VJZD4xPC9yYXNkOkluc3RhbmNlSWQ+PHJhc2Q6UmVzb3VyY2VUeXBlPjM8L3Jhc2Q6UmVzb3VyY2VUeXBlPjxyYXNkOm51bV9vZl9zb2NrZXRzPjI8L3Jhc2Q6bnVtX29mX3NvY2tldHM+PHJhc2Q6Y3B1X3Blcl9zb2NrZXQ+MTwvcmFzZDpjcHVfcGVyX3NvY2tldD48cmFzZDp0aHJlYWRzX3Blcl9jcHU+MTwvcmFzZDp0aHJlYWRzX3Blcl9jcHU+PHJhc2Q6bWF4X251bV9vZl92Y3B1cz4xNjwvcmFzZDptYXhfbnVtX29mX3ZjcHVzPjxyYXNkOlZpcnR1YWxRdWFudGl0eT4yPC9yYXNkOlZpcnR1YWxRdWFudGl0eT48L0l0ZW0+PEl0ZW0+PHJhc2Q6Q2FwdGlvbj4zMDcyIE1CIG9mIG1lbW9yeTwvcmFzZDpDYXB0aW9uPjxyYXNkOkRlc2NyaXB0aW9uPk1lbW9yeSBTaXplPC9yYXNkOkRlc2NyaXB0aW9uPjxyYXNkOkluc3RhbmNlSWQ+MjwvcmFzZDpJbnN0YW5jZUlkPjxyYXNkOlJlc291cmNlVHlwZT40PC9yYXNkOlJlc291cmNlVHlwZT48cmFzZDpBbGxvY2F0aW9uVW5pdHM+TWVnYUJ5dGVzPC9yYXNkOkFsbG9jYXRpb25Vbml0cz48cmFzZDpWaXJ0dWFsUXVhbnRpdHk+MzA3MjwvcmFzZDpWaXJ0dWFsUXVhbnRpdHk+PC9JdGVtPjxJdGVtPjxyYXNkOkNhcHRpb24+RXRoZXJuZXQgYWRhcHRlciBvbiBvdmlydG1nbXQ8L3Jhc2Q6Q2FwdGlvbj48cmFzZDpJbnN0YW5jZUlkPjkzMTU5YjY3LTQ5ZmUtNGFkZC04YjMxLTkxYmU5MTVhMjA4YjwvcmFzZDpJbnN0YW5jZUlkPjxyYXNkOlJlc291cmNlVHlwZT4xMDwvcmFzZDpSZXNvdXJjZVR5cGU+PHJhc2Q6T3RoZXJSZXNvdXJjZVR5cGU+b3ZpcnRtZ210PC9yYXNkOk90aGVyUmVzb3VyY2VUeXBlPjxyYXNkOlJlc291cmNlU3ViVHlwZT4zPC9yYXNkOlJlc291cmNlU3ViVHlwZT48cmFzZDpDb25uZWN0aW9uPm92aXJ0bWdtdDwvcmFzZDpDb25uZWN0aW9uPjxyYXNkOkxpbmtlZD50cnVlPC9yYXNkOkxpbmtlZD48cmFzZDpOYW1lPm5pYzE8L3Jhc2Q6TmFtZT48cmFzZDpFbGVtZW50TmFtZT5uaWMxPC9yYXNkOkVsZW1lbnROYW1lPjxyYXNkOk1BQ0FkZHJlc3M+NTY6NmY6ODU6YWU6MDA6MDA8L3Jhc2Q6TUFDQWRkcmVzcz48cmFzZDpzcGVlZD4xMDAwMDwvcmFzZDpzcGVlZD48VHlwZT5pbnRlcmZhY2U8L1R5cGU+PERldmljZT5icmlkZ2U8L0RldmljZT48cmFzZDpBZGRyZXNzPnt0eXBlPXBjaSwgc2xvdD0weDAzLCBidXM9MHgwMCwgZG9tYWluPTB4MDAwMCwgZnVuY3Rpb249MHgwfTwvcmFzZDpBZGRyZXNzPjxCb290T3JkZXI+MDwvQm9vdE9yZGVyPjxJc1BsdWdnZWQ+dHJ1ZTwvSXNQbHVnZ2VkPjxJc1JlYWRPbmx5PmZhbHNlPC9Jc1JlYWRPbmx5PjxBbGlhcz51YS05MzE1OWI2Ny00OWZlLTRhZGQtOGIzMS05MWJlOTE1YTIwOGI8L0FsaWFzPjwvSXRlbT48SXRlbT48cmFzZDpDYXB0aW9uPlVTQiBDb250cm9sbGVyPC9yYXNkOkNhcHRpb24+PHJhc2Q6SW5zdGFuY2VJZD4zPC9yYXNkOkluc3RhbmNlSWQ+PHJhc2Q6UmVzb3VyY2VUeXBlPjIzPC9yYXNkOlJlc291cmNlVHlwZT48cmFzZDpVc2JQb2xpY3k+RElTQUJMRUQ8L3Jhc2Q6VXNiUG9saWN5PjwvSXRlbT48SXRlbT48cmFzZDpDYXB0aW9uPkdyYXBoaWNhbCBDb250cm9sbGVyPC9yYXNkOkNhcHRpb24+PHJhc2Q6SW5zdGFuY2VJZD42YzQ0NTZmZi1kZTcwLTRkMDEtOWNmMC00YjJlNDliY2ZiYmI8L3Jhc2Q6SW5zdGFuY2VJZD48cmFzZDpSZXNvdXJjZVR5cGU+MjA8L3Jhc2Q6UmVzb3VyY2VUeXBlPjxyYXNkOlZpcnR1YWxRdWFudGl0eT4xPC9yYXNkOlZpcnR1YWxRdWFudGl0eT48cmFzZDpTaW5nbGVQY2lReGw+ZmFsc2U8L3Jhc2Q6U2luZ2xlUGNpUXhsPjxUeXBlPnZpZGVvPC9UeXBlPjxEZXZpY2U+cXhsPC9EZXZpY2U+PHJhc2Q6QWRkcmVzcz57dHlwZT1wY2ksIHNsb3Q9MHgwMiwgYnVzPTB4MDAsIGRvbWFpbj0weDAwMDAsIGZ1bmN0aW9uPTB4MH08L3Jhc2Q6QWRkcmVzcz48Qm9vdE9yZGVyPjA8L0Jvb3RPcmRlcj48SXNQbHVnZ2VkPnRydWU8L0lzUGx1Z2dlZD48SXNSZWFkT25seT5mYWxzZTwvSXNSZWFkT25seT48QWxpYXM+dWEtNmM0NDU2ZmYtZGU3MC00ZDAxLTljZjAtNGIyZTQ5YmNmYmJiPC9BbGlhcz48U3BlY1BhcmFtcz48dmdhbWVtPjE2Mzg0PC92Z2FtZW0+PGhlYWRzPjE8L2hlYWRzPjx2cmFtPjMyNzY4PC92cmFtPjxyYW0+NjU1MzY8L3JhbT48L1NwZWNQYXJhbXM+PC9JdGVtPjxJdGVtPjxyYXNkOkNhcHRpb24+R3JhcGhpY2FsIEZyYW1lYnVmZmVyPC9yYXNkOkNhcHRpb24+PHJhc2Q6SW5zdGFuY2VJZD5kODM1ZDM5NS1mMDFjLTQ5OTEtODY0My1iMDU3OGIyZjNjZjQ8L3Jhc2Q6SW5zdGFuY2VJZD48cmFzZDpSZXNvdXJjZVR5cGU+MjY8L3Jhc2Q6UmVzb3VyY2VUeXBlPjxUeXBlPmdyYXBoaWNzPC9UeXBlPjxEZXZpY2U+c3BpY2U8L0RldmljZT48cmFzZDpBZGRyZXNzPjwvcmFzZDpBZGRyZXNzPjxCb290T3JkZXI+MDwvQm9vdE9yZGVyPjxJc1BsdWdnZWQ+dHJ1ZTwvSXNQbHVnZ2VkPjxJc1JlYWRPbmx5PmZhbHNlPC9Jc1JlYWRPbmx5PjxBbGlhcz48L0FsaWFzPjwvSXRlbT48SXRlbT48cmFzZDpDYXB0aW9uPkdyYXBoaWNhbCBGcmFtZWJ1ZmZlcjwvcmFzZDpDYXB0aW9uPjxyYXNkOkluc3RhbmNlSWQ+MzkzYjE3ODgtOGQxOS00ZjE4LWFjNzMtOTk4NGRiMDEyZTU5PC9yYXNkOkluc3RhbmNlSWQ+PHJhc2Q6UmVzb3VyY2VUeXBlPjI2PC9yYXNkOlJlc291cmNlVHlwZT48VHlwZT5ncmFwaGljczwvVHlwZT48RGV2aWNlPnZuYzwvRGV2aWNlPjxyYXNkOkFkZHJlc3M+PC9yYXNkOkFkZHJlc3M+PEJvb3RPcmRlcj4wPC9Cb290T3JkZXI+PElzUGx1Z2dlZD50cnVlPC9Jc1BsdWdnZWQ+PElzUmVhZE9ubHk+ZmFsc2U8L0lzUmVhZE9ubHk+PEFsaWFzPjwvQWxpYXM+PC9JdGVtPjxJdGVtPjxyYXNkOkNhcHRpb24+Q0RST008L3Jhc2Q6Q2FwdGlvbj48cmFzZDpJbnN0YW5jZUlkPmQyMGQxNDdlLTJlY2QtNGEwNC1hODcxLWY5ZjFhMmI4ZmMxZTwvcmFzZDpJbnN0YW5jZUlkPjxyYXNkOlJlc291cmNlVHlwZT4xNTwvcmFzZDpSZXNvdXJjZVR5cGU+PFR5cGU+ZGlzazwvVHlwZT48RGV2aWNlPmNkcm9tPC9EZXZpY2U+PHJhc2Q6QWRkcmVzcz57dHlwZT1kcml2ZSwgYnVzPTEsIGNvbnRyb2xsZXI9MCwgdGFyZ2V0PTAsIHVuaXQ9MH08L3Jhc2Q6QWRkcmVzcz48Qm9vdE9yZGVyPjI8L0Jvb3RPcmRlcj48SXNQbHVnZ2VkPnRydWU8L0lzUGx1Z2dlZD48SXNSZWFkT25seT50cnVlPC9Jc1JlYWRPbmx5PjxBbGlhcz51YS1kMjBkMTQ3ZS0yZWNkLTRhMDQtYTg3MS1mOWYxYTJiOGZjMWU8L0FsaWFzPjxTcGVjUGFyYW1zPjxwYXRoPnJoZWwtc2VydmVyLTcuNy14ODZfNjQtZHZkLmlzbzwvcGF0aD48L1NwZWNQYXJhbXM+PC9JdGVtPjxJdGVtPjxyYXNkOlJlc291cmNlVHlwZT4wPC9yYXNkOlJlc291cmNlVHlwZT48cmFzZDpJbnN0YW5jZUlkPjg2NWU2YTBjLTNjMDItNDVlZC04ZmNiLWEzMmYzMDA1NGY3YzwvcmFzZDpJbnN0YW5jZUlkPjxUeXBlPmNvbnRyb2xsZXI8L1R5cGU+PERldmljZT52aXJ0aW8tc2VyaWFsPC9EZXZpY2U+PHJhc2Q6QWRkcmVzcz57dHlwZT1wY2ksIHNsb3Q9MHgwNSwgYnVzPTB4MDAsIGRvbWFpbj0weDAwMDAsIGZ1bmN0aW9uPTB4MH08L3Jhc2Q6QWRkcmVzcz48Qm9vdE9yZGVyPjA8L0Jvb3RPcmRlcj48SXNQbHVnZ2VkPnRydWU8L0lzUGx1Z2dlZD48SXNSZWFkT25seT5mYWxzZTwvSXNSZWFkT25seT48QWxpYXM+dWEtODY1ZTZhMGMtM2MwMi00NWVkLThmY2ItYTMyZjMwMDU0ZjdjPC9BbGlhcz48L0l0ZW0+PEl0ZW0+PHJhc2Q6UmVzb3VyY2VUeXBlPjA8L3Jhc2Q6UmVzb3VyY2VUeXBlPjxyYXNkOkluc3RhbmNlSWQ+YjhlZWQ0MjYtMGViMy00Zjk1LTlmYjctNmM0MzA0OTBiZjBlPC9yYXNkOkluc3RhbmNlSWQ+PFR5cGU+Y29udHJvbGxlcjwvVHlwZT48RGV2aWNlPnVzYjwvRGV2aWNlPjxyYXNkOkFkZHJlc3M+e3R5cGU9cGNpLCBzbG90PTB4MDEsIGJ1cz0weDAwLCBkb21haW49MHgwMDAwLCBmdW5jdGlvbj0weDJ9PC9yYXNkOkFkZHJlc3M+PEJvb3RPcmRlcj4wPC9Cb290T3JkZXI+PElzUGx1Z2dlZD50cnVlPC9Jc1BsdWdnZWQ+PElzUmVhZE9ubHk+ZmFsc2U8L0lzUmVhZE9ubHk+PEFsaWFzPnVzYjwvQWxpYXM+PFNwZWNQYXJhbXM+PGluZGV4PjA8L2luZGV4Pjxtb2RlbD5waWl4My11aGNpPC9tb2RlbD48L1NwZWNQYXJhbXM+PC9JdGVtPjxJdGVtPjxyYXNkOlJlc291cmNlVHlwZT4wPC9yYXNkOlJlc291cmNlVHlwZT48cmFzZDpJbnN0YW5jZUlkPmQ2MTgzYzg5LTI3YzgtNDE2NC05NDlmLTA1MmU5ZDc2NTFiMjwvcmFzZDpJbnN0YW5jZUlkPjxUeXBlPmNvbnRyb2xsZXI8L1R5cGU+PERldmljZT52aXJ0aW8tc2NzaTwvRGV2aWNlPjxyYXNkOkFkZHJlc3M+e3R5cGU9cGNpLCBzbG90PTB4MDQsIGJ1cz0weDAwLCBkb21haW49MHgwMDAwLCBmdW5jdGlvbj0weDB9PC9yYXNkOkFkZHJlc3M+PEJvb3RPcmRlcj4wPC9Cb290T3JkZXI+PElzUGx1Z2dlZD50cnVlPC9Jc1BsdWdnZWQ+PElzUmVhZE9ubHk+ZmFsc2U8L0lzUmVhZE9ubHk+PEFsaWFzPnVhLWQ2MTgzYzg5LTI3YzgtNDE2NC05NDlmLTA1MmU5ZDc2NTFiMjwvQWxpYXM+PFNwZWNQYXJhbXM+PGlvVGhyZWFkSWQ+PC9pb1RocmVhZElkPjwvU3BlY1BhcmFtcz48L0l0ZW0+PEl0ZW0+PHJhc2Q6UmVzb3VyY2VUeXBlPjA8L3Jhc2Q6UmVzb3VyY2VUeXBlPjxyYXNkOkluc3RhbmNlSWQ+NTFjMjI4YWUtNDIwYS00Njc5LWE2ZTgtZTliYmVjMWEzMDZhPC9yYXNkOkluc3RhbmNlSWQ+PFR5cGU+cm5nPC9UeXBlPjxEZXZpY2U+dmlydGlvPC9EZXZpY2U+PHJhc2Q6QWRkcmVzcz57dHlwZT1wY2ksIHNsb3Q9MHgwNywgYnVzPTB4MDAsIGRvbWFpbj0weDAwMDAsIGZ1bmN0aW9uPTB4MH08L3Jhc2Q6QWRkcmVzcz48Qm9vdE9yZGVyPjA8L0Jvb3RPcmRlcj48SXNQbHVnZ2VkPnRydWU8L0lzUGx1Z2dlZD48SXNSZWFkT25seT5mYWxzZTwvSXNSZWFkT25seT48QWxpYXM+dWEtNTFjMjI4YWUtNDIwYS00Njc5LWE2ZTgtZTliYmVjMWEzMDZhPC9BbGlhcz48U3BlY1BhcmFtcz48c291cmNlPnVyYW5kb208L3NvdXJjZT48L1NwZWNQYXJhbXM+PC9JdGVtPjxJdGVtPjxyYXNkOlJlc291cmNlVHlwZT4wPC9yYXNkOlJlc291cmNlVHlwZT48cmFzZDpJbnN0YW5jZUlkPjc4ZWQ1M2FiLWM1OTEtNGVjOS05NTBhLTUwYTA1YzQxOGQ5YjwvcmFzZDpJbnN0YW5jZUlkPjxUeXBlPmJhbGxvb248L1R5cGU+PERldmljZT5tZW1iYWxsb29uPC9EZXZpY2U+PHJhc2Q6QWRkcmVzcz57dHlwZT1wY2ksIHNsb3Q9MHgwNiwgYnVzPTB4MDAsIGRvbWFpbj0weDAwMDAsIGZ1bmN0aW9uPTB4MH08L3Jhc2Q6QWRkcmVzcz48Qm9vdE9yZGVyPjA8L0Jvb3RPcmRlcj48SXNQbHVnZ2VkPnRydWU8L0lzUGx1Z2dlZD48SXNSZWFkT25seT50cnVlPC9Jc1JlYWRPbmx5PjxBbGlhcz51YS03OGVkNTNhYi1jNTkxLTRlYzktOTUwYS01MGEwNWM0MThkOWI8L0FsaWFzPjxTcGVjUGFyYW1zPjxtb2RlbD52aXJ0aW88L21vZGVsPjwvU3BlY1BhcmFtcz48L0l0ZW0+PC9TZWN0aW9uPjwvQ29udGVudD48L292ZjpFbnZlbG9wZT4=&lt;/VmConfiguration&gt;&lt;/Snapshot&gt;&lt;/Section&gt;&lt;/Content&gt;&lt;/ovf:Envelope&gt;</data>
-                  <type>ovf</type>
-              </configuration>
-              <custom_script></custom_script>
-              <nic_configurations/>
-              <regenerate_ssh_keys>false</regenerate_ssh_keys>
-          </initialization>
-          <io>
-              <threads>1</threads>
-          </io>
-          <large_icon href="/ovirt-engine/api/icons/286c4070-4374-12d6-af2d-ab35a7395e5f" id="286c4070-4374-12d6-af2d-ab35a7395e5f"/>
-          <memory>3221225472</memory>
-          <memory_policy>
-              <ballooning>true</ballooning>
-              <guaranteed>3221225472</guaranteed>
-              <max>4294967296</max>
-          </memory_policy>
-          <migration>
-              <auto_converge>inherit</auto_converge>
-              <compressed>inherit</compressed>
-          </migration>
-          <migration_downtime>-1</migration_downtime>
-          <multi_queues_enabled>true</multi_queues_enabled>
-          <origin>rhev</origin>
-          <os>
-              <boot>
-                  <devices>
-                      <device>hd</device>
-                      <device>cdrom</device>
-                  </devices>
-              </boot>
-              <type>rhel_7x64</type>
-          </os>
-          <placement_policy>
-              <affinity>migratable</affinity>
-          </placement_policy>
-          <rng_device>
-              <source>urandom</source>
-          </rng_device>
-          <small_icon href="/ovirt-engine/api/icons/a029b4bf-5437-dae6-0cdf-3c9fb623cf1d" id="a029b4bf-5437-dae6-0cdf-3c9fb623cf1d"/>
-          <soundcard_enabled>false</soundcard_enabled>
-          <sso>
-              <methods>
-                  <method id="guest_agent"/>
-              </methods>
-          </sso>
-          <start_paused>false</start_paused>
-          <stateless>false</stateless>
-          <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
-          <time_zone>
-              <name>Europe/Warsaw</name>
-          </time_zone>
-          <type>server</type>
-          <usb>
-              <enabled>false</enabled>
-          </usb>
-          <virtio_scsi>
-              <enabled>true</enabled>
-          </virtio_scsi>
-          <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde"/>
-          <cpu_profile href="/ovirt-engine/api/cpuprofiles/c5926295-65ef-4dba-b234-26db503cb59d" id="c5926295-65ef-4dba-b234-26db503cb59d"/>
-          <quota id="5fa337c2-9eb4-4d83-9d6a-739cf88a2312"/>
-          <fqdn>rhels</fqdn>
-          <guest_operating_system>
-              <architecture>x86_64</architecture>
-              <codename>Server</codename>
-              <distribution>Red Hat Enterprise Linux Server</distribution>
-              <family>Linux</family>
-              <kernel>
-                  <version>
-                      <build>0</build>
-                      <full_version>3.10.0-1062.el7.x86_64</full_version>
-                      <major>3</major>
-                      <minor>10</minor>
-                      <revision>1062</revision>
-                  </version>
-              </kernel>
-              <version>
-                  <full_version>7.7</full_version>
-                  <major>7</major>
-                  <minor>7</minor>
-              </version>
-          </guest_operating_system>
-          <guest_time_zone>
-              <name>EST</name>
-              <utc_offset>-05:00</utc_offset>
-          </guest_time_zone>
-          <next_run_configuration_exists>true</next_run_configuration_exists>
-          <numa_tune_mode>interleave</numa_tune_mode>
-          <run_once>false</run_once>
-          <start_time>2019-12-02T12:25:51.513+01:00</start_time>
-          <status>up</status>
-          <stop_time>2019-12-02T12:25:50.959+01:00</stop_time>
-          <host href="/ovirt-engine/api/hosts/72bce52e-c060-4907-a459-f5cfea517b30" id="72bce52e-c060-4907-a459-f5cfea517b30"/>
-          <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
-          <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
-      </vm>
-    :code: 200
-    :headers:
-      date: Mon, 02 Dec 2019 11:26:44 GMT
-      server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
-      content-encoding: gzip
-      content-type: application/xml;charset=UTF-8
-      content-length: '11147'
-      correlation-id: 140de47e-7c33-48d8-b251-424f418e0f4a
-    :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239{}GET:
 - :body: |
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <cluster href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239" id="112b9702-ee9b-11e9-9d7c-5254005a3239">
         <actions>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/upgrade" rel="upgrade"/>
-            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
             <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/syncallnetworks" rel="syncallnetworks"/>
+            <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/resetemulatedmachine" rel="resetemulatedmachine"/>
         </actions>
         <name>Default</name>
         <description>The default server cluster</description>
         <comment></comment>
-        <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networkfilters" rel="networkfilters"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/networks" rel="networks"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/cpuprofiles" rel="cpuprofiles"/>
-        <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
+        <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/affinitygroups" rel="affinitygroups"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glusterhooks" rel="glusterhooks"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/glustervolumes" rel="glustervolumes"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/enabledfeatures" rel="enabledfeatures"/>
         <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/externalnetworkproviders" rel="externalnetworkproviders"/>
+        <link href="/ovirt-engine/api/clusters/112b9702-ee9b-11e9-9d7c-5254005a3239/permissions" rel="permissions"/>
         <ballooning_enabled>false</ballooning_enabled>
         <cpu>
             <architecture>x86_64</architecture>
@@ -3364,12 +4726,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/112b9702-ee9b
     </cluster>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
     content-length: '1205'
-    correlation-id: 10d4d61b-ae50-4057-b807-e3f094c235ea
+    correlation-id: d1bc8643-08f8-472f-98ed-233cef73cc33
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde{}GET:
 - :body: |
@@ -3377,21 +4739,21 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/adf7976e-d94b
     <cluster href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde" id="adf7976e-d94b-4403-af00-85617634cdde">
         <actions>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/upgrade" rel="upgrade"/>
-            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
             <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/syncallnetworks" rel="syncallnetworks"/>
+            <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/resetemulatedmachine" rel="resetemulatedmachine"/>
         </actions>
         <name>depot_cl</name>
         <description></description>
         <comment></comment>
-        <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networkfilters" rel="networkfilters"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/networks" rel="networks"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/cpuprofiles" rel="cpuprofiles"/>
-        <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
+        <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/affinitygroups" rel="affinitygroups"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glusterhooks" rel="glusterhooks"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/glustervolumes" rel="glustervolumes"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/enabledfeatures" rel="enabledfeatures"/>
         <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/externalnetworkproviders" rel="externalnetworkproviders"/>
+        <link href="/ovirt-engine/api/clusters/adf7976e-d94b-4403-af00-85617634cdde/permissions" rel="permissions"/>
         <ballooning_enabled>false</ballooning_enabled>
         <cpu>
             <architecture>x86_64</architecture>
@@ -3465,12 +4827,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters/adf7976e-d94b
     </cluster>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '1236'
-    correlation-id: 59c0ba42-9234-426d-9bb5-3ed02dcac362
+    content-length: '1235'
+    correlation-id: 68d885a5-0ca2-4a3a-b10b-876bdf8f1a57
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc{}GET:
 - :body: |
@@ -3478,12 +4840,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
     <data_center href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc" id="e57249a3-d28a-455f-b30c-4ac0979f2ccc">
         <name>depot_dc</name>
         <description>Datacenter on depot machine</description>
-        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/networks" rel="networks"/>
-        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas" rel="quotas"/>
-        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/qoss" rel="qoss"/>
         <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/iscsibonds" rel="iscsibonds"/>
-        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/clusters" rel="clusters"/>
+        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/quotas" rel="quotas"/>
+        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/networks" rel="networks"/>
         <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/storagedomains" rel="storagedomains"/>
+        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/clusters" rel="clusters"/>
+        <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/qoss" rel="qoss"/>
         <link href="/ovirt-engine/api/datacenters/e57249a3-d28a-455f-b30c-4ac0979f2ccc/permissions" rel="permissions"/>
         <local>false</local>
         <quota_mode>disabled</quota_mode>
@@ -3503,12 +4865,12 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/e57249a3-d
     </data_center>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '447'
-    correlation-id: ec1e80ee-7bd9-4510-84c9-8dc95b005875
+    content-length: '448'
+    correlation-id: 10a3d48e-c53a-4524-8393-3dde2dfe512d
   :message: 
 https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729{}GET:
 - :body: |
@@ -3523,17 +4885,17 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a
         <name>depot_one</name>
         <description></description>
         <comment></comment>
-        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disksnapshots" rel="disksnapshots"/>
-        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/templates" rel="templates"/>
-        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/vms" rel="vms"/>
-        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
         <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/diskprofiles" rel="diskprofiles"/>
+        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disks" rel="disks"/>
         <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/storageconnections" rel="storageconnections"/>
         <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/permissions" rel="permissions"/>
-        <available>517543559168</available>
+        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/templates" rel="templates"/>
+        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/vms" rel="vms"/>
+        <link href="/ovirt-engine/api/storagedomains/cfbc93a1-17b7-4d03-a8ca-3b3bfef52729/disksnapshots" rel="disksnapshots"/>
+        <available>515396075520</available>
         <backup>false</backup>
         <block_size>512</block_size>
-        <committed>16106127360</committed>
+        <committed>25769803776</committed>
         <critical_space_action_blocker>5</critical_space_action_blocker>
         <discard_after_delete>false</discard_after_delete>
         <external_status>ok</external_status>
@@ -3548,7 +4910,7 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a
         <supports_discard>false</supports_discard>
         <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
         <type>data</type>
-        <used>18253611008</used>
+        <used>20401094656</used>
         <warning_low_space_indicator>10</warning_low_space_indicator>
         <wipe_after_delete>false</wipe_after_delete>
         <data_centers>
@@ -3557,23 +4919,23 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a
     </storage_domain>
   :code: 200
   :headers:
-    date: Mon, 02 Dec 2019 11:26:46 GMT
+    date: Mon, 16 Dec 2019 10:55:56 GMT
     server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
     content-encoding: gzip
     content-type: application/xml;charset=UTF-8
-    content-length: '714'
-    correlation-id: c98b925b-b738-4733-a56a-8d3ff2a7d7dc
+    content-length: '712'
+    correlation-id: abb14eac-fdbc-4b1d-974f-b84fd45f5abe
   :message: 
-? https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/d8afa763-8249-4473-9558-e5431cb76e8e/disks{}GET
+? https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/17a94da8-3d02-430e-9b83-5e39f92907e8/snapshots/fb82cee1-39d6-4733-8c12-8c878ffd79ae/disks{}GET
 : - :body: |
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
       <disks/>
     :code: 200
     :headers:
-      date: Mon, 02 Dec 2019 11:26:46 GMT
+      date: Mon, 16 Dec 2019 10:55:56 GMT
       server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
       content-encoding: gzip
       content-type: application/xml;charset=UTF-8
       content-length: '85'
-      correlation-id: e9e62b31-457c-4e54-b447-655b6422682e
+      correlation-id: 30d889c8-08ef-4168-9798-2793b4d9328c
     :message: 


### PR DESCRIPTION
While reconfiguring disk attachments for a VM,
we need the virtio_scsi support flag to set the disk interface
accordingly, in case it's not specified.

Related to the PR
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/445