### PR TITLE
Fix constant redefinition warnings in specs

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresh_recording_modifier_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresh_recording_modifier_spec.rb
@@ -4,16 +4,17 @@ require_relative 'ovirt_refresher_spec_common'
 describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   include OvirtRefresherSpecCommon
 
+  let(:orig_yml_path) { 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze }
+
   before(:each) do
     init_defaults
     init_connection_vcr
-    stub_const('ORIG_YML_PATH', 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze)
   end
 
   it "will modify the refresh recording correctly" do
     # TODO: @borod108 fix to work with network remodeling
     pending
-    original_yml = YAML.load_file(ORIG_YML_PATH)
+    original_yml = YAML.load_file(orig_yml_path)
     rec_mod = RecordingModifier.new(:yml => original_yml)
     2.times { rec_mod.add_vm_with_inv }
     2.times { rec_mod.add_template_with_inv }

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresh_recording_modifier_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresh_recording_modifier_spec.rb
@@ -7,9 +7,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults
     init_connection_vcr
+    stub_const('ORIG_YML_PATH', 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze)
   end
-
-  ORIG_YML_PATH = 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze
 
   it "will modify the refresh recording correctly" do
     # TODO: @borod108 fix to work with network remodeling

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_template_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_template_spec.rb
@@ -3,10 +3,11 @@ require_relative 'ovirt_refresher_spec_common'
 describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   include OvirtRefresherSpecCommon
 
