### PR TITLE
Add network reconfiguration

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -37,6 +37,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
 
   supports :conversion_host
 
+  supports :reconfigure_network_adapters
+
   POWER_STATES = {
     'up'          => 'on',
     'powering_up' => 'on',

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
@@ -29,7 +29,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure
       "memoryMB"          => (task_options[:vm_memory].to_i if task_options[:vm_memory]),
       "numCPUs"           => (task_options[:number_of_cpus].to_i if task_options[:number_of_cpus]),
       "disksRemove"       => task_options[:disk_remove],
-      "disksAdd"          => (spec_for_added_disks(task_options[:disk_add]) if task_options[:disk_add])
+      "disksAdd"          => (spec_for_added_disks(task_options[:disk_add]) if task_options[:disk_add]),
+      "networkAdapters"   => spec_for_network_adapters(task_options)
     }
   end
 
@@ -38,5 +39,104 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure
       :disks   => disks,
       :storage => storage
     }
+  end
+
+  def spec_for_network_adapters(options)
+    {
+      :edit   => (network_adapters_edit(options[:network_adapter_edit]) if options[:network_adapter_edit]),
+      :add    => (network_adapters_add(options[:network_adapter_add]) if options[:network_adapter_add]),
+      :remove => (network_adapters_remove(options[:network_adapter_remove]) if options[:network_adapter_remove])
+    }.compact
+  end
+
+  def network_adapters_add(adapters)
+    nic_names = hardware.nics.pluck(:device_name)
+    switch_ids = HostSwitch.where(:host => host).pluck(:switch_id)
+
+    adapters.collect do |adapt|
+      new_nic_name = suggest_nic_name(nic_names)
+      nic_names << new_nic_name
+      network_adapter_add_spec(adapt['network'],
+                               new_nic_name,
+                               switch_ids)
+    end
+  end
+
+  def network_adapters_edit(adapters)
+    switch_ids = HostSwitch.where(:host => host).pluck(:switch_id)
+
+    adapters.collect do |adapt|
+      network_adapter_edit_spec(adapt['network'],
+                                adapt['name'],
+                                switch_ids)
+    end
+  end
+
+  def network_adapters_remove(adapters)
+    adapters.collect do |adapt|
+      network_adapter_remove_spec(adapt['network']['vlan'],
+                                  adapt['network']['name'],
+                                  adapt['network']['mac'])
+    end
+  end
+
+  def network_adapter_add_spec(network_name, nic_name, switch_ids)
+    lan = find_lan_by_name(network_name, switch_ids)
+    raise MiqException::MiqVmError, "Network [#{network_name}] not available for the target" unless lan
+
+    {
+      :network         => network_name,
+      :name            => nic_name,
+      :vnic_profile_id => lan.uid_ems
+    }
+  end
+
+  def network_adapter_edit_spec(network_name, nic_name, switch_ids)
+    nic = hardware.nics.find_by_name(nic_name)
+    raise MiqException::MiqVmError, "No NIC named '#{nic_name}' was found" unless nic
+
+    lan = find_lan_by_name(network_name, switch_ids)
+    raise MiqException::MiqVmError, "Network [#{network_name}] not available for the target" unless lan
+
+    {
+      :network         => network_name,
+      :name            => nic_name,
+      :vnic_profile_id => lan.uid_ems,
+      :nic_id          => nic.uid_ems
+    }
+  end
+
+  def network_adapter_remove_spec(network_name, nic_name, mac)
+    nic = hardware.nics.find_by_name(nic_name)
+    raise MiqException::MiqVmError, "No NIC named '#{nic_name}' was found" unless nic
+
+    {
+      :network     => network_name,
+      :name        => nic_name,
+      :mac_address => mac,
+      :nic_id      => nic.uid_ems
+    }
+  end
+
+  def find_lan_by_name(network_name, switch_ids)
+    lan_name, ext_switch_name = network_name.split('/').collect(&:strip)
+
+    switch_ids = ext_switch_ids_by_name(ext_switch_name) if ext_switch_name
+
+    Lan.find_by(:name => lan_name, :switch_id => switch_ids)
+  end
+
+  def ext_switch_ids_by_name(switch_name)
+    ext_management_system.external_distributed_virtual_switches.where(:name => switch_name).pluck(:id)
+  end
+
+  def suggest_nic_name(nic_list)
+    nic_list.inject('nic1') do |memo, n|
+      m = n.match(/^nic(\d+)$/)
+      next memo unless m
+
+      nic_number = m[1].to_i + 1
+      nic_number > memo[3..-1].to_i ? "nic#{nic_number}" : memo
+    end
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
@@ -92,7 +92,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure
   end
 
   def network_adapter_edit_spec(network_name, nic_name, switch_ids)
