### PR TITLE
Native viewer support

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
@@ -196,6 +196,16 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
       SystemConsole.launch_proxy_if_not_local(console_args, originating_server, host_address, host_port)
     end
 
+    def native_console_connection(vm)
+      vm.with_provider_object do |vm_service|
+        consoles = vm_service.graphics_consoles_service.list(:current => true)
+        return nil if consoles.empty?
+
+        console = select_graphics_console(consoles)
+        Base64.encode64(vm_service.graphics_consoles_service.console_service(console.id).remote_viewer_connection_file)
+      end
+    end
+
     def get_template_proxy(template, connection)
       TemplateProxyDecorator.new(
         connection.system_service.templates_service.template_service(template.uid_ems),
@@ -692,6 +702,18 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
     end
 
     private
+
+    def select_graphics_console(consoles)
+      # In case of multiple graphics console ('SPICE + VNC') choose the SPICE one
+      pref_type = 'spice'
+      console = consoles.find { |c| c.protocol.downcase == pref_type }
+
+      unless console
+        console = consoles.first
+        _log.warn("Can't find a console of type #{pref_type}, choosing a #{console.protocol} type one")
+      end
+      console
+    end
 
     #
     # Hot plug of virtual memory has to be done in quanta of this size. Actually this is configurable in the

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm/remote_console_spec.rb
@@ -1,0 +1,94 @@
+describe ManageIQ::Providers::Redhat::InfraManager::Vm::RemoteConsole do
+  let(:user) { FactoryBot.create(:user) }
+  let(:ems) { FactoryBot.create(:ems_redhat) }
+  let(:vm) { FactoryBot.create(:vm_redhat, :ext_management_system => ems) }
+
+
+  it '#native_console_connection_queue' do
+    vm.native_console_connection_queue(user.userid)
+
+    queue_messages = MiqQueue.all
+    expect(queue_messages.length).to eq(1)
+    expect(queue_messages.first.method_name).to eq('native_console_connection')
+    expect(queue_messages.first.args).to be_empty
+  end
+
+  context '#validate_native_console_support' do
+    it 'no errors for the normal situation' do
+      expect { vm.validate_native_console_support }.not_to raise_error
+    end
+
+    context 'errors' do
+      it 'vm with no ems' do
+        vm.update_attribute(:ext_management_system, nil)
+
+        expect { vm.validate_native_console_support }
+          .to raise_error(MiqException::RemoteConsoleNotSupportedError, /registered with a management system/)
+      end
+
+      it 'vm not running' do
+        vm.update_attribute(:raw_power_state, 'poweredOff')
+
+        expect { vm.validate_native_console_support }
+          .to raise_error(MiqException::RemoteConsoleNotSupportedError, /vm to be running/)
+      end
+    end
+  end
+
+  context '#native_console_connection' do
+    let(:graphics_consoles_service) { double('GraphicsConsolesService') }
+    let(:console_service) { double('ConsoleService') }
+    let(:vm_service) { double('VmService', :graphics_consoles_service => graphics_consoles_service) }
+    let(:fake_connection) { 'fake connection content' }
+
+    before(:each) do
+      allow(vm).to receive(:with_provider_object).and_yield(vm_service)
+      allow(graphics_consoles_service).to receive(:list).with(:current => true).and_return(consoles)
+    end
+
+    context 'headless' do
+      let(:consoles) { [] }
+
+      it 'no consoles available' do
+        expect { vm.native_console_connection }
+          .to raise_error(MiqException::RemoteConsoleNotSupportedError, /No remote native console available for this vm/)
+      end
+    end
+
+    context 'one console' do
+      let(:consoles) { [double('VncConsole', :id => '7370696365', :protocol => 'vnc')] }
+
+      it 'connection for the only console' do
+        expect(graphics_consoles_service).to receive(:console_service).with(consoles.first.id).and_return(console_service)
+        expect(console_service).to receive(:remote_viewer_connection_file).and_return(fake_connection)
+
+        res = vm.native_console_connection
+
+        expect(res).to include(
+          :connection => Base64.encode64(fake_connection),
+          :type       => 'application/x-virt-viewer',
+          :name       => 'console.vv'
+        )
+      end
+    end
+
+    context 'more then one console' do
+      let(:vnc_console) { double('VncConsole', :id => '7370696365', :protocol => 'vnc') }
+      let(:spice_console) { double('SpiceConsole', :id => '9998465674', :protocol => 'spice') }
+      let(:consoles) { [vnc_console, spice_console] }
+
+      it 'select the spice console for connection' do
+        expect(graphics_consoles_service).to receive(:console_service).with(spice_console.id).and_return(console_service)
+        expect(console_service).to receive(:remote_viewer_connection_file).and_return(fake_connection)
+
+        res = vm.native_console_connection
+
+        expect(res).to include(
+          :connection => Base64.encode64(fake_connection),
+          :type       => 'application/x-virt-viewer',
+          :name       => 'console.vv'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add native viewer support to allow the download of the connection file.
In case of multiple available consoles the "spice" one is consider the
preferred.
In case of headless vm (with no consoles available) an exception is
raised.

This is PR is a dependency for:
- https://github.com/ManageIQ/manageiq-ui-classic/pull/6574
- https://github.com/ManageIQ/manageiq/pull/19675

Related to BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1451594