### PR TITLE
Allow user to set format and sparsity during provisioning and validate config

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
@@ -47,6 +47,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Cloning
   end
 
   def disk_format
+    format_from_dialog = get_option(:disk_format)
+    return format_from_dialog if format_from_dialog
+
     # If the datastore is not set, we will go with "block", because this will ensure
     # the result of the sparsity will be as set by the user.
     ds_type = 'block' unless dest_datastore
@@ -64,15 +67,15 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Cloning
   end
 
   def clone_type
-    get_option(:linked_clone).nil? ? clone_type_by_disk_format : clone_type_by_linked_clone
+    get_option(:linked_clone).nil? ? clone_type_by_disk_sparsity : clone_type_by_linked_clone
   end
 
   def clone_type_by_linked_clone
     get_option(:linked_clone) ? :linked : :full
   end
 
-  def clone_type_by_disk_format
-    get_option(:disk_format) == 'preallocated' ? :full : :linked
+  def clone_type_by_disk_sparsity
+    get_option(:disk_sparsity) == 'preallocated' ? :full : :linked
   end
 
   def template_clone_options

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/cloning.rb
@@ -88,7 +88,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Cloning
   end
 
   def sparse_disk_value
-    case get_option(:disk_format)
+    case get_option(:disk_sparsity)
     when "preallocated" then false
     when "thin"         then true
     when "default"      then nil   # default choice implies inherit from template

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -219,13 +219,13 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
     src_template = load_ar_obj(src[:vm])
     if selected_linked_clone?
       s_id = src_template.storage_id
-      return storages.detect { |s| s.id == s_id }
+      return [storages.detect { |s| s.id == s_id }].compact
     end
 
     storages = storages.select do |storage|
       src_template.disks.all? do |disk|
         storage_type = storage_type_from_storage(storage)
-        validate_disk(disk, { :storage_type => storage_type })
+        validate_disk(disk, :storage_type => storage_type)
       end
     end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -2,6 +2,8 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
   include CloudInitTemplateMixin
   include SysprepTemplateMixin
 
