### PR TITLE
Ems metrics collector section should remain

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -76,6 +76,8 @@
         :ceilometer:
           :event_types_regex: '\A(firewall|floatingip|gateway|net|port|router|subnet|security_group|vpn)'
     :queue_worker_base:
+      :ems_metrics_collector_worker:
+        :ems_metrics_collector_worker_redhat: {}
       :ems_refresh_worker:
         :ems_refresh_worker_redhat: {}
         :ems_refresh_worker_redhat_network: {}


### PR DESCRIPTION
Without ems_metrics_collector_worker_redhat section the server is unable to
start

See PR:
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/464