### PR TITLE
Html5 console disabled by default

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
@@ -1,12 +1,17 @@
 class ManageIQ::Providers::Redhat::InfraManager::Vm
   module RemoteConsole
     def console_supported?(type)
-      %w(SPICE VNC NATIVE).include?(type.upcase)
+      return true if type.upcase == 'NATIVE'
+
+      %w[SPICE VNC].include?(type.upcase) && html5_console_enabled?
     end
 
     def validate_remote_console_acquire_ticket(protocol, options = {})
       raise(MiqException::RemoteConsoleNotSupportedError,
             "#{protocol} protocol not enabled for this vm") unless protocol.to_sym == :html5
+
+      raise(MiqException::RemoteConsoleNotSupportedError,
+            "Html5 console is disabled by default, check settings to enable it") unless html5_console_enabled?
 
       raise(MiqException::RemoteConsoleNotSupportedError,
             "#{protocol} remote console requires the vm to be registered with a management system.") if ext_management_system.nil?
@@ -78,5 +83,11 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm
 
       MiqTask.generic_action_with_callback(task_opts, queue_opts)
     end
+  end
+
+  private
+
+  def html5_console_enabled?
+    !!::Settings.ems.ems_redhat&.consoles&.html5_enabled
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,8 @@
 ---
 :ems:
   :ems_redhat:
+    :consoles:
+      :html5_enabled: false
     :resolve_ip_addresses: true
     :inventory:
       :read_timeout: 1.hour


### PR DESCRIPTION
Html5 is not officially supported anymore in RHV.
We can disable it by default using a property in the settings file.
In this way the feature can be enabled at user own risk.

Related to BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1668771
