### PR TITLE
[HAMMER] We need all VM details

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -271,7 +271,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       vm.with_provider_object(VERSION_HASH) do |vm_service|
         # Retrieve the current representation of the virtual machine:
         # TODO: no need to retreive vm here, only if memory is updated
-        vm = vm_service.get
+        vm = vm_service.get(:all_content => true)
 
         # Update the memory:
         memory = spec['memoryMB']


### PR DESCRIPTION
While reconfiguring disk attachments for a VM,
we need the virtio_scsi support flag to set the disk interface
accordingly, in case it's not specified.

Backport of #451

(cherry picked from commit ad5336c)

Related to BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1803775