-    nic = hardware.nics.find_by_name(nic_name)
+    nic = hardware.nics.find_by(:name => nic_name)
     raise MiqException::MiqVmError, "No NIC named '#{nic_name}' was found" unless nic
 
     lan = find_lan_by_name(network_name, switch_ids)
@@ -107,7 +107,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure
   end
 
   def network_adapter_remove_spec(network_name, nic_name, mac)
-    nic = hardware.nics.find_by_name(nic_name)
+    nic = hardware.nics.find_by(:name => nic_name)
     raise MiqException::MiqVmError, "No NIC named '#{nic_name}' was found" unless nic
 
     {
@@ -127,7 +127,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure
   end
 
   def ext_switch_ids_by_name(switch_name)
-    ext_management_system.external_distributed_virtual_switches.where(:name => switch_name).pluck(:id)
+    parent_datacenter.external_distributed_virtual_switches.select { |s| s.name == switch_name }.map(&:id)
   end
 
   def suggest_nic_name(nic_list)

--- a/spec/factories/datacenter.rb
+++ b/spec/factories/datacenter.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :datacenter_redhat, :class => 'ManageIQ::Providers::Redhat::InfraManager::Datacenter'
+end

--- a/spec/factories/switch.rb
+++ b/spec/factories/switch.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
 end
 
 FactoryBot.define do
+  factory :external_distributed_virtual_switch_redhat, :class => 'ManageIQ::Providers::Redhat::InfraManager::ExternalDistributedVirtualSwitch'
+end
+
+FactoryBot.define do
   factory :host_switch, :class => 'HostSwitch'
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/v4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/v4_spec.rb
@@ -226,10 +226,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
           expect(nics_service).to receive(:add).and_raise(error)
           expect($log).to receive(:error).with(/Error reconfiguring.*name is already in use/)
 
-          expect {
-            subject
-          }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
-                           "Error reconfiguring [#{spec['networkAdapters'][:add][0][:name]}]. #{error.fault.detail}")
+          expect { subject }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
+                                            "Error reconfiguring [#{spec['networkAdapters'][:add][0][:name]}]. #{error.fault.detail}")
         end
 
         it 'not existing profile id' do
@@ -241,10 +239,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
           expect(nics_service).to receive(:add).and_raise(error)
           expect($log).to receive(:error).with(/Error reconfiguring.*network interface profile doesn't exist.\]/)
 
-          expect {
-            subject
-          }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
-                           "Error reconfiguring [#{spec['networkAdapters'][:add][0][:name]}]. #{error.fault.detail}")
+          expect { subject }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
+                                            "Error reconfiguring [#{spec['networkAdapters'][:add][0][:name]}]. #{error.fault.detail}")
         end
       end
 
@@ -281,7 +277,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
         edit_spec = spec['networkAdapters'][:edit].first
         expect(nics_service).to receive(:nic_service).twice.with(edit_spec[:nic_id]).and_return(nic_service)
         expect(nic_service).to receive(:deactivate)
-        expect(nic_service).to receive(:update).with(:name => edit_spec[:name],
+        expect(nic_service).to receive(:update).with(:name         => edit_spec[:name],
                                                      :vnic_profile => {:id => edit_spec[:vnic_profile_id]})
         expect(nic_service).to receive(:activate)
 
@@ -293,10 +289,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
           expect(nics_service).to receive(:nic_service).and_raise(OvirtSDK4::NotFoundError)
           expect($log).to receive(:error).with(/Error reconfiguring.*NIC not found/)
 
-          expect {
-            subject
-          }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
-                           "Error reconfiguring [#{spec['networkAdapters'][:edit][0][:name]}]. NIC not found")
+          expect { subject }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
+                                            "Error reconfiguring [#{spec['networkAdapters'][:edit][0][:name]}]. NIC not found")
         end
 
         it 'not existing profile id' do
