### PR TITLE
[IVANCHUK] We need all VM details

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -272,7 +272,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
         # Retrieve the current representation of the virtual machine:
         # mandatory for memory parameters and to check if next_run_configuration_exists
 
-        vm = vm_service.get
+        vm = vm_service.get(:all_content => true)
         new_vm_specs = {}
 
         # Update the memory:


### PR DESCRIPTION
While reconfiguring disk attachments for a VM,
we need the virtio_scsi support flag to set the disk interface
accordingly, in case it's not specified.

Backport of https://github.com/ManageIQ/manageiq-providers-ovirt/pull/451

(cherry picked from commit ad5336cb7c4dfcfab5db17c951a4ceff92004d4e)

Related to BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1803775