### PR TITLE
Fix for NICs that don't have a vnic_profile

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
   def id_of_external_network?(network_id)
     network = collector.networks.detect { |net| net.id == network_id }
-    network.external_provider.present?
+    network&.external_provider.present?
   end
 
   def clusters
@@ -515,6 +515,8 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       network = mac && networks.present? ? networks[mac] : nil
 
       vnic_profile_id = nic.dig(:vnic_profile, :id)
+      next if vnic_profile_id.nil?
+
       network_uid = collector.collect_vnic_profiles.detect { |vp| vp.id == vnic_profile_id }&.network&.id
       virtual_switches_persister = id_of_external_network?(network_uid) ? persister.external_distributed_virtual_switches : persister.distributed_virtual_switches
       virtual_lans_persister = id_of_external_network?(network_uid) ? persister.external_distributed_virtual_lans : persister.distributed_virtual_lans


### PR DESCRIPTION
If a NIC doesn't have a vnic_profile looking up if it is an
external_network or not raises a NoMethodError trying to call
external_networks on a nil.

Fixes https://github.com/ManageIQ/manageiq-providers-ovirt/issues/456