@@ -309,10 +303,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
           expect(nics_service).to receive(:nic_service).and_raise(error)
           expect($log).to receive(:error).with(/Error reconfiguring.*network interface profile doesn't exist.\]/)
 
-          expect {
-            subject
-          }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
-                           "Error reconfiguring [#{spec['networkAdapters'][:edit][0][:name]}]. #{error.fault.detail}")
+          expect { subject }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
+                                            "Error reconfiguring [#{spec['networkAdapters'][:edit][0][:name]}]. #{error.fault.detail}")
         end
       end
     end
@@ -331,7 +323,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
         {'networkAdapters' => {:remove => [{:network     => 'oVirtA',
                                             :name        => 'nic2',
                                             :mac_address => '56:6f:85:ae:00:00',
-                                            :nic_id      => 'nic_uid_ems' }]}}
+                                            :nic_id      => 'nic_uid_ems'}]}}
       end
 
       subject(:reconfigure_vm) { ems.vm_reconfigure(vm, :spec => spec) }
@@ -350,10 +342,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
           expect(nics_service).to receive(:nic_service).and_raise(OvirtSDK4::NotFoundError)
           expect($log).to receive(:error).with(/Error reconfiguring.*NIC not found |.*/)
 
-          expect {
-            subject
-          }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
-                           "Error reconfiguring [#{spec['networkAdapters'][:remove][0][:name]}]. NIC not found")
+          expect { subject }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
+                                            "Error reconfiguring [#{spec['networkAdapters'][:remove][0][:name]}]. NIC not found")
         end
 
         it 'generic error while removing' do
@@ -368,10 +358,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
           expect(nic_service).to receive(:remove).and_raise(error)
           expect($log).to receive(:error).with(/Error reconfiguring.*generic failure\]/)
 
-          expect {
-            subject
-          }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
-                           "Error reconfiguring [#{spec['networkAdapters'][:remove][0][:name]}]. #{error.fault.detail}")
+          expect { subject }.to raise_error(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error,
+                                            "Error reconfiguring [#{spec['networkAdapters'][:remove][0][:name]}]. #{error.fault.detail}")
         end
       end
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm/reconfigure_spec.rb
@@ -42,23 +42,26 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure do
   end
 
   context "#build_config_spec" do