+  include_concern "DialogFieldValidation"
+
   SYSPREP_TIMEZONES = {
     '001' => '(UTC-12:00) Dateline Standard Time',
     '002' => '(UTC-11:00) UTC-11',
@@ -122,12 +124,12 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
     get_value(@values[:provision_type]).to_s == 'iso'
   end
 
-  def supports_native_clone?
+  def selected_native_clone?
     get_value(@values[:provision_type]).to_s == 'native_clone'
   end
 
-  def supports_linked_clone?
-    supports_native_clone? && get_value(@values[:linked_clone])
+  def selected_linked_clone?
+    selected_native_clone? && get_value(@values[:linked_clone])
   end
 
   def supports_cloud_init?
@@ -151,7 +153,7 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
   end
 
   def allowed_customization_templates(options = {})
-    if supports_native_clone?
+    if selected_native_clone?
       if get_source_vm&.platform == 'windows'
         allowed_sysprep_customization_templates(options)
       else
@@ -212,14 +214,22 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
 
   def allowed_storages(options = {})
     return [] if (src = resources_for_ui).blank?
-    result = super
-
-    if supports_linked_clone?
-      s_id = load_ar_obj(src[:vm]).storage_id
-      result = result.select { |s| s.id == s_id }
+    storages = super
+    storages = storages.select { |s| s.storage_domain_type == "data" }
+    src_template = load_ar_obj(src[:vm])
+    if selected_linked_clone?
+      s_id = src_template.storage_id
+      return storages.detect { |s| s.id == s_id }
     end
 
-    result.select { |s| s.storage_domain_type == "data" }
+    storages = storages.select do |storage|
+      src_template.disks.all? do |disk|
+        storage_type = storage_type_from_storage(storage)
+        validate_disk(disk, { :storage_type => storage_type })
+      end
+    end
+
+    storages
   end
 
   def source_ems

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow/dialog_field_validation.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow/dialog_field_validation.rb
@@ -1,0 +1,88 @@
+module ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow::DialogFieldValidation
+  def validate_disks_configuration(_field, _values, _dlg, _fld, _value)
+    sparsity = get_value(@values[:disk_sparsity])
+    format = get_value(@values[:disk_format])
+    linked_clone = get_value(@values[:linked_clone])
+    vm_id = get_value(@values[:src_vm_id])
+    vm = VmOrTemplate.find(vm_id)
+
+    if linked_clone
+      if !(default?(sparsity) && default?(format)) || storage_changed_for_disks?(vm)
+        return _("When the 'Linked Clone' option is set, disks and storage configuration cannot be changed")
+      end
+    end
+    disks = vm.disks
+    disks.each do |disk|
+      unless validate_disk(disk)
+        return _("The requested disk configuration for disk #{disk.device_name} is #{requested_disk_sparsity(disk)} with #{requested_disk_format(disk)} format.
+                 This configuration cannot be provisioned on the requested storage")
+      end
+    end
+    nil
+  end
+
+  def requested_disk_format(disk)
+    format = get_value(@values[:disk_format])
+    default?(format) ? disk.format : format
+  end
+
+  def requested_disk_sparsity(disk)
+    sparsity = get_value(@values[:disk_sparsity])
+    disk_sparsity = default?(sparsity) ? disk.thin : sparsity
+    case disk_sparsity
+    when true, "sparse"
+      "sparse"
+    else
+      "preallocated"
+    end
+  end
+
+  def storage_type_from_storage(storage)
+    storage.store_type.to_s.downcase == 'iscsi' ? 'block' : 'file'
+  end
+
+  def storage_type
+    return nil unless dest_storage&.store_type
+
+    storage_type_from_storage(dest_storage)
+  end
+
+  DISK_CONFIGURATIONS = {
+    "file,raw,preallocated"  => true,
+    "file,raw,sparse"        => true,
+    "file,cow,sparse"        => true,
+    "block,raw,preallocated" => true,
+    "block,cow,sparse"       => true
+  }.freeze
+
+  def validate_disk(disk, opts = {})
+    disk_format = requested_disk_format(disk)
+    disk_sparsity = requested_disk_sparsity(disk)
+    validate_disk_configuration(opts[:storage_type] || storage_type, disk_format, disk_sparsity)
+  end
+
+  def validate_disk_configuration(storage_type, format, sparsity)
+    # is storage_type is not given we will assume it is "file" this way it will not block the validation,
+    # in reality the allowed_storages will actually run over each of the configurations with the available storages
+    # and will block the provisioning process if none of them is valid.
+    str_type = storage_type || "file"
+    DISK_CONFIGURATIONS["#{str_type},#{format},#{sparsity}"]
+  end
+
+  def dest_storage
+    ds_id = get_value(@values[:placement_ds_name])
+    Storage.find(ds_id)
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+
+  def storage_changed_for_disks?(vm)
+    return false unless dest_storage
+
+    vm.disks.inject(false) { |res, disk| res || disk.storage_id != dest_storage.id }
+  end
+
+  def default?(str)
+    str == "default" || str.nil?
+  end
+end

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -488,10 +488,11 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
           :location        => index.to_s,
           :size            => device.provisioned_size.to_i,
           :size_on_disk    => device.actual_size.to_i,
-          :disk_type       => device.sparse == true ? 'thin' : 'thick',
+          :thin            => device.sparse,
           :mode            => 'persistent',
           :bootable        => device.try(:bootable),
-          :storage         => persister.storages.lazy_find(ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(storage_ref))
+          :storage         => persister.storages.lazy_find(ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(storage_ref)),
+          :format          => device.format
         )
       end
     end

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -488,6 +488,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
           :location        => index.to_s,
           :size            => device.provisioned_size.to_i,
           :size_on_disk    => device.actual_size.to_i,
+          :disk_type       => device.sparse == true ? 'thin' : 'thick',
           :thin            => device.sparse,
           :mode            => 'persistent',
           :bootable        => device.try(:bootable),

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
@@ -42,23 +42,23 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       end
 
       context "#sparse_disk_value" do
-        it "with nil disk_format value" do
+        it "with nil disk_sparsity value" do
           expect(@vm_prov.sparse_disk_value).to be_nil
         end
 
-        it "with :default disk_format value" do
-          @vm_prov.options[:disk_format] = %w[default Default]
+        it "with :default disk_sparsity value" do
+          @vm_prov.options[:disk_sparsity] = %w[default Default]
           expect(@vm_prov.sparse_disk_value).to be_nil
         end
 
-        it "with :thin disk_format value" do
-          @vm_prov.options[:disk_format] = %w[thin Thin]
+        it "with :thin disk_sparsity value" do
+          @vm_prov.options[:disk_sparsity] = %w[thin Thin]
           expect(@vm_prov.sparse_disk_value).to be_truthy
         end
 
-        it "with :preallocated disk_format value" do
-          @vm_prov.options[:disk_format] = %w[preallocated Preallocated]
-          expect(@vm_prov.sparse_disk_value).to be_falsey
+        it "with :preallocated disk_sparsity value" do
+          @vm_prov.options[:disk_sparsity] = %w[preallocated Preallocated]
+          expect(@vm_prov.sparse_disk_value).to be false
         end
       end
 
@@ -90,17 +90,34 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
           expect(clone_options[:clone_type]).to eq(:full)
         end
 
+        context "with disk_format defined" do
+          before { @vm_prov.options[:linked_clone] = nil }
+          it "with disk_format raw" do
+            @vm_prov.options[:disk_format] = "raw"
+            clone_options = @vm_prov.prepare_for_clone_task
+
+            expect(clone_options[:disk_format]).to eq("raw")
+          end
+
+          it "with disk_format cow" do
+            @vm_prov.options[:disk_format] = "cow"
+            clone_options = @vm_prov.prepare_for_clone_task
+
+            expect(clone_options[:disk_format]).to eq("cow")
+          end
+        end
+
         context "no liked_clone defined" do
           before { @vm_prov.options[:linked_clone] = nil }
-          it "with disk_format preallocated" do
-            @vm_prov.options[:disk_format] = "preallocated"
+          it "with disk_sparsity preallocated" do
+            @vm_prov.options[:disk_sparsity] = "preallocated"
             clone_options = @vm_prov.prepare_for_clone_task
 
             expect(clone_options[:clone_type]).to eq(:full)
           end
 
-          it "with disk format thin" do
-            @vm_prov.options[:disk_format] = "thin"
+          it "with disk sparsity thin" do
+            @vm_prov.options[:disk_sparsity] = "thin"
             clone_options = @vm_prov.prepare_for_clone_task
 
             expect(clone_options[:clone_type]).to eq(:linked)

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow/dialog_field_validation_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow/dialog_field_validation_spec.rb
@@ -1,0 +1,138 @@
+describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow::DialogFieldValidation do
+  include Spec::Support::WorkflowHelper
+
+  def set_workflow_values
+    @workflow.instance_variable_set(:@values, values)
+  end
+
+  attr_reader :storage_type
+
+  def values
+    {
+      :disk_sparsity => @disk_sparsity,
+      :disk_format   => @disk_format,
+      :linked_clone  => @linked_clone,
+      :src_vm_id     => @src_vm_id,
+      :src_ems_id    => @src_ems_id
+    }
+  end
+
+  describe '.validate_disks_configuration' do
+    before do
+      stub_dialog(:get_dialogs)
+      allow_any_instance_of(described_class).to receive(:update_field_visibility)
+      admin = FactoryBot.create(:user_with_group)
+      @ems = FactoryBot.create(:ems_redhat)
+      @template = FactoryBot.create(:template_redhat, :ext_management_system => @ems)
+
+      @storages_on_template = {:file => FactoryBot.create(:storage_nfs, :ext_management_system => @ems), :block => FactoryBot.create(:storage, :store_type => 'iscsi', :ext_management_system => @ems)}
+
+      @hardware = FactoryBot.create(:hardware, :vm_or_template => @template)
+
+      @src_vm_id = @template.id
+      @src_ems_id = @ems.id
+      @workflow = ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow.new(values, admin)
+    end
+
+    subject do
+      set_workflow_values
+      @workflow.validate_disks_configuration({}, {}, {}, {}, {})
+    end
+
+    context "linked_clone set to true" do
+      before { @linked_clone = true }
+      it "does not allow changing format and sparsity" do
+        @disk_format = "cow"
+        @disk_sparsity = "sparse"
+        is_expected.to be_truthy
+      end
+
+      it "is valid when default values are set" do
+        @disk_format = "default"
+        @disk_sparsity = "default"
+        is_expected.to be_nil
+      end
+    end
+
+    context "linked clone is not checked" do
+      before do
+        @linked_clone = false
+      end
+
+      context "with default configurations" do
+        before do
+          @disk_format = "default"
+          @disk_sparsity = "default"
+        end
+
+        @allowed_configs = described_class::DISK_CONFIGURATIONS.keys.collect { |configuration| configuration.split(',') }
+        @sparsities = ['preallocated', 'sparse']
+        @formats = ['cow', 'raw']
+        @storage_types = ['file', 'block']
+
+        @allowed_configs.each do |configuration|
+          it 'is valid for disks with allowed configurations' do
+            storage_type_of_template_disk, disk_format_of_template_disk, disk_sparsity_of_template_disk = configuration
+            FactoryBot.create(:disk,
+                              :device_name => "disk1",
+                              :thin        => disk_sparsity_of_template_disk == 'sparse',
+                              :format      => disk_format_of_template_disk,
+                              :storage     => @storages_on_template[storage_type_of_template_disk.to_sym],
+                              :hardware    => @hardware)
+            allow(@workflow).to receive(:dest_storage).and_return(@storages_on_template[storage_type_of_template_disk.to_sym])
+            is_expected.to be_nil, "expected to be valid when options are set to default and the disk is configured as: #{configuration}"
+          end
+        end
+
+        (@storage_types.product(@formats, @sparsities) - @allowed_configs).each do |configuration|
+          it 'is not valid for non valid configuration' do
+            storage_type_of_template_disk, disk_format_of_template_disk, disk_sparsity_of_template_disk = configuration
+            FactoryBot.create(:disk,
+                              :device_name => "disk1",
+                              :thin        => disk_sparsity_of_template_disk == 'sparse',
+                              :format      => disk_format_of_template_disk,
+                              :storage     => @storages_on_template[storage_type_of_template_disk.to_sym],
+                              :hardware    => @hardware)
+            allow(@workflow).to receive(:dest_storage).and_return(@storages_on_template[storage_type_of_template_disk.to_sym])
+            is_expected.to be, "expected to be non valid when options are set to default and the disk is configured as: #{configuration}"
+          end
+        end
+      end
+
+      context "non default configurations" do
+        @allowed_configs = described_class::DISK_CONFIGURATIONS.keys.collect { |configuration| configuration.split(',') }
+        @sparsities = ['preallocated', 'sparse']
+        @formats = ['cow', 'raw']
+        @storage_types = ['file', 'block']
+
+        @allowed_configs.each do |configuration|
+          it 'is valid for allowed configurations' do
+            @storage_type, @disk_format, @disk_sparsity = configuration
+            FactoryBot.create(:disk,
+                              :device_name => "disk1",
+                              :thin        => true,
+                              :format      => 'cow',
+                              :storage     => @storages_on_template[:file],
+                              :hardware    => @hardware)
+            allow(@workflow).to receive(:dest_storage).and_return(@storages_on_template[@storage_type.to_sym])
+            is_expected.to be_nil, "expected to be valid for #{configuration}"
+          end
+        end
+
+        (@storage_types.product(@formats, @sparsities) - @allowed_configs).each do |configuration|
+          it 'is not valid for non valid configurations' do
+            @storage_type, @disk_format, @disk_sparsity = configuration
+            FactoryBot.create(:disk,
+                              :device_name => "disk1",
+                              :thin        => true,
+                              :format      => 'cow',
+                              :storage     => @storages_on_template[:file],
+                              :hardware    => @hardware)
+            allow(@workflow).to receive(:dest_storage).and_return(@storages_on_template[@storage_type.to_sym])
+            is_expected.to be, "expected to be non valid for #{configuration}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
@@ -37,7 +37,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
     end
 
     it "for linked-clone provisioning" do
-      allow(workflow).to receive(:supports_linked_clone?).and_return(true)
+      allow(workflow).to receive(:selected_linked_clone?).and_return(true)
       template.storage = Storage.where(:storage_domain_type => "data").first
       template.save
 
@@ -82,17 +82,17 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
       expect(workflow.allowed_clusters).to match_array([[cluster1.id, cluster1.name], [cluster2.id, cluster2.name]])
     end
   end
-  context "supports_linked_clone?" do
+  context "selected_linked_clone?" do
     let(:workflow) { described_class.new({:src_vm_id => template.id, :linked_clone => true}, admin) }
 
-    it "when supports_native_clone? is true" do
-      allow(workflow).to receive(:supports_native_clone?).and_return(true)
-      expect(workflow.supports_linked_clone?).to be_truthy
+    it "when selected_native_clone? is true" do
+      allow(workflow).to receive(:selected_native_clone?).and_return(true)
+      expect(workflow.selected_linked_clone?).to be_truthy
     end
 
-    it "when supports_native_clone? is false " do
-      allow(workflow).to receive(:supports_native_clone?).and_return(false)
-      expect(workflow.supports_linked_clone?).to be_falsey
+    it "when selected_native_clone? is false " do
+      allow(workflow).to receive(:selected_native_clone?).and_return(false)
+      expect(workflow.selected_linked_clone?).to be_falsey
     end
   end
 
@@ -110,7 +110,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
 
     it "should retrieve cloud-init templates when cloning" do
       options = {'key' => 'value'}
-      allow(workflow).to receive(:supports_native_clone?).and_return(true)
+      allow(workflow).to receive(:selected_native_clone?).and_return(true)
       expect(workflow).to receive(:allowed_cloud_init_customization_templates).with(options)
       workflow.allowed_customization_templates(options)
     end
@@ -141,7 +141,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
                          :id             => other_region_id,
                          :pxe_image_type => pxe_image_type)
 
