### PR TITLE
[IVANCHUK] Enable to set virtio_scsi disk attachment interface

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -300,7 +300,11 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
 
         # Add disks:
         added_disk_specs = spec['disksAdd']
-        add_vm_disks(vm_service, added_disk_specs) if added_disk_specs
+        if added_disk_specs
+          added_disk_specs[:default] = {}
+          added_disk_specs[:default][:interface] = 'virtio_scsi' if vm.virtio_scsi.enabled
+          add_vm_disks(vm_service, added_disk_specs)
+        end
       end
 
       _log.info("#{log_header} Completed.")
@@ -836,9 +840,10 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
     #
     def add_vm_disks(vm_service, disk_specs)
       storage_spec = disk_specs[:storage]
+      default_disk_spec = disk_specs[:default] || {}
       attachments_service = vm_service.disk_attachments_service
       disk_specs[:disks].each do |disk_spec|
-        attachment = prepare_vm_disk_attachment(disk_spec, storage_spec)
+        attachment = prepare_vm_disk_attachment(default_disk_spec.merge(disk_spec), storage_spec)
         attachments_service.add(attachment)
       end
     end
@@ -857,6 +862,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
         :name             => disk_spec[:disk_name],
         :thin_provisioned => disk_spec[:thin_provisioned],
         :bootable         => disk_spec[:bootable],
+        :interface        => disk_spec[:interface]
       )
       attachment_builder.disk_attachment
     end


### PR DESCRIPTION
Fix issue when disk_add :interface option from VmReconfigure request was not passed to DiskAttachmentBuilder

virtio_scsi is default interface option in oVirt/RHV UI, so make it default in ManageIQ as well.

(cherry picked from commit d8d3bce735385e4c81e575ea7ad76e890395a844)

Backport of https://github.com/ManageIQ/manageiq-providers-ovirt/pull/445

Related to BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1803775

Depends on:
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/472