-    before do
-      @options = {:vm_memory        => '1024',
-                  :number_of_cpus   => '8',
-                  :cores_per_socket => '2',
-                  :disk_add         => [{  "disk_size_in_mb"  => "33",
-                                           "persistent"       => true,
-                                           "thin_provisioned" => true,
-                                           "dependent"        => true,
-                                           "bootable"         => false
-                                        }],
-                  :disk_remove      => [{  "disk_name"      => "2520b46a-799b-472d-89ce-d47f5b65ee5e",
-                                           "delete_backing" => false
-                                        }]
+    let :options do
+      {
+        :vm_memory        => '1024',
+        :number_of_cpus   => '8',
+        :cores_per_socket => '2',
+        :disk_add         => [{  "disk_size_in_mb"  => "33",
+                                  "persistent"       => true,
+                                  "thin_provisioned" => true,
+                                  "dependent"        => true,
+                                  "bootable"         => false
+                              }],
+        :disk_remove      => [{  "disk_name"      => "2520b46a-799b-472d-89ce-d47f5b65ee5e",
+                                  "delete_backing" => false
+                              }],
       }
-      @vm = FactoryBot.create(:vm_redhat, :hardware => FactoryBot.create(:hardware), :storage => storage)
     end
-    subject { @vm.build_config_spec(@options) }
+
+    let(:vm) { FactoryBot.create(:vm_redhat, :hardware => FactoryBot.create(:hardware), :storage => storage) }
+
+    subject { vm.build_config_spec(options) }
 
     it "memoryMB" do
       expect(subject["memoryMB"]).to eq(1024)
@@ -86,6 +89,205 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure do
       expect(subject["disksRemove"].size).to eq(1)
       expect(subject["disksRemove"][0]["disk_name"]).to eq("2520b46a-799b-472d-89ce-d47f5b65ee5e")
       expect(subject["disksRemove"][0]["delete_backing"]).to be_falsey
+    end
+
+    context 'network adapters spec' do
+      let(:ems) { FactoryBot.create(:ems_redhat) }
+      let!(:cluster1) { FactoryBot.create(:ems_cluster, :uid_ems => "uid_ems", :name => 'Cluster1') }
+      let!(:host1) { FactoryBot.create(:host_redhat, :ext_management_system => ems, :ems_cluster => cluster1) }
+      let!(:host2) { FactoryBot.create(:host_redhat, :ext_management_system => ems, :ems_cluster => cluster1) }
+      let!(:distributed_virtual_switch) { FactoryBot.create(:distributed_virtual_switch_redhat, :ems_id => ems.id, :name => "network") }
+      let!(:host_switch_1) { FactoryBot.create(:host_switch, :host => host1, :switch => distributed_virtual_switch) }
+      let!(:host_switch_2) { FactoryBot.create(:host_switch, :host => host2, :switch => distributed_virtual_switch) }
+      let!(:lan_mgmt) { FactoryBot.create(:lan, :name => 'ovirtmgmt', :switch => distributed_virtual_switch) }
+      let(:nic1) { FactoryBot.create(:guest_device_nic, :lan => lan_mgmt, :device_name => 'nic1', :uid_ems => 'nic1_uid_ems') }
+      let(:hardware) { FactoryBot.create(:hardware, :guest_devices => [nic1]) }
+      let!(:vm) do
+        FactoryBot.create(:vm_redhat,
+                          :ext_management_system => ems,
+                          :host                  => host1,
+                          :storage               => storage,
+                          :hardware              => hardware)
+      end
+
+      shared_examples_for 'nic not found' do
+        subject { vm.build_config_spec(specs) }
+
+        it 'no nic for the vm' do
+          expect { subject }.to raise_error(MiqException::MiqVmError, /No NIC named.*was found/)
+        end
+      end
+
+      shared_examples_for 'not available lan' do |network_name|
+        subject { vm.build_config_spec(specs) }
+
+        it 'no lan for hosts' do
+          expect { subject }.to raise_error(MiqException::MiqVmError, /Network.*not available for the target/)
+        end
+
+        it 'no lan for vm host' do
+          wrong_switch = FactoryBot.create(:distributed_virtual_switch_redhat, :ems_id => ems.id, :name => "wrong_network")
+          FactoryBot.create(:lan,
+                            :name    => network_name,
+                            :uid_ems => "#{network_name}_uid_ems",
+                            :switch  => wrong_switch)
+          FactoryBot.create(:host_switch, :host => host2, :switch => wrong_switch)
+
+          expect { subject }.to raise_error(MiqException::MiqVmError, /Network.*not available.* for the target/)
+        end
+      end
+
+      let :edit_specs do
+        {:network_adapter_edit => [{'network' => 'oVirtB', 'name' => 'nic1'}]}
+      end
+
+      let :add_specs do
+        {:network_adapter_add => [{'network' => 'oVirtA', 'name' => 'to be determined'}]}
+      end
+
+      let :remove_specs do
+        {:network_adapter_remove => [{'network' => {'name'      => 'nic1',
+                                                    'vlan'      => 'ovirtmgmt',
+                                                    'mac'       => '56:6f:85:ae:00:00',
+                                                    '$$hashKey' => 'object:51'}}]}
+      end
+
+      let :options do
+        {}.merge(edit_specs).merge(add_specs)
+      end
+
+      context 'available lan' do
+        before :each do
+          FactoryBot.create(:lan,
+                            :name    => 'oVirtA',
+                            :uid_ems => 'ovirta_uid_ems',
+                            :switch  => distributed_virtual_switch)
+
+          FactoryBot.create(:lan,
+                            :name    => 'oVirtB',
+                            :uid_ems => 'ovirtb_uid_ems',
+                            :switch  => distributed_virtual_switch)
+        end
+
+        context 'edit network' do
+          subject { vm.build_config_spec(edit_specs)['networkAdapters'][:edit].first }
+
+          it { is_expected.to include(:network => 'oVirtB', :name => 'nic1', :vnic_profile_id => 'ovirtb_uid_ems', :nic_id => 'nic1_uid_ems') }
+        end
+
+        context 'add network' do
+          subject { vm.build_config_spec(add_specs)['networkAdapters'][:add].first }
+
+          it { is_expected.to include(:network => 'oVirtA', :name => 'nic2', :vnic_profile_id => 'ovirta_uid_ems') }
+        end
+      end
+
+      context 'external lan' do
+        let!(:external_distributed_virtual_switch) do
+          FactoryBot.create(:external_distributed_virtual_switch_redhat,
+                            :ems_id => ems.id,
+                            :name   => 'ext_network')
+        end
+
+        let!(:ext_lan) do
+          FactoryBot.create(:lan,
+                            :name    => 'ext_lan',
+                            :uid_ems => 'ext_net_uid_ems',
+                            :switch  => external_distributed_virtual_switch)
+        end
+
+        context 'edit network' do
+          subject { vm.build_config_spec(options)['networkAdapters'][:edit].first }
+
+          let :options do
+            {:network_adapter_edit => [{'network' => 'ext_lan/ext_network', 'name' => 'nic1'}]}
+          end
+
+          it { is_expected.to include(:network => 'ext_lan/ext_network', :name => 'nic1', :vnic_profile_id => 'ext_net_uid_ems', :nic_id => 'nic1_uid_ems') }
+        end
+
+        context 'add network' do
+          subject { vm.build_config_spec(options)['networkAdapters'][:add].first }
+
+          let :options do
+            {:network_adapter_add => [{'network' => 'ext_lan/ext_network', 'name' => 'nic1'}]}
+          end
+
+          it { is_expected.to include(:network => 'ext_lan/ext_network', :name => 'nic2', :vnic_profile_id => 'ext_net_uid_ems') }
+        end
+      end
+
+      context 'remove network' do
+        subject { vm.build_config_spec(remove_specs)['networkAdapters'][:remove].first }
+
+        it { is_expected.to include(:network => 'ovirtmgmt', :name => 'nic1', :mac_address => '56:6f:85:ae:00:00', :nic_id => nic1.uid_ems) }
+      end
+
+      context 'edit lan errors' do
+        it_behaves_like 'not available lan', 'oVirtA' do
+          let(:specs) { edit_specs }
+        end
+      end
+
+      context 'add lan errors' do
+        it_behaves_like 'not available lan', 'oVirtA' do
+          let(:specs) { add_specs }
+        end
+      end
+
+      context 'edit nic errors' do
+        it_behaves_like 'nic not found' do
+          let(:specs) do
+            {:network_adapter_edit => [{'network' => 'oVirtB',
+                                        'name'    => 'not_existing_nic'}]}
+          end
+        end
+      end
+
+      context 'add nic errors' do
+        it_behaves_like 'nic not found' do
+          let(:specs) do
+            {:network_adapter_remove => [{'network' => {'name'      => 'not_existing_nic',
+                                                        'vlan'      => 'ovirtmgmt',
+                                                        'mac'       => '56:6f:85:ae:00:00',
+                                                        '$$hashKey' => 'object:51'}}]}
+          end
+        end
+      end
+    end
+  end
+
+  describe '#suggest_nic_name' do
+    subject { vm.suggest_nic_name(nics) }
+
+    context 'no nics' do
+      let(:nics) { %w[] }
+
+      it { is_expected.to eq('nic1') }
+    end
+
+    context 'one nic' do
+      let(:nics) { ['nic1'] }
+
+      it { is_expected.to eq('nic2') }
+    end
+
+    context 'more nics' do
+      let(:nics) { %w[nic1 nic20 nic10 nic2] }
+
+      it { is_expected.to eq('nic21') }
+    end
+
+    context 'only nics with non standard names' do
+      let(:nics) { %w[ext3 lo10] }
+
+      it { is_expected.to eq('nic1') }
+    end
+
+    context 'nics with standard and non standard names' do
+      let(:nics) { %w[nic14 ext3 lo10 nic2] }
+
+      it { is_expected.to eq('nic15') }
     end
   end
 end


### PR DESCRIPTION
Vm reconfiguration extended to NICs, allowing
user to add, remove and edit VM network interfaces

Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/480

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1751151