+  let(:counted_models) { [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze }
+
   before(:each) do
     init_defaults
     init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_graph_target_template.yml')
-    stub_const('COUNTED_MODELS', [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze)
   end
 
   it 'refreshes template host properly when placement_policy defined' do
@@ -21,14 +22,14 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(template.ems_id).to eq(@ems.id)
     expect(template.host_id).to be_present
     saved_template       = template_to_comparable_hash(template)
-    saved_counted_models = COUNTED_MODELS.map { |m| [m.name, m.count] }
+    saved_counted_models = counted_models.map { |m| [m.name, m.count] }
     template.host        = nil
     template.save
     EmsRefresh.refresh(template)
     template.reload
-    counted_models = COUNTED_MODELS.map { |m| [m.name, m.count] }
+    all_counted_models = counted_models.map { |m| [m.name, m.count] }
     expect(saved_template).to eq(template_to_comparable_hash(template))
-    expect(saved_counted_models).to eq(counted_models)
+    expect(saved_counted_models).to eq(all_counted_models)
   end
 
   it 'does not change the template when target refresh after full refresh' do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_template_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_template_spec.rb
@@ -6,9 +6,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults
     init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_graph_target_template.yml')
+    stub_const('COUNTED_MODELS', [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze)
   end
-
-  COUNTED_MODELS = [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze
 
   it 'refreshes template host properly when placement_policy defined' do
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).with(kind_of(Hash)) do |opts|

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_vm_spec.rb
@@ -6,14 +6,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults
     init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_deleted_snapshot.yml')
+    stub_const('COUNTED_MODELS', [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze)
 
     @ovirt_service_inventory = ManageIQ::Providers::Redhat::InfraManager::Inventory
     allow_any_instance_of(@ovirt_service_inventory)
                      .to receive(:collect_vnic_profiles).and_return([])
     @collector = ManageIQ::Providers::Redhat::Inventory::Collector
   end
-
-  COUNTED_MODELS = [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze
 
   it 'does not change the vm when target refresh after full refresh' do
     allow(Spec::Support::OvirtSDK::ConnectionVCR).to receive(:new).with(kind_of(Hash)) do |opts|

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_vm_spec.rb
@@ -51,9 +51,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     vm.save
     EmsRefresh.refresh(vm)
     vm.reload
-    new_counted_models = counted_models.map { |m| [m.name, m.count] }
+    all_counted_models = counted_models.map { |m| [m.name, m.count] }
     expect(saved_vm).to eq(vm_to_comparable_hash(vm))
-    expect(saved_counted_models).to eq(new_counted_models)
+    expect(saved_counted_models).to eq(all_counted_models)
   end
 
   it 'refreshes successfuly after snapshot removal' do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_vm_spec.rb
@@ -3,10 +3,11 @@ require_relative 'ovirt_refresher_spec_common'
 describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   include OvirtRefresherSpecCommon
 
+  let(:counted_models) { [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze }
+
   before(:each) do
     init_defaults
     init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_deleted_snapshot.yml')
-    stub_const('COUNTED_MODELS', [CustomAttribute, EmsFolder, EmsCluster, Datacenter].freeze)
 
     @ovirt_service_inventory = ManageIQ::Providers::Redhat::InfraManager::Inventory
     allow_any_instance_of(@ovirt_service_inventory)
@@ -25,12 +26,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     vm = VmOrTemplate.where(:name => "vm_on").first
     expect(vm.ems_id).to eq(@ems.id)
     saved_vm             = vm_to_comparable_hash(vm)
-    saved_counted_models = COUNTED_MODELS.map { |m| [m.name, m.count] }
+    saved_counted_models = counted_models.map { |m| [m.name, m.count] }
     EmsRefresh.refresh(vm)
     vm.reload
-    counted_models = COUNTED_MODELS.map { |m| [m.name, m.count] }
+    all_counted_models = counted_models.map { |m| [m.name, m.count] }
     expect(saved_vm).to eq(vm_to_comparable_hash(vm))
-    expect(saved_counted_models).to eq(counted_models)
+    expect(saved_counted_models).to eq(all_counted_models)
   end
 
   it 'refreshes vm hosts properly' do
@@ -45,14 +46,14 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(vm.ems_id).to eq(@ems.id)
     expect(vm.host_id).to be_present
     saved_vm             = vm_to_comparable_hash(vm)
-    saved_counted_models = COUNTED_MODELS.map { |m| [m.name, m.count] }
+    saved_counted_models = counted_models.map { |m| [m.name, m.count] }
     vm.host              = nil
     vm.save
     EmsRefresh.refresh(vm)
     vm.reload
-    counted_models = COUNTED_MODELS.map { |m| [m.name, m.count] }
+    new_counted_models = counted_models.map { |m| [m.name, m.count] }
     expect(saved_vm).to eq(vm_to_comparable_hash(vm))
-    expect(saved_counted_models).to eq(counted_models)
+    expect(saved_counted_models).to eq(new_counted_models)
   end
 
   it 'refreshes successfuly after snapshot removal' do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_huge_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_huge_async_spec.rb
@@ -10,9 +10,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   before(:each) do
     init_defaults
     init_connection_vcr
+    stub_const('ORIG_YML_PATH', 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze)
   end
-
-  ORIG_YML_PATH = 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze
 
   it "will perform a full refresh on v4.1" do
     # TODO: @borod108 fix to work with network remodeling

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_huge_async_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_huge_async_spec.rb
@@ -7,17 +7,18 @@ require_relative 'ovirt_refresher_spec_common'
 describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   include OvirtRefresherSpecCommon
 
+  let(:orig_yml_path) { 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze }
+
   before(:each) do
     init_defaults
     init_connection_vcr
-    stub_const('ORIG_YML_PATH', 'spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/ovirt_sdk_refresh_recording_for_mod.yml'.freeze)
   end
 
   it "will perform a full refresh on v4.1" do
     # TODO: @borod108 fix to work with network remodeling
     pending
 
-    original_yml = YAML.load_file(ORIG_YML_PATH)
+    original_yml = YAML.load_file(orig_yml_path)
     rec_mod = RecordingModifier.new(:yml => original_yml)
 
     2.times do


### PR DESCRIPTION
Currently if you run the specs locally you will see the following warnings:

```
spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_vm_spec.rb:16: warning: already initialized constant COUNTED_MODELS
spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_graph_target_template_spec.rb:11: warning: previous definition of COUNTED_MODELS was here
spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_huge_async_spec.rb:15: warning: already initialized constant ORIG_YML_PATH
spec/models/manageiq/providers/redhat/infra_manager/refresher/refresh_recording_modifier_spec.rb:12: warning: previous definition of ORIG_YML_PATH was here
```
~~This PR stubs out the constants properly, with the bonus that these warnings go away.~~

Edit: We can just use `let` here.