### PR TITLE
Subclass InfraManager metrics capture

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Redhat::InfraManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+class ManageIQ::Providers::Redhat::InfraManager::MetricsCapture < ManageIQ::Providers::InfraManager::MetricsCapture
   #
   # Connect / Disconnect / Intialize methods
   #

--- a/spec/models/manageiq/providers/redhat/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/metrics_capture_spec.rb
@@ -1,5 +1,14 @@
 describe ManageIQ::Providers::Redhat::InfraManager::MetricsCapture do
   require 'ovirt_metrics'
+
+  context "#perf_capture_object" do
+    let(:ems) { FactoryBot.create(:ems_redhat_with_metrics_authentication) }
+    let(:host) { FactoryBot.create(:host_redhat, :ems_id => ems.id) }
+    it "returns the correct class" do
+      expect(host.perf_capture_object.class).to eq(described_class)
+    end
+  end
+
   context '#perf_collect_metrics' do
     let(:ems) { FactoryBot.create(:ems_redhat_with_metrics_authentication) }
     let(:host) { FactoryBot.create(:host_redhat, :ems_id => ems.id) }


### PR DESCRIPTION
Ovirt is an infra metrics capture class. subclassing the proper parent

part of ManageIQ/manageiq#19684

NOTE: this one is not open/shut like the others.

The hierarchy is a little odd. Especially since there is a NetworkManager with network capture
Wondering if this is good enough, or if we need to get into modules and the like