-      expect(workflow).to receive(:supports_native_clone?).and_return(true)
+      expect(workflow).to receive(:selected_native_clone?).and_return(true)
       result = workflow.allowed_customization_templates
       expect(result.size).to eq(1)
       expect(result.first.id).to eq(template.id)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
@@ -503,7 +503,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
         :size_on_disk    => 2_561_437_696,
         :mode            => "persistent",
         :disk_type       => "thin",
-        :start_connected => true
+        :start_connected => true,
+        :format          => "cow"
       )
       expect(disk.storage).to eq(@storage)
 
@@ -645,7 +646,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
         :size_on_disk    => 204_800,
         :mode            => "persistent",
         :disk_type       => "thin",
-        :start_connected => true
+        :start_connected => true,
+        :format          => "cow"
       )
       expect(disk.storage).to eq(@storage) ## CHECK MANUALLY
 
@@ -754,7 +756,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
         :size_on_disk    => 12_775_424,
         :mode            => "persistent",
         :disk_type       => "thin",
-        :start_connected => true
+        :start_connected => true,
+        :format          => "cow"
       )
       expect(disk.storage).to eq(@storage)
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
@@ -502,8 +502,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
         :size            => 8_589_934_592,
         :size_on_disk    => 2_561_437_696,
         :mode            => "persistent",
-        :disk_type       => "thin",
         :start_connected => true,
+        :thin            => true,
         :format          => "cow"
       )
       expect(disk.storage).to eq(@storage)
@@ -645,8 +645,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
         :size            => 46_137_344,
         :size_on_disk    => 204_800,
         :mode            => "persistent",
-        :disk_type       => "thin",
         :start_connected => true,
+        :thin            => true,
         :format          => "cow"
       )
       expect(disk.storage).to eq(@storage) ## CHECK MANUALLY
@@ -755,8 +755,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
         :size            => 46_137_344,
         :size_on_disk    => 12_775_424,
         :mode            => "persistent",
-        :disk_type       => "thin",
         :start_connected => true,
+        :thin            => true,
         :format          => "cow"
       )
       expect(disk.storage).to eq(@storage)


### PR DESCRIPTION
We will now save the disk format as part of the refresh.
Will now allow the user to select disk_format
Will validate disk configuration.

Depends on: https://github.com/ManageIQ/manageiq-schema/pull/459
Depends on: https://github.com/ManageIQ/manageiq/pull/19849
Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/6692
Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1726590