### PR TITLE
External networks belong to datacenter

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/datacenter.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/datacenter.rb
@@ -1,2 +1,8 @@
 class ManageIQ::Providers::Redhat::InfraManager::Datacenter < ManageIQ::Providers::InfraManager::Datacenter
+  def distributed_virtual_switches
+    children(:of_type => 'Switch')
+  end
+
+  alias add_distributed_virtual_switch set_child
+  alias remove_distributed_virtual_switch remove_child
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/datacenter.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/datacenter.rb
@@ -3,6 +3,13 @@ class ManageIQ::Providers::Redhat::InfraManager::Datacenter < ManageIQ::Provider
     children(:of_type => 'Switch')
   end
 
-  alias add_distributed_virtual_switch set_child
-  alias remove_distributed_virtual_switch remove_child
+  def external_distributed_virtual_switches
+    distributed_virtual_switches.select do |s|
+      s.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ExternalDistributedVirtualSwitch)
+    end
+  end
+
+  def external_distributed_virtual_lans
+    external_distributed_virtual_switches.map(&:lans).flatten
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/external_distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/external_distributed_virtual_switch.rb
@@ -1,3 +1,12 @@
 class ManageIQ::Providers::Redhat::InfraManager::ExternalDistributedVirtualSwitch < ManageIQ::Providers::InfraManager::DistributedVirtualSwitch
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :external_distributed_virtual_switches, :class_name => "ManageIQ::Providers::Redhat::InfraManager"
+
+  include RelationshipMixin
+  self.default_relationship_type = "ems_metadata"
+
+  def parent_datacenter
+    detect_ancestor(:of_type => "EmsFolder") { |a| a.kind_of?(Datacenter) }
+  end
+
+  alias datacenter parent_datacenter
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/external_distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/external_distributed_virtual_switch.rb
@@ -7,6 +7,4 @@ class ManageIQ::Providers::Redhat::InfraManager::ExternalDistributedVirtualSwitc
   def parent_datacenter
     detect_ancestor(:of_type => "EmsFolder") { |a| a.kind_of?(Datacenter) }
   end
-
-  alias datacenter parent_datacenter
 end

--- a/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
@@ -29,12 +29,7 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
     add_snapshots
     add_storages
 
-    add_collection(infra, :parent_blue_folders)
-    add_collection(infra, :root_folder_relationship)
-    add_collection(infra, :vm_resource_pools)
-    add_collection(infra, :vm_parent_blue_folders)
     add_collection(infra, :distributed_virtual_switches)
-
     add_collection(infra, :external_distributed_virtual_switches) do |builder|
       builder.add_properties(
         :manager_ref          => %i[uid_ems],
@@ -52,6 +47,10 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
         :complete                     => !targeted?
       )
     end
+    add_collection(infra, :parent_blue_folders)
+    add_collection(infra, :root_folder_relationship)
+    add_collection(infra, :vm_resource_pools)
+    add_collection(infra, :vm_parent_blue_folders)
   end
 
   # group :clusters

--- a/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
@@ -18,7 +18,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
       builder.add_properties(:model_class => Lan)
       builder.add_properties(:complete => !targeted?)
     end
-
     add_collection(infra, :networks)
     add_collection(infra, :operating_systems)
     add_collection(infra, :vms)
@@ -38,7 +37,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
       )
       builder.add_default_values(:ems_id => ->(persister) { persister.manager.id })
     end
-
     add_collection(infra, :external_distributed_virtual_lans) do |builder|
       builder.add_properties(
         :manager_ref                  => %i[switch uid_ems],
@@ -48,6 +46,9 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
       )
     end
     add_collection(infra, :parent_blue_folders)
+
+    add_parent_blue_folders
+
     add_collection(infra, :root_folder_relationship)
     add_collection(infra, :vm_resource_pools)
     add_collection(infra, :vm_parent_blue_folders)
@@ -106,6 +107,16 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
         :manager_ref => %i(uid),
         :strategy    => :local_db_find_missing_references,
       )
+    end
+  end
+
+  def add_parent_blue_folders
+    add_collection(infra, :parent_blue_folders) do |builder|
+      dependency_collections = %i[clusters ems_folders datacenters hosts resource_pools storages distributed_virtual_switches external_distributed_virtual_switches]
+      dependency_attributes = dependency_collections.each_with_object({}) do |collection, hash|
+        hash[collection] = ->(persister) { [persister.collections[collection]].compact }
+      end
+      builder.add_dependency_attributes(dependency_attributes)
     end
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_multi_datacenter_network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_multi_datacenter_network_spec.rb
@@ -25,18 +25,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     dc2 = Datacenter.where(:uid_ems => 'f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd').first
     dc3 = Datacenter.where(:uid_ems => '2c4d1610-6b88-4330-a745-26e1f2b4ad97').first
 
-    expect(dc1.distributed_virtual_switches.count).to eq(1)
-    expect(dc2.distributed_virtual_switches.count).to eq(0)
-    expect(dc3.distributed_virtual_switches.count).to eq(1)
+    expect(dc1.external_distributed_virtual_switches.count).to eq(1)
+    expect(dc2.external_distributed_virtual_switches.count).to eq(0)
+    expect(dc3.external_distributed_virtual_switches.count).to eq(1)
 
-    # the following samples works with datacenter_id into switch schema migration
-    # expect(dc1.external_distributed_virtual_switches.count).to eq(1)
-    # expect(dc1.external_distributed_virtual_lans.count).to eq(1)
-
-    # expect(dc2.external_distributed_virtual_switches.count).to eq(0)
-    # expect(dc2.external_distributed_virtual_lans.count).to eq(0)
-
-    # expect(dc3.external_distributed_virtual_switches.count).to eq(1)
-    # expect(dc3.external_distributed_virtual_lans.count).to eq(1)
+    expect(dc1.external_distributed_virtual_lans.count).to eq(1)
+    expect(dc2.external_distributed_virtual_lans.count).to eq(0)
+    expect(dc3.external_distributed_virtual_lans.count).to eq(1)
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_multi_datacenter_network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_multi_datacenter_network_spec.rb
@@ -1,0 +1,42 @@
+require 'fog/openstack'
+require_relative 'ovirt_refresher_spec_common'
+
+describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
+  include OvirtRefresherSpecCommon
+
+  before(:each) do
+    init_defaults(:hostname => 'engine-43.lab.inz.redhat.com', :port => 443)
+    init_connection_vcr('spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_multi_datacenter_network_recording.yml')
+  end
+
+  it 'external networks belong to dc' do
+    EmsRefresh.refresh(@ems)
+    VCR.use_cassette("#{described_class.parent.name.underscore}/refresh/refresher_multi_external_network_ovn_provider") do
+      Fog::OpenStack.instance_variable_set(:@version, nil)
+      EmsRefresh.refresh(@ems.network_manager)
+    end
+    @ems.reload
+
+    expect(ManageIQ::Providers::Redhat::InfraManager::Datacenter.count).to eq(3)
+    expect(ManageIQ::Providers::Redhat::InfraManager::DistributedVirtualSwitch.count).to eq(6)
+    expect(ManageIQ::Providers::Redhat::InfraManager::ExternalDistributedVirtualSwitch.count).to eq(2)
+
+    dc1 = Datacenter.where(:uid_ems => '5ca0335c-be48-4cf4-acd3-283763cb7e04').first
+    dc2 = Datacenter.where(:uid_ems => 'f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd').first
+    dc3 = Datacenter.where(:uid_ems => '2c4d1610-6b88-4330-a745-26e1f2b4ad97').first
+
+    expect(dc1.distributed_virtual_switches.count).to eq(1)
+    expect(dc2.distributed_virtual_switches.count).to eq(0)
+    expect(dc3.distributed_virtual_switches.count).to eq(1)
+
+    # the following samples works with datacenter_id into switch schema migration
+    # expect(dc1.external_distributed_virtual_switches.count).to eq(1)
+    # expect(dc1.external_distributed_virtual_lans.count).to eq(1)
+
+    # expect(dc2.external_distributed_virtual_switches.count).to eq(0)
+    # expect(dc2.external_distributed_virtual_lans.count).to eq(0)
+
+    # expect(dc3.external_distributed_virtual_switches.count).to eq(1)
+    # expect(dc3.external_distributed_virtual_lans.count).to eq(1)
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_multi_datacenter_network_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_multi_datacenter_network_recording.yml
@@ -1,0 +1,4854 @@
+---
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/clusters{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <clusters>
+        <cluster href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125" id="1930506d-e424-4a3e-8262-9c5d7bcd5125">
+            <actions>
+                <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/resetemulatedmachine" rel="resetemulatedmachine"/>
+                <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/syncallnetworks" rel="syncallnetworks"/>
+            </actions>
+            <name>depot-cl</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/glusterhooks" rel="glusterhooks"/>
+            <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/networkfilters" rel="networkfilters"/>
+            <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/glustervolumes" rel="glustervolumes"/>
+            <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/enabledfeatures" rel="enabledfeatures"/>
+            <link href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125/affinitygroups" rel="affinitygroups"/>
+            <ballooning_enabled>false</ballooning_enabled>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <type>Intel Nehalem Family</type>
+            </cpu>
+            <custom_scheduling_policy_properties>
+                <property>
+                    <name>HighUtilization</name>
+                    <value>80</value>
+                </property>
+                <property>
+                    <name>CpuOverCommitDurationMinutes</name>
+                    <value>2</value>
+                </property>
+            </custom_scheduling_policy_properties>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_connectivity_broken>
+                    <enabled>true</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+                <skip_if_gluster_bricks_up>false</skip_if_gluster_bricks_up>
+                <skip_if_gluster_quorum_not_met>false</skip_if_gluster_quorum_not_met>
+                <skip_if_sd_active>
+                    <enabled>true</enabled>
+                </skip_if_sd_active>
+            </fencing_policy>
+            <firewall_type>firewalld</firewall_type>
+            <gluster_service>false</gluster_service>
+            <ha_reservation>false</ha_reservation>
+            <ksm>
+                <enabled>false</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <log_max_memory_used_threshold>95</log_max_memory_used_threshold>
+            <log_max_memory_used_threshold_type>percentage</log_max_memory_used_threshold_type>
+            <memory_policy>
+                <over_commit>
+                    <percent>100</percent>
+                </over_commit>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <bandwidth>
+                    <assignment_method>auto</assignment_method>
+                </bandwidth>
+                <compressed>inherit</compressed>
+                <policy id="80554327-0569-496b-bdeb-fcbbf52b827b"/>
+            </migration>
+            <required_rng_sources>
+                <required_rng_source>urandom</required_rng_source>
+            </required_rng_sources>
+            <switch_type>legacy</switch_type>
+            <threads_as_cores>false</threads_as_cores>
+            <trusted_service>false</trusted_service>
+            <tunnel_migration>false</tunnel_migration>
+            <version>
+                <major>4</major>
+                <minor>3</minor>
+            </version>
+            <virt_service>true</virt_service>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+            <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812"/>
+        </cluster>
+        <cluster href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c" id="e8e70184-251c-4921-9b13-ab2970a92d2c">
+            <actions>
+                <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/resetemulatedmachine" rel="resetemulatedmachine"/>
+                <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/syncallnetworks" rel="syncallnetworks"/>
+            </actions>
+            <name>H1-Local</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/glusterhooks" rel="glusterhooks"/>
+            <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/networkfilters" rel="networkfilters"/>
+            <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/glustervolumes" rel="glustervolumes"/>
+            <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/enabledfeatures" rel="enabledfeatures"/>
+            <link href="/ovirt-engine/api/clusters/e8e70184-251c-4921-9b13-ab2970a92d2c/affinitygroups" rel="affinitygroups"/>
+            <ballooning_enabled>false</ballooning_enabled>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <type>Intel Skylake Client IBRS SSBD Family</type>
+            </cpu>
+            <custom_scheduling_policy_properties>
+                <property>
+                    <name>HighUtilization</name>
+                    <value>80</value>
+                </property>
+                <property>
+                    <name>CpuOverCommitDurationMinutes</name>
+                    <value>2</value>
+                </property>
+            </custom_scheduling_policy_properties>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_connectivity_broken>
+                    <enabled>false</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+                <skip_if_gluster_bricks_up>false</skip_if_gluster_bricks_up>
+                <skip_if_gluster_quorum_not_met>false</skip_if_gluster_quorum_not_met>
+                <skip_if_sd_active>
+                    <enabled>false</enabled>
+                </skip_if_sd_active>
+            </fencing_policy>
+            <firewall_type>firewalld</firewall_type>
+            <gluster_service>false</gluster_service>
+            <ha_reservation>false</ha_reservation>
+            <ksm>
+                <enabled>false</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <log_max_memory_used_threshold>95</log_max_memory_used_threshold>
+            <log_max_memory_used_threshold_type>percentage</log_max_memory_used_threshold_type>
+            <memory_policy>
+                <over_commit>
+                    <percent>100</percent>
+                </over_commit>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <bandwidth>
+                    <assignment_method>auto</assignment_method>
+                </bandwidth>
+                <compressed>inherit</compressed>
+            </migration>
+            <required_rng_sources>
+                <required_rng_source>urandom</required_rng_source>
+            </required_rng_sources>
+            <switch_type>legacy</switch_type>
+            <threads_as_cores>false</threads_as_cores>
+            <trusted_service>false</trusted_service>
+            <tunnel_migration>false</tunnel_migration>
+            <version>
+                <major>4</major>
+                <minor>3</minor>
+            </version>
+            <virt_service>true</virt_service>
+            <data_center href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd" id="f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd"/>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+            <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812"/>
+        </cluster>
+        <cluster href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b" id="a703ad0d-42d6-4946-af31-98b64f3b0d1b">
+            <actions>
+                <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/resetemulatedmachine" rel="resetemulatedmachine"/>
+                <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/syncallnetworks" rel="syncallnetworks"/>
+            </actions>
+            <name>H1-Local1</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/glusterhooks" rel="glusterhooks"/>
+            <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/networkfilters" rel="networkfilters"/>
+            <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/glustervolumes" rel="glustervolumes"/>
+            <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/enabledfeatures" rel="enabledfeatures"/>
+            <link href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b/affinitygroups" rel="affinitygroups"/>
+            <ballooning_enabled>false</ballooning_enabled>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <type>Intel Skylake Client IBRS SSBD Family</type>
+            </cpu>
+            <custom_scheduling_policy_properties>
+                <property>
+                    <name>HighUtilization</name>
+                    <value>80</value>
+                </property>
+                <property>
+                    <name>CpuOverCommitDurationMinutes</name>
+                    <value>2</value>
+                </property>
+            </custom_scheduling_policy_properties>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_connectivity_broken>
+                    <enabled>false</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+                <skip_if_gluster_bricks_up>false</skip_if_gluster_bricks_up>
+                <skip_if_gluster_quorum_not_met>false</skip_if_gluster_quorum_not_met>
+                <skip_if_sd_active>
+                    <enabled>false</enabled>
+                </skip_if_sd_active>
+            </fencing_policy>
+            <firewall_type>firewalld</firewall_type>
+            <gluster_service>false</gluster_service>
+            <ha_reservation>false</ha_reservation>
+            <ksm>
+                <enabled>false</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <log_max_memory_used_threshold>95</log_max_memory_used_threshold>
+            <log_max_memory_used_threshold_type>percentage</log_max_memory_used_threshold_type>
+            <memory_policy>
+                <over_commit>
+                    <percent>100</percent>
+                </over_commit>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <bandwidth>
+                    <assignment_method>auto</assignment_method>
+                </bandwidth>
+                <compressed>inherit</compressed>
+            </migration>
+            <required_rng_sources>
+                <required_rng_source>urandom</required_rng_source>
+            </required_rng_sources>
+            <switch_type>legacy</switch_type>
+            <threads_as_cores>false</threads_as_cores>
+            <trusted_service>false</trusted_service>
+            <tunnel_migration>false</tunnel_migration>
+            <version>
+                <major>4</major>
+                <minor>3</minor>
+            </version>
+            <virt_service>true</virt_service>
+            <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97"/>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+            <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812"/>
+        </cluster>
+        <cluster href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0" id="b070c619-ef8e-4d24-8571-1920a622fde0">
+            <actions>
+                <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/resetemulatedmachine" rel="resetemulatedmachine"/>
+                <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/syncallnetworks" rel="syncallnetworks"/>
+            </actions>
+            <name>secondary-depot</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/glusterhooks" rel="glusterhooks"/>
+            <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/networkfilters" rel="networkfilters"/>
+            <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/glustervolumes" rel="glustervolumes"/>
+            <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/enabledfeatures" rel="enabledfeatures"/>
+            <link href="/ovirt-engine/api/clusters/b070c619-ef8e-4d24-8571-1920a622fde0/affinitygroups" rel="affinitygroups"/>
+            <ballooning_enabled>false</ballooning_enabled>
+            <cpu>
+                <architecture>undefined</architecture>
+                <type></type>
+            </cpu>
+            <custom_scheduling_policy_properties>
+                <property>
+                    <name>HighUtilization</name>
+                    <value>80</value>
+                </property>
+                <property>
+                    <name>CpuOverCommitDurationMinutes</name>
+                    <value>2</value>
+                </property>
+            </custom_scheduling_policy_properties>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_connectivity_broken>
+                    <enabled>true</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+                <skip_if_gluster_bricks_up>false</skip_if_gluster_bricks_up>
+                <skip_if_gluster_quorum_not_met>false</skip_if_gluster_quorum_not_met>
+                <skip_if_sd_active>
+                    <enabled>true</enabled>
+                </skip_if_sd_active>
+            </fencing_policy>
+            <firewall_type>firewalld</firewall_type>
+            <gluster_service>false</gluster_service>
+            <ha_reservation>false</ha_reservation>
+            <ksm>
+                <enabled>false</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <log_max_memory_used_threshold>95</log_max_memory_used_threshold>
+            <log_max_memory_used_threshold_type>percentage</log_max_memory_used_threshold_type>
+            <memory_policy>
+                <over_commit>
+                    <percent>100</percent>
+                </over_commit>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <bandwidth>
+                    <assignment_method>auto</assignment_method>
+                </bandwidth>
+                <compressed>inherit</compressed>
+                <policy id="80554327-0569-496b-bdeb-fcbbf52b827b"/>
+            </migration>
+            <required_rng_sources>
+                <required_rng_source>urandom</required_rng_source>
+            </required_rng_sources>
+            <switch_type>legacy</switch_type>
+            <threads_as_cores>false</threads_as_cores>
+            <trusted_service>false</trusted_service>
+            <tunnel_migration>false</tunnel_migration>
+            <version>
+                <major>4</major>
+                <minor>3</minor>
+            </version>
+            <virt_service>true</virt_service>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+            <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812"/>
+        </cluster>
+        <cluster href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025" id="28b64100-f6fe-4f3a-9195-1e008915f025">
+            <actions>
+                <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/resetemulatedmachine" rel="resetemulatedmachine"/>
+                <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/syncallnetworks" rel="syncallnetworks"/>
+            </actions>
+            <name>spare-depot</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/externalnetworkproviders" rel="externalnetworkproviders"/>
+            <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/glusterhooks" rel="glusterhooks"/>
+            <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/networkfilters" rel="networkfilters"/>
+            <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/glustervolumes" rel="glustervolumes"/>
+            <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/enabledfeatures" rel="enabledfeatures"/>
+            <link href="/ovirt-engine/api/clusters/28b64100-f6fe-4f3a-9195-1e008915f025/affinitygroups" rel="affinitygroups"/>
+            <ballooning_enabled>false</ballooning_enabled>
+            <cpu>
+                <architecture>undefined</architecture>
+                <type></type>
+            </cpu>
+            <custom_scheduling_policy_properties>
+                <property>
+                    <name>HighUtilization</name>
+                    <value>80</value>
+                </property>
+                <property>
+                    <name>CpuOverCommitDurationMinutes</name>
+                    <value>2</value>
+                </property>
+            </custom_scheduling_policy_properties>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_connectivity_broken>
+                    <enabled>true</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+                <skip_if_gluster_bricks_up>false</skip_if_gluster_bricks_up>
+                <skip_if_gluster_quorum_not_met>false</skip_if_gluster_quorum_not_met>
+                <skip_if_sd_active>
+                    <enabled>true</enabled>
+                </skip_if_sd_active>
+            </fencing_policy>
+            <firewall_type>firewalld</firewall_type>
+            <gluster_service>false</gluster_service>
+            <ha_reservation>false</ha_reservation>
+            <ksm>
+                <enabled>false</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <log_max_memory_used_threshold>95</log_max_memory_used_threshold>
+            <log_max_memory_used_threshold_type>percentage</log_max_memory_used_threshold_type>
+            <memory_policy>
+                <over_commit>
+                    <percent>100</percent>
+                </over_commit>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <bandwidth>
+                    <assignment_method>auto</assignment_method>
+                </bandwidth>
+                <compressed>inherit</compressed>
+                <policy id="80554327-0569-496b-bdeb-fcbbf52b827b"/>
+            </migration>
+            <required_rng_sources>
+                <required_rng_source>urandom</required_rng_source>
+            </required_rng_sources>
+            <switch_type>legacy</switch_type>
+            <threads_as_cores>false</threads_as_cores>
+            <trusted_service>false</trusted_service>
+            <tunnel_migration>false</tunnel_migration>
+            <version>
+                <major>4</major>
+                <minor>3</minor>
+            </version>
+            <virt_service>true</virt_service>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+            <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812"/>
+        </cluster>
+    </clusters>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:11 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '1920'
+    correlation-id: 70636b19-eb20-42fb-8072-00e52b9b8d43
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>depot-data1</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/vms" rel="vms"/>
+            <available>522912268288</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>45097156608</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <storage>
+                <address>depot.lab.inz.redhat.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/data1</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>12884901888</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506" id="18f2ed09-c043-4709-8c69-b335f1b79506">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>depot-data2</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/vms" rel="vms"/>
+            <available>522912268288</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <storage>
+                <address>depot.lab.inz.redhat.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/data2</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>12884901888</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859" id="218bc2c4-de36-4e7b-be7a-49fd5ac57859">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>H1-local-data-first-chunk</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/vms" rel="vms"/>
+            <available>4294967296</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <storage>
+                <path>/data/host01_local_data_first_chunk_of_the_ones_available</path>
+                <type>localfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>2147483648</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a" id="fcea1e91-aed4-438c-955b-ea462082e59a">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>H1-Local-data-second-chunk</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/vms" rel="vms"/>
+            <available>13958643712</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <storage>
+                <path>/var/host01_local_data_second_chunk_of_the_ones_available</path>
+                <type>localfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>1073741824</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee" id="c1b11db0-278c-477c-a594-f149c211d9ee">
+            <actions>
+                <link href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/updateovfstore" rel="updateovfstore"/>
+                <link href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/reduceluns" rel="reduceluns"/>
+            </actions>
+            <name>iso</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/files" rel="files"/>
+            <link href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/permissions" rel="permissions"/>
+            <available>522912268288</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <storage>
+                <address>depot.lab.inz.redhat.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/ISO</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>12884901888</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '1311'
+    correlation-id: 938c8ec6-0b33-4002-9236-55a5d290e527
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <hosts>
+        <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0">
+            <actions>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/refresh" rel="refresh"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/install" rel="install"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/approve" rel="approve"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/commitnetconfig" rel="commitnetconfig"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/enrollcertificate" rel="enrollcertificate"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/fence" rel="fence"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/forceselectspm" rel="forceselectspm"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/iscsidiscover" rel="iscsidiscover"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/iscsilogin" rel="iscsilogin"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/unregisteredstoragedomainsdiscover" rel="unregisteredstoragedomainsdiscover"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/upgradecheck" rel="upgradecheck"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/setupnetworks" rel="setupnetworks"/>
+            </actions>
+            <name>H1</name>
+            <comment></comment>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/fenceagents" rel="fenceagents"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/devices" rel="devices"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/hooks" rel="hooks"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/storage" rel="storage"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/storageconnectionextensions" rel="storageconnectionextensions"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/unmanagednetworks" rel="unmanagednetworks"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics" rel="statistics"/>
+            <address>host01-43.lab.inz.redhat.com</address>
+            <auto_numa_status>disable</auto_numa_status>
+            <certificate>
+                <organization>lab.inz.redhat.com</organization>
+                <subject>O=lab.inz.redhat.com,CN=host01-43.lab.inz.redhat.com</subject>
+            </certificate>
+            <cpu>
+                <name>Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz</name>
+                <speed>3696</speed>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+                <type>Intel Skylake Client IBRS SSBD Family</type>
+            </cpu>
+            <device_passthrough>
+                <enabled>false</enabled>
+            </device_passthrough>
+            <external_status>ok</external_status>
+            <hardware_information>
+                <family>Red Hat Enterprise Linux</family>
+                <manufacturer>Red Hat</manufacturer>
+                <product_name>KVM</product_name>
+                <supported_rng_sources>
+                    <supported_rng_source>hwrng</supported_rng_source>
+                    <supported_rng_source>random</supported_rng_source>
+                </supported_rng_sources>
+                <uuid>E1321EE2-55DB-4FBC-ABD0-2182DC63D655</uuid>
+                <version>RHEL 7.6.0 PC (i440FX + PIIX, 1996)</version>
+            </hardware_information>
+            <iscsi>
+                <initiator>iqn.1994-05.com.redhat:6264754203b2</initiator>
+            </iscsi>
+            <kdump_status>disabled</kdump_status>
+            <ksm>
+                <enabled>false</enabled>
+            </ksm>
+            <libvirt_version>
+                <build>0</build>
+                <full_version>libvirt-4.5.0-23.el7_7.1</full_version>
+                <major>4</major>
+                <minor>5</minor>
+                <revision>0</revision>
+            </libvirt_version>
+            <max_scheduling_memory>7796162560</max_scheduling_memory>
+            <memory>8200912896</memory>
+            <numa_supported>false</numa_supported>
+            <os>
+                <custom_kernel_cmdline></custom_kernel_cmdline>
+                <reported_kernel_cmdline>BOOT_IMAGE=/rhvh-4.3.6.2-0.20190924.0+1/vmlinuz-3.10.0-1062.1.2.el7.x86_64 root=/dev/rhvh/rhvh-4.3.6.2-0.20190924.0+1 ro crashkernel=auto spectre_v2=retpoline rd.lvm.lv=rhvh/rhvh-4.3.6.2-0.20190924.0+1 rd.lvm.lv=rhvh/swap rhgb quiet LANG=en_US.UTF-8 img.bootid=rhvh-4.3.6.2-0.20190924.0+1</reported_kernel_cmdline>
+                <type>RHEL</type>
+                <version>
+                    <full_version>7.7 - 2.el7ev</full_version>
+                    <major>7</major>
+                    <minor>7</minor>
+                </version>
+            </os>
+            <port>54321</port>
+            <power_management>
+                <automatic_pm_enabled>true</automatic_pm_enabled>
+                <enabled>false</enabled>
+                <kdump_detection>true</kdump_detection>
+                <pm_proxies/>
+            </power_management>
+            <protocol>stomp</protocol>
+            <se_linux>
+                <mode>enforcing</mode>
+            </se_linux>
+            <spm>
+                <priority>5</priority>
+                <status>spm</status>
+            </spm>
+            <ssh>
+                <fingerprint>SHA256:H+EHKUKxIC7XL3Efg8YtmQbig+ApcxlI7zAU+MmaQGU</fingerprint>
+                <port>22</port>
+            </ssh>
+            <status>up</status>
+            <summary>
+                <active>0</active>
+                <migrating>0</migrating>
+                <total>0</total>
+            </summary>
+            <transparent_hugepages>
+                <enabled>true</enabled>
+            </transparent_hugepages>
+            <type>ovirt_node</type>
+            <update_available>false</update_available>
+            <version>
+                <build>33</build>
+                <full_version>vdsm-4.30.33-1.el7ev</full_version>
+                <major>4</major>
+                <minor>30</minor>
+                <revision>0</revision>
+            </version>
+            <vgpu_placement>consolidated</vgpu_placement>
+            <cluster href="/ovirt-engine/api/clusters/a703ad0d-42d6-4946-af31-98b64f3b0d1b" id="a703ad0d-42d6-4946-af31-98b64f3b0d1b"/>
+        </host>
+        <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e">
+            <actions>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/refresh" rel="refresh"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/install" rel="install"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/approve" rel="approve"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/commitnetconfig" rel="commitnetconfig"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/enrollcertificate" rel="enrollcertificate"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/fence" rel="fence"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/forceselectspm" rel="forceselectspm"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/iscsidiscover" rel="iscsidiscover"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/iscsilogin" rel="iscsilogin"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/unregisteredstoragedomainsdiscover" rel="unregisteredstoragedomainsdiscover"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/upgradecheck" rel="upgradecheck"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/upgrade" rel="upgrade"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/syncallnetworks" rel="syncallnetworks"/>
+                <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/setupnetworks" rel="setupnetworks"/>
+            </actions>
+            <name>H2</name>
+            <comment></comment>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/fenceagents" rel="fenceagents"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/devices" rel="devices"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/hooks" rel="hooks"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/storage" rel="storage"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/storageconnectionextensions" rel="storageconnectionextensions"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/unmanagednetworks" rel="unmanagednetworks"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/externalnetworkproviderconfigurations" rel="externalnetworkproviderconfigurations"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics" rel="statistics"/>
+            <address>host02-43.lab.inz.redhat.com</address>
+            <auto_numa_status>disable</auto_numa_status>
+            <certificate>
+                <organization>lab.inz.redhat.com</organization>
+                <subject>O=lab.inz.redhat.com,CN=host02-43.lab.inz.redhat.com</subject>
+            </certificate>
+            <cpu>
+                <name>Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz</name>
+                <speed>3696</speed>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>4</sockets>
+                    <threads>1</threads>
+                </topology>
+                <type>Intel Skylake Client IBRS SSBD Family</type>
+            </cpu>
+            <device_passthrough>
+                <enabled>false</enabled>
+            </device_passthrough>
+            <external_status>ok</external_status>
+            <hardware_information>
+                <family>Red Hat Enterprise Linux</family>
+                <manufacturer>Red Hat</manufacturer>
+                <product_name>KVM</product_name>
+                <supported_rng_sources>
+                    <supported_rng_source>hwrng</supported_rng_source>
+                    <supported_rng_source>random</supported_rng_source>
+                </supported_rng_sources>
+                <uuid>6BC57350-6BDD-4598-8E0B-824182346D2E</uuid>
+                <version>RHEL 7.6.0 PC (i440FX + PIIX, 1996)</version>
+            </hardware_information>
+            <iscsi>
+                <initiator>iqn.1994-05.com.redhat:6264754203b2</initiator>
+            </iscsi>
+            <kdump_status>disabled</kdump_status>
+            <ksm>
+                <enabled>false</enabled>
+            </ksm>
+            <libvirt_version>
+                <build>0</build>
+                <full_version>libvirt-4.5.0-23.el7_7.1</full_version>
+                <major>4</major>
+                <minor>5</minor>
+                <revision>0</revision>
+            </libvirt_version>
+            <max_scheduling_memory>6544162816</max_scheduling_memory>
+            <memory>8200912896</memory>
+            <numa_supported>false</numa_supported>
+            <os>
+                <custom_kernel_cmdline></custom_kernel_cmdline>
+                <reported_kernel_cmdline>BOOT_IMAGE=/rhvh-4.3.6.2-0.20190924.0+1/vmlinuz-3.10.0-1062.1.2.el7.x86_64 root=/dev/rhvh/rhvh-4.3.6.2-0.20190924.0+1 ro crashkernel=auto spectre_v2=retpoline rd.lvm.lv=rhvh/rhvh-4.3.6.2-0.20190924.0+1 rd.lvm.lv=rhvh/swap rhgb quiet LANG=en_US.UTF-8 img.bootid=rhvh-4.3.6.2-0.20190924.0+1</reported_kernel_cmdline>
+                <type>RHEL</type>
+                <version>
+                    <full_version>7.7 - 2.el7ev</full_version>
+                    <major>7</major>
+                    <minor>7</minor>
+                </version>
+            </os>
+            <port>54321</port>
+            <power_management>
+                <automatic_pm_enabled>true</automatic_pm_enabled>
+                <enabled>false</enabled>
+                <kdump_detection>true</kdump_detection>
+                <pm_proxies/>
+            </power_management>
+            <protocol>stomp</protocol>
+            <se_linux>
+                <mode>enforcing</mode>
+            </se_linux>
+            <spm>
+                <priority>5</priority>
+                <status>spm</status>
+            </spm>
+            <ssh>
+                <fingerprint>SHA256:LHAzHsnipu+q5gw43xKxMXuJk7X/JvC9kDn3W1oQGf8</fingerprint>
+                <port>22</port>
+            </ssh>
+            <status>up</status>
+            <summary>
+                <active>1</active>
+                <migrating>0</migrating>
+                <total>1</total>
+            </summary>
+            <transparent_hugepages>
+                <enabled>true</enabled>
+            </transparent_hugepages>
+            <type>ovirt_node</type>
+            <update_available>false</update_available>
+            <version>
+                <build>33</build>
+                <full_version>vdsm-4.30.33-1.el7ev</full_version>
+                <major>4</major>
+                <minor>30</minor>
+                <revision>0</revision>
+            </version>
+            <vgpu_placement>consolidated</vgpu_placement>
+            <cluster href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125" id="1930506d-e424-4a3e-8262-9c5d7bcd5125"/>
+        </host>
+    </hosts>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '2328'
+    correlation-id: 11c567f6-d2bf-4538-bb48-a9f578345fff
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vms>
+        <vm href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056" id="ca7e8d64-0fc7-45de-b258-ae471ea31056">
+            <actions>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/suspend" rel="suspend"/>
+            </actions>
+            <name>Debbie</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/backups" rel="backups"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+                <type>i440fx_sea_bios</type>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2020-01-31T18:37:27.000+01:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <address>192.168.178.49</address>
+                <allow_override>false</allow_override>
+                <certificate>
+                    <content>-----BEGIN CERTIFICATE-----
+    MIIDujCCAqKgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwRTELMAkGA1UEBhMCVVMxEjAQBgNVBAoM
+    CWZyaXR6LmJveDEiMCAGA1UEAwwZZW5naW5lLTQzLmZyaXR6LmJveC41OTIyODAeFw0yMDAxMzAx
+    NjUwMTJaFw0zMDAxMjgxNjUwMTJaMEUxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlmcml0ei5ib3gx
+    IjAgBgNVBAMMGWVuZ2luZS00My5mcml0ei5ib3guNTkyMjgwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+    DwAwggEKAoIBAQDL2j0k5lv67YBeeqCR9oFmO5lmtRDsYirJiGny03DlANISSrudSdnqeYIRPvX8
+    1Pm40LFV0Xsbfv9uENB47ErkWdzSCb88lUCxqtQxNtlU4jGQBfSLkicbxSYIX8cYnVn9mRoyCQdp
+    Q7KDdT3AQDZvTEq2ZfX05fkB+XljuU9gOGtznVseesJ/g9+DYYeDOxNhBHIgcc496ApdrqRGq76E
+    23S0nIEtfLXDLGHf1GKeABMDtr7Xwo+JbyRz7gLMI73N3FN+hRi5cqdPHoccWTZ61Hfm60+1K/LU
+    Biqn2qHhW0wvGk3ua+treCIuJSlnD/g9gPU68TESe7IHIy8CFhoHAgMBAAGjgbMwgbAwHQYDVR0O
+    BBYEFDFDJBEMasp46vRUDRjhft+CKmdqMG4GA1UdIwRnMGWAFDFDJBEMasp46vRUDRjhft+CKmdq
+    oUmkRzBFMQswCQYDVQQGEwJVUzESMBAGA1UECgwJZnJpdHouYm94MSIwIAYDVQQDDBllbmdpbmUt
+    NDMuZnJpdHouYm94LjU5MjI4ggIQADAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAN
+    BgkqhkiG9w0BAQsFAAOCAQEAUDN/+eilZMDJjezuR4E9mWzrdEq+AtKZM1mHa35RSPD1/6+n9kOm
+    yffoU0qYxXbIxG80IiuDB53xK8rGy+2vYst2+eF2r9lZOSlJR8RuoyanwDC96gNytVg7c6orKIy4
+    sLXn1KWX/Fh991T0Bn9xF0HglqcVPD2KtQckGe63+TAKChHM0yx2w48aoJf4O/8Vn0dBh1vBRXIi
+    IpO76MjzLAyED3zWmuqVvWhpISbYi5qaabVnyMzFAKewoijqDj7Sy50mvwf2QlUlQc2o1e29b5cv
+    uoGpwGKats1LYGXvNOYcMhdXqpzmgiouA3nJ1WyDPxqYp1W2N2c1xT+jcDzmJg==
+    -----END CERTIFICATE-----
+    </content>
+                    <organization>lab.inz.redhat.com</organization>
+                    <subject>O=lab.inz.redhat.com,CN=host02-43.lab.inz.redhat.com</subject>
+                </certificate>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <port>5901</port>
+                <secure_port>5902</secure_port>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/8049d860-cf22-4b1b-cf59-d2f228ecb9f2" id="8049d860-cf22-4b1b-cf59-d2f228ecb9f2"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <multi_queues_enabled>true</multi_queues_enabled>
+            <origin>rhev</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other_linux</type>
+            </os>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <small_icon href="/ovirt-engine/api/icons/d6a560d7-054e-4bd6-faee-f0e3132d948d" id="d6a560d7-054e-4bd6-faee-f0e3132d948d"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+            <time_zone>
+                <name>Europe/Budapest</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125" id="1930506d-e424-4a3e-8262-9c5d7bcd5125"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/7e5344a6-3434-445a-9478-d989e1180fcf" id="7e5344a6-3434-445a-9478-d989e1180fcf"/>
+            <quota id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <run_once>false</run_once>
+            <start_time>2020-03-03T11:33:14.840+01:00</start_time>
+            <status>up</status>
+            <stop_time>2020-03-02T20:33:46.389+01:00</stop_time>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0" id="882b9a7c-f3f0-49a3-bda6-1ee289a6adf0">
+            <actions>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/suspend" rel="suspend"/>
+            </actions>
+            <name>rhel_seven</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/backups" rel="backups"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+                <type>i440fx_sea_bios</type>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2020-02-04T09:25:27.000+01:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>true</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <io>
+                <threads>1</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/d451982e-7c98-9329-709c-44fbaa46da26" id="d451982e-7c98-9329-709c-44fbaa46da26"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <multi_queues_enabled>true</multi_queues_enabled>
+            <origin>rhev</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                        <device>cdrom</device>
+                    </devices>
+                </boot>
+                <type>rhel_7x64</type>
+            </os>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <small_icon href="/ovirt-engine/api/icons/a82f7562-5ea9-07b9-cf1c-176e92f9ffaf" id="a82f7562-5ea9-07b9-cf1c-176e92f9ffaf"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>server</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125" id="1930506d-e424-4a3e-8262-9c5d7bcd5125"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/7e5344a6-3434-445a-9478-d989e1180fcf" id="7e5344a6-3434-445a-9478-d989e1180fcf"/>
+            <quota id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <status>down</status>
+            <stop_reason></stop_reason>
+            <stop_time>2020-02-20T21:06:16.748+01:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1" id="a99773ed-28a3-4370-8240-df9e732bc3e1">
+            <actions>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/suspend" rel="suspend"/>
+            </actions>
+            <name>vm_off</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/backups" rel="backups"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+                <type>i440fx_sea_bios</type>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2020-02-03T18:51:47.577+01:00</creation_time>
+            <custom_compatibility_version>
+                <major>4</major>
+                <minor>3</minor>
+            </custom_compatibility_version>
+            <custom_properties>
+                <custom_property>
+                    <name>viodiskcache</name>
+                    <value>writethrough</value>
+                </custom_property>
+            </custom_properties>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>true</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <cloud_init_network_protocol>openstack_metadata</cloud_init_network_protocol>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+                <user_name></user_name>
+            </initialization>
+            <io>
+                <threads>1</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/794fe0d7-daa5-0c21-551b-8c37f89bdeb0" id="794fe0d7-daa5-0c21-551b-8c37f89bdeb0"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <multi_queues_enabled>true</multi_queues_enabled>
+            <origin>rhev</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>debian_7</type>
+            </os>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <small_icon href="/ovirt-engine/api/icons/72056e12-fe3f-4a82-1209-68eeea225831" id="72056e12-fe3f-4a82-1209-68eeea225831"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <type>server</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125" id="1930506d-e424-4a3e-8262-9c5d7bcd5125"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/7e5344a6-3434-445a-9478-d989e1180fcf" id="7e5344a6-3434-445a-9478-d989e1180fcf"/>
+            <quota id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <status>down</status>
+            <stop_reason></stop_reason>
+            <stop_time>2020-02-10T20:00:51.799+01:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59" id="8e418698-62e0-4260-a111-11109aa80c59"/>
+            <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+        </vm>
+        <vm href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a" id="e23898b2-0540-456c-a1ce-0df108c4df9a">
+            <actions>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/commitsnapshot" rel="commitsnapshot"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/undosnapshot" rel="undosnapshot"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/previewsnapshot" rel="previewsnapshot"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/suspend" rel="suspend"/>
+            </actions>
+            <name>vm_on</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/backups" rel="backups"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/affinitylabels" rel="affinitylabels"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/statistics" rel="statistics"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+                <type>i440fx_sea_bios</type>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2020-02-03T18:00:14.659+01:00</creation_time>
+            <custom_properties>
+                <custom_property>
+                    <name>sap_agent</name>
+                    <value>false</value>
+                </custom_property>
+            </custom_properties>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <host_name>vm_on</host_name>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/d451982e-7c98-9329-709c-44fbaa46da26" id="d451982e-7c98-9329-709c-44fbaa46da26"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <multi_queues_enabled>true</multi_queues_enabled>
+            <origin>rhev</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other_linux_kernel_4</type>
+            </os>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <small_icon href="/ovirt-engine/api/icons/a82f7562-5ea9-07b9-cf1c-176e92f9ffaf" id="a82f7562-5ea9-07b9-cf1c-176e92f9ffaf"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+            <time_zone>
+                <name>Europe/Warsaw</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125" id="1930506d-e424-4a3e-8262-9c5d7bcd5125"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/7e5344a6-3434-445a-9478-d989e1180fcf" id="7e5344a6-3434-445a-9478-d989e1180fcf"/>
+            <quota id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+            <status>down</status>
+            <stop_reason></stop_reason>
+            <stop_time>2020-02-10T20:00:52.638+01:00</stop_time>
+            <original_template href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59" id="8e418698-62e0-4260-a111-11109aa80c59"/>
+            <template href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59" id="8e418698-62e0-4260-a111-11109aa80c59"/>
+        </vm>
+    </vms>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '4449'
+    correlation-id: a0e77952-1dcf-4ab6-b418-b4ff4d5862fc
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <templates>
+        <template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000">
+            <actions>
+                <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/export" rel="export"/>
+            </actions>
+            <name>Blank</name>
+            <description>Blank template</description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/tags" rel="tags"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+                <type>i440fx_sea_bios</type>
+            </bios>
+            <cpu>
+                <architecture>undefined</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2008-03-31T23:00:00.000+02:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>0</priority>
+            </high_availability>
+            <io>
+                <threads>1</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/892b9301-2eb6-4cce-a12d-7b184e74ef25" id="892b9301-2eb6-4cce-a12d-7b184e74ef25"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <multi_queues_enabled>true</multi_queues_enabled>
+            <origin>ovirt</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other</type>
+            </os>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <small_icon href="/ovirt-engine/api/icons/7f96b798-4857-4096-ad52-5e2b800c74d4" id="7f96b798-4857-4096-ad52-5e2b800c74d4"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <status>ok</status>
+            <version>
+                <version_name></version_name>
+                <version_number>0</version_number>
+                <base_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
+            </version>
+        </template>
+        <template href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59" id="8e418698-62e0-4260-a111-11109aa80c59">
+            <actions>
+                <link href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/export" rel="export"/>
+            </actions>
+            <name>debTemplate</name>
+            <description>Debian Template</description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/diskattachments" rel="diskattachments"/>
+            <link href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/tags" rel="tags"/>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+                <type>i440fx_sea_bios</type>
+            </bios>
+            <cpu>
+                <architecture>x86_64</architecture>
+                <topology>
+                    <cores>1</cores>
+                    <sockets>1</sockets>
+                    <threads>1</threads>
+                </topology>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <creation_time>2020-02-03T16:51:33.069+01:00</creation_time>
+            <delete_protected>false</delete_protected>
+            <display>
+                <allow_override>false</allow_override>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <smartcard_enabled>false</smartcard_enabled>
+                <type>spice</type>
+            </display>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <initialization>
+                <authorized_ssh_keys></authorized_ssh_keys>
+                <custom_script></custom_script>
+                <nic_configurations/>
+                <regenerate_ssh_keys>false</regenerate_ssh_keys>
+            </initialization>
+            <io>
+                <threads>0</threads>
+            </io>
+            <large_icon href="/ovirt-engine/api/icons/8049d860-cf22-4b1b-cf59-d2f228ecb9f2" id="8049d860-cf22-4b1b-cf59-d2f228ecb9f2"/>
+            <memory>1073741824</memory>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <max>4294967296</max>
+            </memory_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <migration_downtime>-1</migration_downtime>
+            <multi_queues_enabled>true</multi_queues_enabled>
+            <origin>rhev</origin>
+            <os>
+                <boot>
+                    <devices>
+                        <device>hd</device>
+                    </devices>
+                </boot>
+                <type>other_linux</type>
+            </os>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <small_icon href="/ovirt-engine/api/icons/d6a560d7-054e-4bd6-faee-f0e3132d948d" id="d6a560d7-054e-4bd6-faee-f0e3132d948d"/>
+            <sso>
+                <methods>
+                    <method id="guest_agent"/>
+                </methods>
+            </sso>
+            <start_paused>false</start_paused>
+            <stateless>false</stateless>
+            <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+            <time_zone>
+                <name>Europe/Budapest</name>
+            </time_zone>
+            <type>desktop</type>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <cluster href="/ovirt-engine/api/clusters/1930506d-e424-4a3e-8262-9c5d7bcd5125" id="1930506d-e424-4a3e-8262-9c5d7bcd5125"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/7e5344a6-3434-445a-9478-d989e1180fcf" id="7e5344a6-3434-445a-9478-d989e1180fcf"/>
+            <status>ok</status>
+            <version>
+                <version_name>base version</version_name>
+                <version_number>1</version_number>
+                <base_template href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59" id="8e418698-62e0-4260-a111-11109aa80c59"/>
+            </version>
+        </template>
+    </templates>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '1581'
+    correlation-id: 7983967f-4d2a-4ef7-b269-176731037675
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/networks{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <networks>
+        <network href="/ovirt-engine/api/networks/6a0cb90c-16ac-47ae-b262-ac382b2c42e5" id="6a0cb90c-16ac-47ae-b262-ac382b2c42e5">
+            <name>extNetwork</name>
+            <description>External Network</description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/networks/6a0cb90c-16ac-47ae-b262-ac382b2c42e5/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/6a0cb90c-16ac-47ae-b262-ac382b2c42e5/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/6a0cb90c-16ac-47ae-b262-ac382b2c42e5/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            <external_provider href="/ovirt-engine/api/openstacknetworkproviders/e729290a-bec2-46dc-a315-b1bb14fd1071" id="e729290a-bec2-46dc-a315-b1bb14fd1071"/>
+            <external_provider_physical_network href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb" id="dac27d35-5858-4663-abd2-bf087050b3eb"/>
+        </network>
+        <network href="/ovirt-engine/api/networks/8d9ca8a2-44ed-4795-8e5a-a7a7a09ddbd2" id="8d9ca8a2-44ed-4795-8e5a-a7a7a09ddbd2">
+            <name>net2</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/networks/8d9ca8a2-44ed-4795-8e5a-a7a7a09ddbd2/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/8d9ca8a2-44ed-4795-8e5a-a7a7a09ddbd2/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/8d9ca8a2-44ed-4795-8e5a-a7a7a09ddbd2/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+        </network>
+        <network href="/ovirt-engine/api/networks/1cbd356f-14f3-4a59-a63b-0166180c69b6" id="1cbd356f-14f3-4a59-a63b-0166180c69b6">
+            <name>net3</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/networks/1cbd356f-14f3-4a59-a63b-0166180c69b6/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/1cbd356f-14f3-4a59-a63b-0166180c69b6/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/1cbd356f-14f3-4a59-a63b-0166180c69b6/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+        </network>
+        <network href="/ovirt-engine/api/networks/054fb15d-6c27-42d0-b8dd-c1ad847416ba" id="054fb15d-6c27-42d0-b8dd-c1ad847416ba">
+            <name>net4</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/networks/054fb15d-6c27-42d0-b8dd-c1ad847416ba/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/054fb15d-6c27-42d0-b8dd-c1ad847416ba/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/054fb15d-6c27-42d0-b8dd-c1ad847416ba/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+        </network>
+        <network href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb" id="dac27d35-5858-4663-abd2-bf087050b3eb">
+            <name>ovirtmgmt</name>
+            <description>Default Management Network</description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+        </network>
+        <network href="/ovirt-engine/api/networks/e4e023b7-53bc-4b1b-8e4a-888ec3f32b5e" id="e4e023b7-53bc-4b1b-8e4a-888ec3f32b5e">
+            <name>ovirtmgmt</name>
+            <description>Default Management Network</description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/networks/e4e023b7-53bc-4b1b-8e4a-888ec3f32b5e/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/e4e023b7-53bc-4b1b-8e4a-888ec3f32b5e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/e4e023b7-53bc-4b1b-8e4a-888ec3f32b5e/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd" id="f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd"/>
+        </network>
+        <network href="/ovirt-engine/api/networks/cf9474f7-0d00-447f-8163-ba856e3e866c" id="cf9474f7-0d00-447f-8163-ba856e3e866c">
+            <name>extNetwork</name>
+            <description>External network on H1-Local1</description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/networks/cf9474f7-0d00-447f-8163-ba856e3e866c/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/cf9474f7-0d00-447f-8163-ba856e3e866c/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/cf9474f7-0d00-447f-8163-ba856e3e866c/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97"/>
+            <external_provider href="/ovirt-engine/api/openstacknetworkproviders/e729290a-bec2-46dc-a315-b1bb14fd1071" id="e729290a-bec2-46dc-a315-b1bb14fd1071"/>
+            <external_provider_physical_network href="/ovirt-engine/api/networks/080dbd4f-53a7-412d-b3df-38bfc7fe887d" id="080dbd4f-53a7-412d-b3df-38bfc7fe887d"/>
+        </network>
+        <network href="/ovirt-engine/api/networks/080dbd4f-53a7-412d-b3df-38bfc7fe887d" id="080dbd4f-53a7-412d-b3df-38bfc7fe887d">
+            <name>ovirtmgmt</name>
+            <description>Default Management Network</description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/networks/080dbd4f-53a7-412d-b3df-38bfc7fe887d/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/networks/080dbd4f-53a7-412d-b3df-38bfc7fe887d/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/networks/080dbd4f-53a7-412d-b3df-38bfc7fe887d/vnicprofiles" rel="vnicprofiles"/>
+            <mtu>0</mtu>
+            <stp>false</stp>
+            <usages>
+                <usage>vm</usage>
+            </usages>
+            <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97"/>
+        </network>
+    </networks>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '894'
+    correlation-id: 47214403-421b-4c94-adae-899f2a0812e5
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04">
+            <name>depot-dc</name>
+            <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/qoss" rel="qoss"/>
+            <local>false</local>
+            <quota_mode>disabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>3</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>3</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+        <data_center href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd" id="f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd">
+            <name>H1-Local</name>
+            <link href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd/qoss" rel="qoss"/>
+            <local>true</local>
+            <quota_mode>disabled</quota_mode>
+            <status>uninitialized</status>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>3</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>3</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+        <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97">
+            <name>H1-Local1</name>
+            <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/qoss" rel="qoss"/>
+            <local>true</local>
+            <quota_mode>disabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>3</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>3</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '618'
+    correlation-id: c0e44eda-5660-4f80-8f73-1eceeebf62a4
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/disks{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disks>
+        <disk href="/ovirt-engine/api/disks/5a5bbfe4-6755-4028-b246-ecf9e7b2044d" id="5a5bbfe4-6755-4028-b246-ecf9e7b2044d">
+            <actions>
+                <link href="/ovirt-engine/api/disks/5a5bbfe4-6755-4028-b246-ecf9e7b2044d/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/5a5bbfe4-6755-4028-b246-ecf9e7b2044d/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/5a5bbfe4-6755-4028-b246-ecf9e7b2044d/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/5a5bbfe4-6755-4028-b246-ecf9e7b2044d/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/5a5bbfe4-6755-4028-b246-ecf9e7b2044d/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/5a5bbfe4-6755-4028-b246-ecf9e7b2044d/sparsify" rel="sparsify"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/5a5bbfe4-6755-4028-b246-ecf9e7b2044d/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/5a5bbfe4-6755-4028-b246-ecf9e7b2044d/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>c9e3fb9e-cfe4-4c12-a690-ec8e799f758c</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/3adbeee0-ce53-4dcb-9bcb-2c701175d5ef" id="3adbeee0-ce53-4dcb-9bcb-2c701175d5ef"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506" id="18f2ed09-c043-4709-8c69-b335f1b79506"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e158d131-ec47-493a-b4c0-f72e5d8ce73c" id="e158d131-ec47-493a-b4c0-f72e5d8ce73c">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e158d131-ec47-493a-b4c0-f72e5d8ce73c/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e158d131-ec47-493a-b4c0-f72e5d8ce73c/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/e158d131-ec47-493a-b4c0-f72e5d8ce73c/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e158d131-ec47-493a-b4c0-f72e5d8ce73c/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e158d131-ec47-493a-b4c0-f72e5d8ce73c/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e158d131-ec47-493a-b4c0-f72e5d8ce73c/sparsify" rel="sparsify"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/e158d131-ec47-493a-b4c0-f72e5d8ce73c/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e158d131-ec47-493a-b4c0-f72e5d8ce73c/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>f2497d66-eeaf-4dd2-8bab-c4eac59dea43</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/3adbeee0-ce53-4dcb-9bcb-2c701175d5ef" id="3adbeee0-ce53-4dcb-9bcb-2c701175d5ef"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506" id="18f2ed09-c043-4709-8c69-b335f1b79506"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/e7e94619-771b-4e72-8564-c7a620f4420a" id="e7e94619-771b-4e72-8564-c7a620f4420a">
+            <actions>
+                <link href="/ovirt-engine/api/disks/e7e94619-771b-4e72-8564-c7a620f4420a/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/e7e94619-771b-4e72-8564-c7a620f4420a/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/e7e94619-771b-4e72-8564-c7a620f4420a/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/e7e94619-771b-4e72-8564-c7a620f4420a/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/e7e94619-771b-4e72-8564-c7a620f4420a/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/e7e94619-771b-4e72-8564-c7a620f4420a/sparsify" rel="sparsify"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/e7e94619-771b-4e72-8564-c7a620f4420a/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/e7e94619-771b-4e72-8564-c7a620f4420a/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>b9a8cb29-f65f-4388-b811-a2840cd1cee0</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/adb6de05-c38e-420f-b471-014c136e3d49" id="adb6de05-c38e-420f-b471-014c136e3d49">
+            <actions>
+                <link href="/ovirt-engine/api/disks/adb6de05-c38e-420f-b471-014c136e3d49/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/adb6de05-c38e-420f-b471-014c136e3d49/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/adb6de05-c38e-420f-b471-014c136e3d49/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/adb6de05-c38e-420f-b471-014c136e3d49/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/adb6de05-c38e-420f-b471-014c136e3d49/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/adb6de05-c38e-420f-b471-014c136e3d49/sparsify" rel="sparsify"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/adb6de05-c38e-420f-b471-014c136e3d49/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/adb6de05-c38e-420f-b471-014c136e3d49/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>bb58ac5a-3777-4a3e-8703-4e897a8b137a</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/a7ef71a5-0405-472b-843f-197a5c7171e8" id="a7ef71a5-0405-472b-843f-197a5c7171e8">
+            <actions>
+                <link href="/ovirt-engine/api/disks/a7ef71a5-0405-472b-843f-197a5c7171e8/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/a7ef71a5-0405-472b-843f-197a5c7171e8/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/a7ef71a5-0405-472b-843f-197a5c7171e8/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/a7ef71a5-0405-472b-843f-197a5c7171e8/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/a7ef71a5-0405-472b-843f-197a5c7171e8/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/a7ef71a5-0405-472b-843f-197a5c7171e8/sparsify" rel="sparsify"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/a7ef71a5-0405-472b-843f-197a5c7171e8/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/a7ef71a5-0405-472b-843f-197a5c7171e8/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>98dc2977-4462-446e-ab25-05b7b76b9b1d</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/25b8185a-b9d2-4610-94a2-0439b7ae200c" id="25b8185a-b9d2-4610-94a2-0439b7ae200c"/>
+            <quota href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/quotas/a01a0a5f-fc8f-4be1-9028-54eb15523ea5" id="a01a0a5f-fc8f-4be1-9028-54eb15523ea5"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a" id="fcea1e91-aed4-438c-955b-ea462082e59a"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/156f42c0-8a1d-4a78-9118-5f517d9c2806" id="156f42c0-8a1d-4a78-9118-5f517d9c2806">
+            <actions>
+                <link href="/ovirt-engine/api/disks/156f42c0-8a1d-4a78-9118-5f517d9c2806/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/156f42c0-8a1d-4a78-9118-5f517d9c2806/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/156f42c0-8a1d-4a78-9118-5f517d9c2806/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/156f42c0-8a1d-4a78-9118-5f517d9c2806/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/156f42c0-8a1d-4a78-9118-5f517d9c2806/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/156f42c0-8a1d-4a78-9118-5f517d9c2806/sparsify" rel="sparsify"/>
+            </actions>
+            <name>OVF_STORE</name>
+            <description>OVF_STORE</description>
+            <link href="/ovirt-engine/api/disks/156f42c0-8a1d-4a78-9118-5f517d9c2806/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/156f42c0-8a1d-4a78-9118-5f517d9c2806/statistics" rel="statistics"/>
+            <actual_size>134217728</actual_size>
+            <alias>OVF_STORE</alias>
+            <backup>none</backup>
+            <content_type>ovf_store</content_type>
+            <format>raw</format>
+            <image_id>ffb5c047-9e54-47bc-936b-287af0557b6c</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>134217728</provisioned_size>
+            <shareable>true</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <wipe_after_delete>false</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/25b8185a-b9d2-4610-94a2-0439b7ae200c" id="25b8185a-b9d2-4610-94a2-0439b7ae200c"/>
+            <quota href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/quotas/a01a0a5f-fc8f-4be1-9028-54eb15523ea5" id="a01a0a5f-fc8f-4be1-9028-54eb15523ea5"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a" id="fcea1e91-aed4-438c-955b-ea462082e59a"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/dc4bb7c5-32e8-49b3-9a99-a028bf452d81" id="dc4bb7c5-32e8-49b3-9a99-a028bf452d81">
+            <actions>
+                <link href="/ovirt-engine/api/disks/dc4bb7c5-32e8-49b3-9a99-a028bf452d81/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/dc4bb7c5-32e8-49b3-9a99-a028bf452d81/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/dc4bb7c5-32e8-49b3-9a99-a028bf452d81/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/dc4bb7c5-32e8-49b3-9a99-a028bf452d81/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/dc4bb7c5-32e8-49b3-9a99-a028bf452d81/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/dc4bb7c5-32e8-49b3-9a99-a028bf452d81/sparsify" rel="sparsify"/>
+            </actions>
+            <name>rhel_seven_snapshot_metadata</name>
+            <description>Memory snapshot disk for snapshot 'three' of VM 'rhel_seven' (VM ID: '882b9a7c-f3f0-49a3-bda6-1ee289a6adf0')</description>
+            <link href="/ovirt-engine/api/disks/dc4bb7c5-32e8-49b3-9a99-a028bf452d81/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/dc4bb7c5-32e8-49b3-9a99-a028bf452d81/statistics" rel="statistics"/>
+            <actual_size>12288</actual_size>
+            <alias>rhel_seven_snapshot_metadata</alias>
+            <backup>none</backup>
+            <content_type>memory_metadata_volume</content_type>
+            <format>raw</format>
+            <image_id>c8aabcb5-201e-474c-8702-5e69a70da5c3</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10240</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>12288</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775" id="073751df-8c43-4e9c-bf7b-d7ca7452f775">
+            <actions>
+                <link href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775/sparsify" rel="sparsify"/>
+            </actions>
+            <name>deb10_Disk1</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775/statistics" rel="statistics"/>
+            <actual_size>1603645440</actual_size>
+            <alias>deb10_Disk1</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>raw</format>
+            <image_id>18bd57b0-3d2a-42fd-8423-91b8b026d4fc</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>8589934592</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>1603645440</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503" id="d6fc6e5a-ad97-4062-b0f8-523841d31503">
+            <actions>
+                <link href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503/sparsify" rel="sparsify"/>
+            </actions>
+            <name>deb10_Disk1</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503/statistics" rel="statistics"/>
+            <actual_size>1657110528</actual_size>
+            <alias>deb10_Disk1</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>cow</format>
+            <image_id>efff4176-2366-4198-8ec9-f63a8a472941</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>8589934592</provisioned_size>
+            <qcow_version>qcow2_v3</qcow_version>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>1657110528</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/29cadd13-1743-4d20-b5ee-d375683517b1" id="29cadd13-1743-4d20-b5ee-d375683517b1">
+            <actions>
+                <link href="/ovirt-engine/api/disks/29cadd13-1743-4d20-b5ee-d375683517b1/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/29cadd13-1743-4d20-b5ee-d375683517b1/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/29cadd13-1743-4d20-b5ee-d375683517b1/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/29cadd13-1743-4d20-b5ee-d375683517b1/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/29cadd13-1743-4d20-b5ee-d375683517b1/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/29cadd13-1743-4d20-b5ee-d375683517b1/sparsify" rel="sparsify"/>
+            </actions>
+            <name>rhel_seven_snapshot_metadata</name>
+            <description>Memory snapshot disk for snapshot 'one' of VM 'rhel_seven' (VM ID: '882b9a7c-f3f0-49a3-bda6-1ee289a6adf0')</description>
+            <link href="/ovirt-engine/api/disks/29cadd13-1743-4d20-b5ee-d375683517b1/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/29cadd13-1743-4d20-b5ee-d375683517b1/statistics" rel="statistics"/>
+            <actual_size>12288</actual_size>
+            <alias>rhel_seven_snapshot_metadata</alias>
+            <backup>none</backup>
+            <content_type>memory_metadata_volume</content_type>
+            <format>raw</format>
+            <image_id>594b7cca-0a52-4a53-b887-bdc4e1adb8b6</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10240</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>12288</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b" id="36b02b75-fcbd-42c1-818f-82ec90d4780b">
+            <actions>
+                <link href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b/sparsify" rel="sparsify"/>
+            </actions>
+            <name>deb10_Disk1</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b/statistics" rel="statistics"/>
+            <actual_size>19013632</actual_size>
+            <alias>deb10_Disk1</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>cow</format>
+            <image_id>f352996a-6365-4074-a000-0136fcae61a4</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>8589934592</provisioned_size>
+            <qcow_version>qcow2_v3</qcow_version>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>1739710464</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/fd02f50b-1552-4867-a55f-a10ab29d6333" id="fd02f50b-1552-4867-a55f-a10ab29d6333">
+            <actions>
+                <link href="/ovirt-engine/api/disks/fd02f50b-1552-4867-a55f-a10ab29d6333/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/fd02f50b-1552-4867-a55f-a10ab29d6333/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/fd02f50b-1552-4867-a55f-a10ab29d6333/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/fd02f50b-1552-4867-a55f-a10ab29d6333/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/fd02f50b-1552-4867-a55f-a10ab29d6333/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/fd02f50b-1552-4867-a55f-a10ab29d6333/sparsify" rel="sparsify"/>
+            </actions>
+            <name>Debbie_snapshot_metadata</name>
+            <description>Memory snapshot disk for snapshot 'Third' of VM 'Debbie' (VM ID: 'ca7e8d64-0fc7-45de-b258-ae471ea31056')</description>
+            <link href="/ovirt-engine/api/disks/fd02f50b-1552-4867-a55f-a10ab29d6333/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/fd02f50b-1552-4867-a55f-a10ab29d6333/statistics" rel="statistics"/>
+            <actual_size>20480</actual_size>
+            <alias>Debbie_snapshot_metadata</alias>
+            <backup>none</backup>
+            <content_type>memory_metadata_volume</content_type>
+            <format>raw</format>
+            <image_id>6d9dd839-2370-4d6b-8e06-e7c395bf24eb</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10240</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>20480</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/9145e999-376d-445a-8948-f45a1fe49736" id="9145e999-376d-445a-8948-f45a1fe49736">
+            <actions>
+                <link href="/ovirt-engine/api/disks/9145e999-376d-445a-8948-f45a1fe49736/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/9145e999-376d-445a-8948-f45a1fe49736/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/9145e999-376d-445a-8948-f45a1fe49736/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/9145e999-376d-445a-8948-f45a1fe49736/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/9145e999-376d-445a-8948-f45a1fe49736/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/9145e999-376d-445a-8948-f45a1fe49736/sparsify" rel="sparsify"/>
+            </actions>
+            <name>Debbie_snapshot_metadata</name>
+            <description>Memory snapshot disk for snapshot 'second' of VM 'Debbie' (VM ID: 'ca7e8d64-0fc7-45de-b258-ae471ea31056')</description>
+            <link href="/ovirt-engine/api/disks/9145e999-376d-445a-8948-f45a1fe49736/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/9145e999-376d-445a-8948-f45a1fe49736/statistics" rel="statistics"/>
+            <actual_size>16384</actual_size>
+            <alias>Debbie_snapshot_metadata</alias>
+            <backup>none</backup>
+            <content_type>memory_metadata_volume</content_type>
+            <format>raw</format>
+            <image_id>3982c7f3-03dd-4475-83b7-048aadb1912b</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10240</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>16384</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd" id="d9ba0873-5d5e-464a-945d-132bccba49fd">
+            <actions>
+                <link href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd/sparsify" rel="sparsify"/>
+            </actions>
+            <name>Debbie_Disk2</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd/statistics" rel="statistics"/>
+            <actual_size>200704</actual_size>
+            <alias>Debbie_Disk2</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>cow</format>
+            <image_id>31b7dcb4-ae9b-497b-b4bc-07e5d7a37d95</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>15728640</provisioned_size>
+            <qcow_version>qcow2_v3</qcow_version>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>401408</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/4ba7bb60-46b6-4d97-aed4-b4920702032e" id="4ba7bb60-46b6-4d97-aed4-b4920702032e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/4ba7bb60-46b6-4d97-aed4-b4920702032e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/4ba7bb60-46b6-4d97-aed4-b4920702032e/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/4ba7bb60-46b6-4d97-aed4-b4920702032e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/4ba7bb60-46b6-4d97-aed4-b4920702032e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/4ba7bb60-46b6-4d97-aed4-b4920702032e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/4ba7bb60-46b6-4d97-aed4-b4920702032e/sparsify" rel="sparsify"/>
+            </actions>
+            <name>rhel_seven_snapshot_metadata</name>
+            <description>Memory snapshot disk for snapshot 'two' of VM 'rhel_seven' (VM ID: '882b9a7c-f3f0-49a3-bda6-1ee289a6adf0')</description>
+            <link href="/ovirt-engine/api/disks/4ba7bb60-46b6-4d97-aed4-b4920702032e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/4ba7bb60-46b6-4d97-aed4-b4920702032e/statistics" rel="statistics"/>
+            <actual_size>12288</actual_size>
+            <alias>rhel_seven_snapshot_metadata</alias>
+            <backup>none</backup>
+            <content_type>memory_metadata_volume</content_type>
+            <format>raw</format>
+            <image_id>d93b0b1f-127c-4b77-9747-510b45c8e9d1</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10240</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>12288</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/c9d02e16-961a-4dd9-985a-f18fddae95f3" id="c9d02e16-961a-4dd9-985a-f18fddae95f3">
+            <actions>
+                <link href="/ovirt-engine/api/disks/c9d02e16-961a-4dd9-985a-f18fddae95f3/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/c9d02e16-961a-4dd9-985a-f18fddae95f3/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/c9d02e16-961a-4dd9-985a-f18fddae95f3/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/c9d02e16-961a-4dd9-985a-f18fddae95f3/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/c9d02e16-961a-4dd9-985a-f18fddae95f3/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/c9d02e16-961a-4dd9-985a-f18fddae95f3/sparsify" rel="sparsify"/>
+            </actions>
+            <name>Debbie_snapshot_memory</name>
+            <description>Memory snapshot disk for snapshot 'second' of VM 'Debbie' (VM ID: 'ca7e8d64-0fc7-45de-b258-ae471ea31056')</description>
+            <link href="/ovirt-engine/api/disks/c9d02e16-961a-4dd9-985a-f18fddae95f3/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/c9d02e16-961a-4dd9-985a-f18fddae95f3/statistics" rel="statistics"/>
+            <actual_size>292659200</actual_size>
+            <alias>Debbie_snapshot_memory</alias>
+            <backup>none</backup>
+            <content_type>memory_dump_volume</content_type>
+            <format>raw</format>
+            <image_id>1300c0ea-dd7f-4998-95ca-027edf470872</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>1384120320</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>292659200</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/694821fa-5b19-415d-aa97-bba7b2f08e99" id="694821fa-5b19-415d-aa97-bba7b2f08e99">
+            <actions>
+                <link href="/ovirt-engine/api/disks/694821fa-5b19-415d-aa97-bba7b2f08e99/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/694821fa-5b19-415d-aa97-bba7b2f08e99/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/694821fa-5b19-415d-aa97-bba7b2f08e99/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/694821fa-5b19-415d-aa97-bba7b2f08e99/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/694821fa-5b19-415d-aa97-bba7b2f08e99/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/694821fa-5b19-415d-aa97-bba7b2f08e99/sparsify" rel="sparsify"/>
+            </actions>
+            <name>Debbie_snapshot_memory</name>
+            <description>Memory snapshot disk for snapshot 'first' of VM 'Debbie' (VM ID: 'ca7e8d64-0fc7-45de-b258-ae471ea31056')</description>
+            <link href="/ovirt-engine/api/disks/694821fa-5b19-415d-aa97-bba7b2f08e99/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/694821fa-5b19-415d-aa97-bba7b2f08e99/statistics" rel="statistics"/>
+            <actual_size>292454400</actual_size>
+            <alias>Debbie_snapshot_memory</alias>
+            <backup>none</backup>
+            <content_type>memory_dump_volume</content_type>
+            <format>raw</format>
+            <image_id>16d0ebd3-6517-4f63-a953-be5073f1081e</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>1384120320</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>292454400</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/f79c758d-2e36-48d1-ab5b-035e1e1d037e" id="f79c758d-2e36-48d1-ab5b-035e1e1d037e">
+            <actions>
+                <link href="/ovirt-engine/api/disks/f79c758d-2e36-48d1-ab5b-035e1e1d037e/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/f79c758d-2e36-48d1-ab5b-035e1e1d037e/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/f79c758d-2e36-48d1-ab5b-035e1e1d037e/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f79c758d-2e36-48d1-ab5b-035e1e1d037e/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f79c758d-2e36-48d1-ab5b-035e1e1d037e/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f79c758d-2e36-48d1-ab5b-035e1e1d037e/sparsify" rel="sparsify"/>
+            </actions>
+            <name>Debbie_snapshot_metadata</name>
+            <description>Memory snapshot disk for snapshot 'first' of VM 'Debbie' (VM ID: 'ca7e8d64-0fc7-45de-b258-ae471ea31056')</description>
+            <link href="/ovirt-engine/api/disks/f79c758d-2e36-48d1-ab5b-035e1e1d037e/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/f79c758d-2e36-48d1-ab5b-035e1e1d037e/statistics" rel="statistics"/>
+            <actual_size>16384</actual_size>
+            <alias>Debbie_snapshot_metadata</alias>
+            <backup>none</backup>
+            <content_type>memory_metadata_volume</content_type>
+            <format>raw</format>
+            <image_id>5c2ece27-7c81-4476-ad9e-f10d206d3026</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>10240</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>false</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>16384</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6" id="f5c0844f-70ee-4e12-a188-0e3dcbb140a6">
+            <actions>
+                <link href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6/sparsify" rel="sparsify"/>
+            </actions>
+            <name>rhel_seven_Disk1</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6/statistics" rel="statistics"/>
+            <actual_size>19275776</actual_size>
+            <alias>rhel_seven_Disk1</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>cow</format>
+            <image_id>6211e146-b0d1-411e-b1db-ea7f8fafbbb7</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>9663676416</provisioned_size>
+            <qcow_version>qcow2_v3</qcow_version>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>1742389248</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d" id="55e644df-ca85-4ff4-ab5f-33885e90a17d">
+            <actions>
+                <link href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d/sparsify" rel="sparsify"/>
+            </actions>
+            <name>Debbie_Disk3</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d/statistics" rel="statistics"/>
+            <actual_size>200704</actual_size>
+            <alias>Debbie_Disk3</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>cow</format>
+            <image_id>e9be22ba-9c5a-4c88-bcb5-1e01eb2a8174</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>31457280</provisioned_size>
+            <qcow_version>qcow2_v3</qcow_version>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>401408</total_size>
+            <wipe_after_delete>false</wipe_after_delete>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2" id="313a3fd2-528a-4fbb-9343-5efa9946f3d2">
+            <actions>
+                <link href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2/sparsify" rel="sparsify"/>
+            </actions>
+            <name>deb10_Disk1</name>
+            <description></description>
+            <link href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2/statistics" rel="statistics"/>
+            <actual_size>16781312</actual_size>
+            <alias>deb10_Disk1</alias>
+            <backup>none</backup>
+            <content_type>data</content_type>
+            <format>cow</format>
+            <image_id>81ff7bdb-578c-4b59-840d-94188d5e8e82</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>8589934592</provisioned_size>
+            <qcow_version>qcow2_v3</qcow_version>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>16781312</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+        <disk href="/ovirt-engine/api/disks/21a83eba-bd4d-4a03-8fdc-20542d892ea6" id="21a83eba-bd4d-4a03-8fdc-20542d892ea6">
+            <actions>
+                <link href="/ovirt-engine/api/disks/21a83eba-bd4d-4a03-8fdc-20542d892ea6/reduce" rel="reduce"/>
+                <link href="/ovirt-engine/api/disks/21a83eba-bd4d-4a03-8fdc-20542d892ea6/move" rel="move"/>
+                <link href="/ovirt-engine/api/disks/21a83eba-bd4d-4a03-8fdc-20542d892ea6/copy" rel="copy"/>
+                <link href="/ovirt-engine/api/disks/21a83eba-bd4d-4a03-8fdc-20542d892ea6/export" rel="export"/>
+                <link href="/ovirt-engine/api/disks/21a83eba-bd4d-4a03-8fdc-20542d892ea6/refreshlun" rel="refreshlun"/>
+                <link href="/ovirt-engine/api/disks/21a83eba-bd4d-4a03-8fdc-20542d892ea6/sparsify" rel="sparsify"/>
+            </actions>
+            <name>rhel_seven_snapshot_memory</name>
+            <description>Memory snapshot disk for snapshot 'one' of VM 'rhel_seven' (VM ID: '882b9a7c-f3f0-49a3-bda6-1ee289a6adf0')</description>
+            <link href="/ovirt-engine/api/disks/21a83eba-bd4d-4a03-8fdc-20542d892ea6/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/disks/21a83eba-bd4d-4a03-8fdc-20542d892ea6/statistics" rel="statistics"/>
+            <actual_size>292409344</actual_size>
+            <alias>rhel_seven_snapshot_memory</alias>
+            <backup>none</backup>
+            <content_type>memory_dump_volume</content_type>
+            <format>raw</format>
+            <image_id>539bf8f2-2f21-4333-82c5-651d970dd041</image_id>
+            <propagate_errors>false</propagate_errors>
+            <provisioned_size>1384120320</provisioned_size>
+            <shareable>false</shareable>
+            <sparse>true</sparse>
+            <status>ok</status>
+            <storage_type>image</storage_type>
+            <total_size>292409344</total_size>
+            <wipe_after_delete>true</wipe_after_delete>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/66209aed-ab17-4016-a92e-2e26bcb7ec04" id="66209aed-ab17-4016-a92e-2e26bcb7ec04"/>
+            <quota href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/quotas/d3a5edf0-1330-4933-afb0-ed18ca5bd1c2" id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+            <storage_domains>
+                <storage_domain href="/ovirt-engine/api/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+            </storage_domains>
+        </disk>
+    </disks>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '3606'
+    correlation-id: 9991a6d9-521d-41b9-a528-b88b89260b95
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vnicprofiles{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <vnic_profiles>
+        <vnic_profile href="/ovirt-engine/api/vnicprofiles/f6898bd4-bcca-4ea4-bedf-3dc976396b36" id="f6898bd4-bcca-4ea4-bedf-3dc976396b36">
+            <name>ovirtmgmt</name>
+            <link href="/ovirt-engine/api/vnicprofiles/f6898bd4-bcca-4ea4-bedf-3dc976396b36/permissions" rel="permissions"/>
+            <pass_through>
+                <mode>disabled</mode>
+            </pass_through>
+            <port_mirroring>false</port_mirroring>
+            <network href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb" id="dac27d35-5858-4663-abd2-bf087050b3eb"/>
+            <network_filter href="/ovirt-engine/api/networkfilters/cffc2e9a-4449-11ea-ad39-5254005a3239" id="cffc2e9a-4449-11ea-ad39-5254005a3239"/>
+        </vnic_profile>
+        <vnic_profile href="/ovirt-engine/api/vnicprofiles/c8df273f-b67c-4527-9423-46b9e4625aed" id="c8df273f-b67c-4527-9423-46b9e4625aed">
+            <name>oVirtB</name>
+            <link href="/ovirt-engine/api/vnicprofiles/c8df273f-b67c-4527-9423-46b9e4625aed/permissions" rel="permissions"/>
+            <pass_through>
+                <mode>disabled</mode>
+            </pass_through>
+            <port_mirroring>false</port_mirroring>
+            <network href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb" id="dac27d35-5858-4663-abd2-bf087050b3eb"/>
+            <network_filter href="/ovirt-engine/api/networkfilters/cffc2e9a-4449-11ea-ad39-5254005a3239" id="cffc2e9a-4449-11ea-ad39-5254005a3239"/>
+        </vnic_profile>
+        <vnic_profile href="/ovirt-engine/api/vnicprofiles/76ec486d-d881-4ad7-ab59-6371cdfcd723" id="76ec486d-d881-4ad7-ab59-6371cdfcd723">
+            <name>extNetwork</name>
+            <link href="/ovirt-engine/api/vnicprofiles/76ec486d-d881-4ad7-ab59-6371cdfcd723/permissions" rel="permissions"/>
+            <pass_through>
+                <mode>disabled</mode>
+            </pass_through>
+            <port_mirroring>false</port_mirroring>
+            <network href="/ovirt-engine/api/networks/6a0cb90c-16ac-47ae-b262-ac382b2c42e5" id="6a0cb90c-16ac-47ae-b262-ac382b2c42e5"/>
+        </vnic_profile>
+        <vnic_profile href="/ovirt-engine/api/vnicprofiles/265ac89f-98c2-41be-a78b-97852159adb1" id="265ac89f-98c2-41be-a78b-97852159adb1">
+            <name>vnic1</name>
+            <link href="/ovirt-engine/api/vnicprofiles/265ac89f-98c2-41be-a78b-97852159adb1/permissions" rel="permissions"/>
+            <pass_through>
+                <mode>disabled</mode>
+            </pass_through>
+            <port_mirroring>false</port_mirroring>
+            <network href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb" id="dac27d35-5858-4663-abd2-bf087050b3eb"/>
+            <network_filter href="/ovirt-engine/api/networkfilters/cffc2e9a-4449-11ea-ad39-5254005a3239" id="cffc2e9a-4449-11ea-ad39-5254005a3239"/>
+        </vnic_profile>
+        <vnic_profile href="/ovirt-engine/api/vnicprofiles/1c1e6b52-57e4-4559-82d7-a365133d1f4a" id="1c1e6b52-57e4-4559-82d7-a365133d1f4a">
+            <name>ovirtmgmt</name>
+            <link href="/ovirt-engine/api/vnicprofiles/1c1e6b52-57e4-4559-82d7-a365133d1f4a/permissions" rel="permissions"/>
+            <pass_through>
+                <mode>disabled</mode>
+            </pass_through>
+            <port_mirroring>false</port_mirroring>
+            <network href="/ovirt-engine/api/networks/080dbd4f-53a7-412d-b3df-38bfc7fe887d" id="080dbd4f-53a7-412d-b3df-38bfc7fe887d"/>
+            <network_filter href="/ovirt-engine/api/networkfilters/cffc2e9a-4449-11ea-ad39-5254005a3239" id="cffc2e9a-4449-11ea-ad39-5254005a3239"/>
+        </vnic_profile>
+        <vnic_profile href="/ovirt-engine/api/vnicprofiles/0896b4ac-30d8-451e-89c8-b8dcccc1017d" id="0896b4ac-30d8-451e-89c8-b8dcccc1017d">
+            <name>ovirtmgmt</name>
+            <link href="/ovirt-engine/api/vnicprofiles/0896b4ac-30d8-451e-89c8-b8dcccc1017d/permissions" rel="permissions"/>
+            <pass_through>
+                <mode>disabled</mode>
+            </pass_through>
+            <port_mirroring>false</port_mirroring>
+            <network href="/ovirt-engine/api/networks/e4e023b7-53bc-4b1b-8e4a-888ec3f32b5e" id="e4e023b7-53bc-4b1b-8e4a-888ec3f32b5e"/>
+            <network_filter href="/ovirt-engine/api/networkfilters/cffc2e9a-4449-11ea-ad39-5254005a3239" id="cffc2e9a-4449-11ea-ad39-5254005a3239"/>
+        </vnic_profile>
+        <vnic_profile href="/ovirt-engine/api/vnicprofiles/58f56a36-a9a9-4da0-8503-26d6ce4d5c73" id="58f56a36-a9a9-4da0-8503-26d6ce4d5c73">
+            <name>extNetwork</name>
+            <link href="/ovirt-engine/api/vnicprofiles/58f56a36-a9a9-4da0-8503-26d6ce4d5c73/permissions" rel="permissions"/>
+            <pass_through>
+                <mode>disabled</mode>
+            </pass_through>
+            <port_mirroring>false</port_mirroring>
+            <network href="/ovirt-engine/api/networks/cf9474f7-0d00-447f-8163-ba856e3e866c" id="cf9474f7-0d00-447f-8163-ba856e3e866c"/>
+        </vnic_profile>
+    </vnic_profiles>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '721'
+    correlation-id: 0d87ddbb-90f6-4f83-a75d-5e751e88fe4b
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <host_nics>
+        <host_nic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/nics/04ca5782-debf-4f02-88e2-db5c0c1c38d9" id="04ca5782-debf-4f02-88e2-db5c0c1c38d9">
+            <actions/>
+            <name>ens3</name>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/nics/04ca5782-debf-4f02-88e2-db5c0c1c38d9/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/nics/04ca5782-debf-4f02-88e2-db5c0c1c38d9/linklayerdiscoveryprotocolelements" rel="linklayerdiscoveryprotocolelements"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/nics/04ca5782-debf-4f02-88e2-db5c0c1c38d9/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/nics/04ca5782-debf-4f02-88e2-db5c0c1c38d9/statistics" rel="statistics"/>
+            <boot_protocol>dhcp</boot_protocol>
+            <bridged>true</bridged>
+            <custom_configuration>false</custom_configuration>
+            <ip>
+                <address>192.168.178.48</address>
+                <gateway>192.168.178.1</gateway>
+                <netmask>255.255.255.0</netmask>
+                <version>v4</version>
+            </ip>
+            <ipv6>
+                <gateway>::</gateway>
+                <version>v6</version>
+            </ipv6>
+            <ipv6_boot_protocol>autoconf</ipv6_boot_protocol>
+            <mac>
+                <address>52:54:00:4c:62:0b</address>
+            </mac>
+            <mtu>1500</mtu>
+            <properties/>
+            <speed>1000000000</speed>
+            <status>up</status>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+            <network href="/ovirt-engine/api/networks/080dbd4f-53a7-412d-b3df-38bfc7fe887d" id="080dbd4f-53a7-412d-b3df-38bfc7fe887d"/>
+        </host_nic>
+    </host_nics>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '570'
+    correlation-id: '0924e240-f233-4b67-b142-80c51e75f888'
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <statistics>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896" id="7816602b-c05c-3db7-a4da-3769f7ad8896">
+            <name>memory.total</name>
+            <description>Total memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>8200912896</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08" id="b7499508-c1c3-32f0-8174-c1783e57bb08">
+            <name>memory.used</name>
+            <description>Used memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>492054773</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946" id="5a0fba9d-33d7-3cbf-addd-ba462040c946">
+            <name>memory.free</name>
+            <description>Free memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>7708858123</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc" id="ffc0e1fd-fa34-3f85-9862-8a841c1658bc">
+            <name>memory.shared</name>
+            <description>Shared memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f" id="c81c86f0-bc61-3c78-a543-898b8339d03f">
+            <name>memory.buffers</name>
+            <description>IO buffers</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11" id="1b6244ee-8dbd-365d-8762-482ddc05ee11">
+            <name>memory.cached</name>
+            <description>OS caches</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b" id="c43847d7-3bc1-3aaf-b92c-902e64bbdb5b">
+            <name>swap.total</name>
+            <description>Total swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>5367660544</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46" id="1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46">
+            <name>swap.free</name>
+            <description>Free swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>5367660544</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9" id="27686b4e-ba8d-3576-bc70-d68cbd8a2ba9">
+            <name>swap.used</name>
+            <description>Used swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07" id="ea00da15-de2d-3393-a7cb-810c4b19ed07">
+            <name>swap.cached</name>
+            <description>Swap also in memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169" id="f740b9ad-14a7-3f6c-9b80-efff44777169">
+            <name>ksm.cpu.current</name>
+            <description>KSM CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719" id="a1fab379-66e2-3b1d-9914-81a9e79cb719">
+            <name>cpu.current.user</name>
+            <description>User CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815" id="a98c1e11-078c-3593-a57e-4b12c1ce9815">
+            <name>cpu.current.system</name>
+            <description>System CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac" id="4ae97794-f56d-3f05-a9e7-8798887cd1ac">
+            <name>cpu.current.idle</name>
+            <description>Idle CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>99</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/65860dae-c890-312e-9314-5c01f31225ab" id="65860dae-c890-312e-9314-5c01f31225ab">
+            <name>cpu.load.avg.5m</name>
+            <description>CPU 5 minute load average</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0.010</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/statistics/3ceb2072-a5a5-3b21-9bb2-e966471fd81c" id="3ceb2072-a5a5-3b21-9bb2-e966471fd81c">
+            <name>boot.time</name>
+            <description>Boot time of the machine</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>none</unit>
+            <values>
+                <value>
+                    <datum>1583229555</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+        </statistic>
+        <statistic id="0cd932f5-ca10-33ec-9ee4-afa34ab786a6">
+            <name>hugepages.1048576.free</name>
+            <description>Amount of free huge pages of the given size</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>none</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+        </statistic>
+        <statistic id="6c5d91a5-6077-3f4e-8390-4023c6178729">
+            <name>hugepages.2048.free</name>
+            <description>Amount of free huge pages of the given size</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>none</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+        </statistic>
+    </statistics>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '1224'
+    correlation-id: 5af37e32-4282-4428-b5a4-db1f0e3c412f
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <host_nics>
+        <host_nic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/nics/c21efb3b-372e-420a-aaf2-8f2c2a71511b" id="c21efb3b-372e-420a-aaf2-8f2c2a71511b">
+            <actions/>
+            <name>ens3</name>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/nics/c21efb3b-372e-420a-aaf2-8f2c2a71511b/networklabels" rel="networklabels"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/nics/c21efb3b-372e-420a-aaf2-8f2c2a71511b/linklayerdiscoveryprotocolelements" rel="linklayerdiscoveryprotocolelements"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/nics/c21efb3b-372e-420a-aaf2-8f2c2a71511b/networkattachments" rel="networkattachments"/>
+            <link href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/nics/c21efb3b-372e-420a-aaf2-8f2c2a71511b/statistics" rel="statistics"/>
+            <boot_protocol>dhcp</boot_protocol>
+            <bridged>true</bridged>
+            <custom_configuration>false</custom_configuration>
+            <ip>
+                <address>192.168.178.49</address>
+                <gateway>192.168.178.1</gateway>
+                <netmask>255.255.255.0</netmask>
+                <version>v4</version>
+            </ip>
+            <ipv6>
+                <gateway>::</gateway>
+                <version>v6</version>
+            </ipv6>
+            <ipv6_boot_protocol>autoconf</ipv6_boot_protocol>
+            <mac>
+                <address>52:54:00:73:9e:7d</address>
+            </mac>
+            <mtu>1500</mtu>
+            <properties/>
+            <speed>1000000000</speed>
+            <status>up</status>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+            <network href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb" id="dac27d35-5858-4663-abd2-bf087050b3eb"/>
+        </host_nic>
+    </host_nics>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '573'
+    correlation-id: f2777300-8f30-4f42-b45b-509d0d172c86
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <statistics>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896" id="7816602b-c05c-3db7-a4da-3769f7ad8896">
+            <name>memory.total</name>
+            <description>Total memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>8200912896</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08" id="b7499508-c1c3-32f0-8174-c1783e57bb08">
+            <name>memory.used</name>
+            <description>Used memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>1066118676</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946" id="5a0fba9d-33d7-3cbf-addd-ba462040c946">
+            <name>memory.free</name>
+            <description>Free memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>7134794220</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc" id="ffc0e1fd-fa34-3f85-9862-8a841c1658bc">
+            <name>memory.shared</name>
+            <description>Shared memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f" id="c81c86f0-bc61-3c78-a543-898b8339d03f">
+            <name>memory.buffers</name>
+            <description>IO buffers</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11" id="1b6244ee-8dbd-365d-8762-482ddc05ee11">
+            <name>memory.cached</name>
+            <description>OS caches</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b" id="c43847d7-3bc1-3aaf-b92c-902e64bbdb5b">
+            <name>swap.total</name>
+            <description>Total swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>5367660544</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46" id="1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46">
+            <name>swap.free</name>
+            <description>Free swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>5367660544</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9" id="27686b4e-ba8d-3576-bc70-d68cbd8a2ba9">
+            <name>swap.used</name>
+            <description>Used swap</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07" id="ea00da15-de2d-3393-a7cb-810c4b19ed07">
+            <name>swap.cached</name>
+            <description>Swap also in memory</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>bytes</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169" id="f740b9ad-14a7-3f6c-9b80-efff44777169">
+            <name>ksm.cpu.current</name>
+            <description>KSM CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719" id="a1fab379-66e2-3b1d-9914-81a9e79cb719">
+            <name>cpu.current.user</name>
+            <description>User CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>2</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815" id="a98c1e11-078c-3593-a57e-4b12c1ce9815">
+            <name>cpu.current.system</name>
+            <description>System CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>2</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac" id="4ae97794-f56d-3f05-a9e7-8798887cd1ac">
+            <name>cpu.current.idle</name>
+            <description>Idle CPU usage</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>96</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/65860dae-c890-312e-9314-5c01f31225ab" id="65860dae-c890-312e-9314-5c01f31225ab">
+            <name>cpu.load.avg.5m</name>
+            <description>CPU 5 minute load average</description>
+            <kind>gauge</kind>
+            <type>decimal</type>
+            <unit>percent</unit>
+            <values>
+                <value>
+                    <datum>0.20</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/statistics/3ceb2072-a5a5-3b21-9bb2-e966471fd81c" id="3ceb2072-a5a5-3b21-9bb2-e966471fd81c">
+            <name>boot.time</name>
+            <description>Boot time of the machine</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>none</unit>
+            <values>
+                <value>
+                    <datum>1583229553</datum>
+                </value>
+            </values>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+        </statistic>
+        <statistic id="0cd932f5-ca10-33ec-9ee4-afa34ab786a6">
+            <name>hugepages.1048576.free</name>
+            <description>Amount of free huge pages of the given size</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>none</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+        </statistic>
+        <statistic id="6c5d91a5-6077-3f4e-8390-4023c6178729">
+            <name>hugepages.2048.free</name>
+            <description>Amount of free huge pages of the given size</description>
+            <kind>gauge</kind>
+            <type>integer</type>
+            <unit>none</unit>
+            <values>
+                <value>
+                    <datum>0</datum>
+                </value>
+            </values>
+        </statistic>
+    </statistics>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '1227'
+    correlation-id: af714f64-3ce2-447c-8f83-1c39d16aa59e
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/nics/cbf094c6-045f-464f-bcf4-7abe2eea8190" id="cbf094c6-045f-464f-bcf4-7abe2eea8190">
+            <actions>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/nics/cbf094c6-045f-464f-bcf4-7abe2eea8190/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/nics/cbf094c6-045f-464f-bcf4-7abe2eea8190/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/nics/cbf094c6-045f-464f-bcf4-7abe2eea8190/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/nics/cbf094c6-045f-464f-bcf4-7abe2eea8190/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/nics/cbf094c6-045f-464f-bcf4-7abe2eea8190/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056" id="ca7e8d64-0fc7-45de-b258-ae471ea31056"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:59:c0:00:01</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/f6898bd4-bcca-4ea4-bedf-3dc976396b36" id="f6898bd4-bcca-4ea4-bedf-3dc976396b36"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '428'
+    correlation-id: f7166aa9-dca7-4f68-9891-0cf38800964b
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '96'
+    correlation-id: '0847ccf3-54fc-4c6c-abae-cb6b1b575f8a'
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/f244080d-0788-4714-bf8c-0d85567efda0" id="f244080d-0788-4714-bf8c-0d85567efda0">
+            <actions>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/f244080d-0788-4714-bf8c-0d85567efda0/restore" rel="restore"/>
+            </actions>
+            <description>first</description>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/f244080d-0788-4714-bf8c-0d85567efda0/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/f244080d-0788-4714-bf8c-0d85567efda0/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/f244080d-0788-4714-bf8c-0d85567efda0/disks" rel="disks"/>
+            <date>2020-02-19T12:43:44.755+01:00</date>
+            <persist_memorystate>true</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>regular</snapshot_type>
+            <vm id="ca7e8d64-0fc7-45de-b258-ae471ea31056">
+                <name>Debbie</name>
+                <description></description>
+                <comment></comment>
+                <bios>
+                    <boot_menu>
+                        <enabled>false</enabled>
+                    </boot_menu>
+                    <type>i440fx_sea_bios</type>
+                </bios>
+                <cpu>
+                    <architecture>x86_64</architecture>
+                    <topology>
+                        <cores>1</cores>
+                        <sockets>1</sockets>
+                        <threads>1</threads>
+                    </topology>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <creation_time>2020-01-31T18:37:27.000+01:00</creation_time>
+                <delete_protected>false</delete_protected>
+                <display>
+                    <address>192.168.178.49</address>
+                    <allow_override>false</allow_override>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <monitors>1</monitors>
+                    <port>5901</port>
+                    <secure_port>5902</secure_port>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <smartcard_enabled>false</smartcard_enabled>
+                    <type>spice</type>
+                </display>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>1</priority>
+                </high_availability>
+                <initialization>
+                    <regenerate_ssh_keys>false</regenerate_ssh_keys>
+                </initialization>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <large_icon id="8049d860-cf22-4b1b-cf59-d2f228ecb9f2"/>
+                <memory>1073741824</memory>
+                <memory_policy>
+                    <guaranteed>1073741824</guaranteed>
+                    <max>4294967296</max>
+                </memory_policy>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <migration_downtime>-1</migration_downtime>
+                <multi_queues_enabled>true</multi_queues_enabled>
+                <origin>rhev</origin>
+                <os>
+                    <boot>
+                        <devices>
+                            <device>hd</device>
+                        </devices>
+                    </boot>
+                    <type>other_linux</type>
+                </os>
+                <placement_policy>
+                    <affinity>migratable</affinity>
+                </placement_policy>
+                <small_icon id="d6a560d7-054e-4bd6-faee-f0e3132d948d"/>
+                <sso>
+                    <methods>
+                        <method id="guest_agent"/>
+                    </methods>
+                </sso>
+                <start_paused>false</start_paused>
+                <stateless>false</stateless>
+                <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+                <time_zone>
+                    <name>Europe/Budapest</name>
+                </time_zone>
+                <type>desktop</type>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <cluster id="1930506d-e424-4a3e-8262-9c5d7bcd5125"/>
+                <cpu_profile id="7e5344a6-3434-445a-9478-d989e1180fcf"/>
+                <quota id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+                <next_run_configuration_exists>false</next_run_configuration_exists>
+                <numa_tune_mode>interleave</numa_tune_mode>
+                <run_once>false</run_once>
+                <start_time>2020-03-03T11:33:14.840+01:00</start_time>
+                <status>up</status>
+                <stop_time>2020-02-17T18:42:27.000+01:00</stop_time>
+                <host id="72877001-6012-4921-bdd2-3ff17043083e"/>
+                <original_template id="00000000-0000-0000-0000-000000000000"/>
+                <template id="00000000-0000-0000-0000-000000000000"/>
+            </vm>
+        </snapshot>
+        <snapshot href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/129f9565-c090-44d6-8181-998e2f160c83" id="129f9565-c090-44d6-8181-998e2f160c83">
+            <actions>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/129f9565-c090-44d6-8181-998e2f160c83/restore" rel="restore"/>
+            </actions>
+            <description>second</description>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/129f9565-c090-44d6-8181-998e2f160c83/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/129f9565-c090-44d6-8181-998e2f160c83/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/129f9565-c090-44d6-8181-998e2f160c83/disks" rel="disks"/>
+            <date>2020-02-19T12:47:48.404+01:00</date>
+            <persist_memorystate>true</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>regular</snapshot_type>
+            <vm id="ca7e8d64-0fc7-45de-b258-ae471ea31056">
+                <name>Debbie</name>
+                <description></description>
+                <comment></comment>
+                <bios>
+                    <boot_menu>
+                        <enabled>false</enabled>
+                    </boot_menu>
+                    <type>i440fx_sea_bios</type>
+                </bios>
+                <cpu>
+                    <architecture>x86_64</architecture>
+                    <topology>
+                        <cores>1</cores>
+                        <sockets>1</sockets>
+                        <threads>1</threads>
+                    </topology>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <creation_time>2020-01-31T18:37:27.000+01:00</creation_time>
+                <delete_protected>false</delete_protected>
+                <display>
+                    <address>192.168.178.49</address>
+                    <allow_override>false</allow_override>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <monitors>1</monitors>
+                    <port>5901</port>
+                    <secure_port>5902</secure_port>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <smartcard_enabled>false</smartcard_enabled>
+                    <type>spice</type>
+                </display>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>1</priority>
+                </high_availability>
+                <initialization>
+                    <regenerate_ssh_keys>false</regenerate_ssh_keys>
+                </initialization>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <large_icon id="8049d860-cf22-4b1b-cf59-d2f228ecb9f2"/>
+                <memory>1073741824</memory>
+                <memory_policy>
+                    <guaranteed>1073741824</guaranteed>
+                    <max>4294967296</max>
+                </memory_policy>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <migration_downtime>-1</migration_downtime>
+                <multi_queues_enabled>true</multi_queues_enabled>
+                <origin>rhev</origin>
+                <os>
+                    <boot>
+                        <devices>
+                            <device>hd</device>
+                        </devices>
+                    </boot>
+                    <type>other_linux</type>
+                </os>
+                <placement_policy>
+                    <affinity>migratable</affinity>
+                </placement_policy>
+                <small_icon id="d6a560d7-054e-4bd6-faee-f0e3132d948d"/>
+                <sso>
+                    <methods>
+                        <method id="guest_agent"/>
+                    </methods>
+                </sso>
+                <start_paused>false</start_paused>
+                <stateless>false</stateless>
+                <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+                <time_zone>
+                    <name>Europe/Budapest</name>
+                </time_zone>
+                <type>desktop</type>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <cluster id="1930506d-e424-4a3e-8262-9c5d7bcd5125"/>
+                <cpu_profile id="7e5344a6-3434-445a-9478-d989e1180fcf"/>
+                <quota id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+                <next_run_configuration_exists>false</next_run_configuration_exists>
+                <numa_tune_mode>interleave</numa_tune_mode>
+                <run_once>false</run_once>
+                <start_time>2020-03-03T11:33:14.840+01:00</start_time>
+                <status>up</status>
+                <stop_time>2020-02-17T18:42:27.000+01:00</stop_time>
+                <host id="72877001-6012-4921-bdd2-3ff17043083e"/>
+                <original_template id="00000000-0000-0000-0000-000000000000"/>
+                <template id="00000000-0000-0000-0000-000000000000"/>
+            </vm>
+        </snapshot>
+        <snapshot href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/2dc97444-22fa-47c9-972f-a947f6fa7b5d" id="2dc97444-22fa-47c9-972f-a947f6fa7b5d">
+            <actions>
+                <link href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/2dc97444-22fa-47c9-972f-a947f6fa7b5d/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2020-02-19T12:47:48.404+01:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '1740'
+    correlation-id: d49d8138-3c24-448b-96dd-41c0fda64092
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/diskattachments/36b02b75-fcbd-42c1-818f-82ec90d4780b" id="36b02b75-fcbd-42c1-818f-82ec90d4780b">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <read_only>false</read_only>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/36b02b75-fcbd-42c1-818f-82ec90d4780b" id="36b02b75-fcbd-42c1-818f-82ec90d4780b"/>
+            <vm href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056" id="ca7e8d64-0fc7-45de-b258-ae471ea31056"/>
+        </disk_attachment>
+        <disk_attachment href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/diskattachments/d9ba0873-5d5e-464a-945d-132bccba49fd" id="d9ba0873-5d5e-464a-945d-132bccba49fd">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio_scsi</interface>
+            <pass_discard>false</pass_discard>
+            <read_only>false</read_only>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/d9ba0873-5d5e-464a-945d-132bccba49fd" id="d9ba0873-5d5e-464a-945d-132bccba49fd"/>
+            <vm href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056" id="ca7e8d64-0fc7-45de-b258-ae471ea31056"/>
+        </disk_attachment>
+        <disk_attachment href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/diskattachments/55e644df-ca85-4ff4-ab5f-33885e90a17d" id="55e644df-ca85-4ff4-ab5f-33885e90a17d">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio_scsi</interface>
+            <pass_discard>false</pass_discard>
+            <read_only>false</read_only>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/55e644df-ca85-4ff4-ab5f-33885e90a17d" id="55e644df-ca85-4ff4-ab5f-33885e90a17d"/>
+            <vm href="/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056" id="ca7e8d64-0fc7-45de-b258-ae471ea31056"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '410'
+    correlation-id: 8a7cfefe-195a-4a66-aac0-53bf7db9892c
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/b8c06c28-402c-4fcf-8227-3bfa5e074c27" id="b8c06c28-402c-4fcf-8227-3bfa5e074c27">
+            <actions>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/b8c06c28-402c-4fcf-8227-3bfa5e074c27/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/b8c06c28-402c-4fcf-8227-3bfa5e074c27/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/b8c06c28-402c-4fcf-8227-3bfa5e074c27/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/b8c06c28-402c-4fcf-8227-3bfa5e074c27/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/b8c06c28-402c-4fcf-8227-3bfa5e074c27/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0" id="882b9a7c-f3f0-49a3-bda6-1ee289a6adf0"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:59:c0:00:00</address>
+            </mac>
+            <plugged>true</plugged>
+            <reported_devices>
+                <reported_device href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reporteddevices/65746830-3536-3a36-663a-35393a63303a" id="65746830-3536-3a36-663a-35393a63303a">
+                    <name>eth0</name>
+                    <description>guest reported data</description>
+                    <ips>
+                        <ip>
+                            <address>192.168.178.62</address>
+                            <version>v4</version>
+                        </ip>
+                        <ip>
+                            <address>fe80::37ee:4ca9:9bba:d731</address>
+                            <version>v6</version>
+                        </ip>
+                    </ips>
+                    <mac>
+                        <address>56:6f:59:c0:00:00</address>
+                    </mac>
+                    <type>network</type>
+                </reported_device>
+            </reported_devices>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/f6898bd4-bcca-4ea4-bedf-3dc976396b36" id="f6898bd4-bcca-4ea4-bedf-3dc976396b36"/>
+        </nic>
+        <nic href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/e8857d60-9cf3-44b8-9e10-4036c3a7e5ff" id="e8857d60-9cf3-44b8-9e10-4036c3a7e5ff">
+            <actions>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/e8857d60-9cf3-44b8-9e10-4036c3a7e5ff/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/e8857d60-9cf3-44b8-9e10-4036c3a7e5ff/activate" rel="activate"/>
+            </actions>
+            <name>nic2</name>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/e8857d60-9cf3-44b8-9e10-4036c3a7e5ff/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/e8857d60-9cf3-44b8-9e10-4036c3a7e5ff/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/e8857d60-9cf3-44b8-9e10-4036c3a7e5ff/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0" id="882b9a7c-f3f0-49a3-bda6-1ee289a6adf0"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:59:c0:00:02</address>
+            </mac>
+            <plugged>true</plugged>
+            <reported_devices>
+                <reported_device href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reporteddevices/65746831-3536-3a36-663a-35393a63303a" id="65746831-3536-3a36-663a-35393a63303a">
+                    <name>eth1</name>
+                    <description>guest reported data</description>
+                    <mac>
+                        <address>56:6f:59:c0:00:02</address>
+                    </mac>
+                    <type>network</type>
+                </reported_device>
+            </reported_devices>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/c8df273f-b67c-4527-9423-46b9e4625aed" id="c8df273f-b67c-4527-9423-46b9e4625aed"/>
+        </nic>
+        <nic href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/d058f767-ca2f-41d1-8b02-d7f997351e4f" id="d058f767-ca2f-41d1-8b02-d7f997351e4f">
+            <actions>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/d058f767-ca2f-41d1-8b02-d7f997351e4f/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/d058f767-ca2f-41d1-8b02-d7f997351e4f/activate" rel="activate"/>
+            </actions>
+            <name>nic3</name>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/d058f767-ca2f-41d1-8b02-d7f997351e4f/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/d058f767-ca2f-41d1-8b02-d7f997351e4f/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/nics/d058f767-ca2f-41d1-8b02-d7f997351e4f/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0" id="882b9a7c-f3f0-49a3-bda6-1ee289a6adf0"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:59:c0:00:03</address>
+            </mac>
+            <plugged>true</plugged>
+            <reported_devices>
+                <reported_device href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reporteddevices/65746832-3536-3a36-663a-35393a63303a" id="65746832-3536-3a36-663a-35393a63303a">
+                    <name>eth2</name>
+                    <description>guest reported data</description>
+                    <mac>
+                        <address>56:6f:59:c0:00:03</address>
+                    </mac>
+                    <type>network</type>
+                </reported_device>
+            </reported_devices>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/265ac89f-98c2-41be-a78b-97852159adb1" id="265ac89f-98c2-41be-a78b-97852159adb1"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '871'
+    correlation-id: 2d91ceb0-6e22-464c-825c-2bceed9fb920
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices>
+        <reported_device href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reporteddevices/65746830-3536-3a36-663a-35393a63303a" id="65746830-3536-3a36-663a-35393a63303a">
+            <name>eth0</name>
+            <description>guest reported data</description>
+            <ips>
+                <ip>
+                    <address>192.168.178.62</address>
+                    <version>v4</version>
+                </ip>
+                <ip>
+                    <address>fe80::37ee:4ca9:9bba:d731</address>
+                    <version>v6</version>
+                </ip>
+            </ips>
+            <mac>
+                <address>56:6f:59:c0:00:00</address>
+            </mac>
+            <type>network</type>
+            <vm href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0" id="882b9a7c-f3f0-49a3-bda6-1ee289a6adf0"/>
+        </reported_device>
+        <reported_device href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reporteddevices/65746831-3536-3a36-663a-35393a63303a" id="65746831-3536-3a36-663a-35393a63303a">
+            <name>eth1</name>
+            <description>guest reported data</description>
+            <mac>
+                <address>56:6f:59:c0:00:02</address>
+            </mac>
+            <type>network</type>
+            <vm href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0" id="882b9a7c-f3f0-49a3-bda6-1ee289a6adf0"/>
+        </reported_device>
+        <reported_device href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/reporteddevices/65746832-3536-3a36-663a-35393a63303a" id="65746832-3536-3a36-663a-35393a63303a">
+            <name>eth2</name>
+            <description>guest reported data</description>
+            <mac>
+                <address>56:6f:59:c0:00:03</address>
+            </mac>
+            <type>network</type>
+            <vm href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0" id="882b9a7c-f3f0-49a3-bda6-1ee289a6adf0"/>
+        </reported_device>
+    </reported_devices>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '407'
+    correlation-id: 013aaba7-d801-42fa-9995-0477528d6296
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots/4f81c601-d896-4c12-b34e-0bfcabd7d9e1" id="4f81c601-d896-4c12-b34e-0bfcabd7d9e1">
+            <actions>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots/4f81c601-d896-4c12-b34e-0bfcabd7d9e1/restore" rel="restore"/>
+            </actions>
+            <description>one</description>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots/4f81c601-d896-4c12-b34e-0bfcabd7d9e1/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots/4f81c601-d896-4c12-b34e-0bfcabd7d9e1/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots/4f81c601-d896-4c12-b34e-0bfcabd7d9e1/disks" rel="disks"/>
+            <date>2020-02-19T16:30:58.143+01:00</date>
+            <persist_memorystate>true</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>regular</snapshot_type>
+            <vm id="882b9a7c-f3f0-49a3-bda6-1ee289a6adf0">
+                <name>rhel_seven</name>
+                <description></description>
+                <comment></comment>
+                <bios>
+                    <boot_menu>
+                        <enabled>false</enabled>
+                    </boot_menu>
+                    <type>i440fx_sea_bios</type>
+                </bios>
+                <cpu>
+                    <architecture>x86_64</architecture>
+                    <topology>
+                        <cores>1</cores>
+                        <sockets>1</sockets>
+                        <threads>1</threads>
+                    </topology>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <creation_time>2020-02-04T09:25:27.000+01:00</creation_time>
+                <delete_protected>false</delete_protected>
+                <display>
+                    <allow_override>true</allow_override>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <monitors>1</monitors>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <smartcard_enabled>false</smartcard_enabled>
+                </display>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>1</priority>
+                </high_availability>
+                <initialization>
+                    <regenerate_ssh_keys>false</regenerate_ssh_keys>
+                </initialization>
+                <io>
+                    <threads>1</threads>
+                </io>
+                <large_icon id="d451982e-7c98-9329-709c-44fbaa46da26"/>
+                <memory>1073741824</memory>
+                <memory_policy>
+                    <guaranteed>1073741824</guaranteed>
+                    <max>4294967296</max>
+                </memory_policy>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <migration_downtime>-1</migration_downtime>
+                <multi_queues_enabled>true</multi_queues_enabled>
+                <origin>rhev</origin>
+                <os>
+                    <boot>
+                        <devices>
+                            <device>hd</device>
+                            <device>cdrom</device>
+                        </devices>
+                    </boot>
+                    <type>rhel_7x64</type>
+                </os>
+                <placement_policy>
+                    <affinity>migratable</affinity>
+                </placement_policy>
+                <small_icon id="a82f7562-5ea9-07b9-cf1c-176e92f9ffaf"/>
+                <sso>
+                    <methods>
+                        <method id="guest_agent"/>
+                    </methods>
+                </sso>
+                <start_paused>false</start_paused>
+                <stateless>false</stateless>
+                <storage_error_resume_behaviour>auto_resume</storage_error_resume_behaviour>
+                <time_zone>
+                    <name>Etc/GMT</name>
+                </time_zone>
+                <type>server</type>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <cluster id="1930506d-e424-4a3e-8262-9c5d7bcd5125"/>
+                <cpu_profile id="7e5344a6-3434-445a-9478-d989e1180fcf"/>
+                <quota id="d3a5edf0-1330-4933-afb0-ed18ca5bd1c2"/>
+                <next_run_configuration_exists>false</next_run_configuration_exists>
+                <numa_tune_mode>interleave</numa_tune_mode>
+                <status>down</status>
+                <stop_reason></stop_reason>
+                <stop_time>2020-02-11T20:20:10.000+01:00</stop_time>
+                <original_template id="00000000-0000-0000-0000-000000000000"/>
+                <template id="00000000-0000-0000-0000-000000000000"/>
+            </vm>
+        </snapshot>
+        <snapshot href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots/82fbf338-b43d-4288-9165-6616ddd0605d" id="82fbf338-b43d-4288-9165-6616ddd0605d">
+            <actions>
+                <link href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots/82fbf338-b43d-4288-9165-6616ddd0605d/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2020-02-19T16:30:58.143+01:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '1496'
+    correlation-id: e3daa387-36f7-4492-b8a6-5994c6a16040
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/diskattachments/f5c0844f-70ee-4e12-a188-0e3dcbb140a6" id="f5c0844f-70ee-4e12-a188-0e3dcbb140a6">
+            <active>true</active>
+            <bootable>true</bootable>
+            <interface>virtio_scsi</interface>
+            <logical_name>/dev/sda2</logical_name>
+            <pass_discard>false</pass_discard>
+            <read_only>false</read_only>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/f5c0844f-70ee-4e12-a188-0e3dcbb140a6" id="f5c0844f-70ee-4e12-a188-0e3dcbb140a6"/>
+            <vm href="/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0" id="882b9a7c-f3f0-49a3-bda6-1ee289a6adf0"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '340'
+    correlation-id: 3f51b2c5-9e5d-435d-aa4f-7ace9ad264db
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/nics/a7cc98ef-0e8b-42fb-9938-25e128df356f" id="a7cc98ef-0e8b-42fb-9938-25e128df356f">
+            <actions>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/nics/a7cc98ef-0e8b-42fb-9938-25e128df356f/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/nics/a7cc98ef-0e8b-42fb-9938-25e128df356f/activate" rel="activate"/>
+            </actions>
+            <name>nic6</name>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/nics/a7cc98ef-0e8b-42fb-9938-25e128df356f/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/nics/a7cc98ef-0e8b-42fb-9938-25e128df356f/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/nics/a7cc98ef-0e8b-42fb-9938-25e128df356f/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1" id="a99773ed-28a3-4370-8240-df9e732bc3e1"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:59:c0:00:0e</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/f6898bd4-bcca-4ea4-bedf-3dc976396b36" id="f6898bd4-bcca-4ea4-bedf-3dc976396b36"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '430'
+    correlation-id: 7c96c04b-6dd7-4bbc-8db8-ecfa0f3782aa
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '96'
+    correlation-id: 8b3e8e69-a15b-4296-a3c3-83a60e5820c7
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/snapshots/0a66f7f7-d99d-4e99-99ec-5410b8ed28cd" id="0a66f7f7-d99d-4e99-99ec-5410b8ed28cd">
+            <actions>
+                <link href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/snapshots/0a66f7f7-d99d-4e99-99ec-5410b8ed28cd/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2020-02-03T18:51:47.608+01:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '332'
+    correlation-id: 9f9133bf-04e9-48b6-886e-ecedb9aaffa1
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1/diskattachments/d6fc6e5a-ad97-4062-b0f8-523841d31503" id="d6fc6e5a-ad97-4062-b0f8-523841d31503">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <read_only>false</read_only>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/d6fc6e5a-ad97-4062-b0f8-523841d31503" id="d6fc6e5a-ad97-4062-b0f8-523841d31503"/>
+            <vm href="/ovirt-engine/api/vms/a99773ed-28a3-4370-8240-df9e732bc3e1" id="a99773ed-28a3-4370-8240-df9e732bc3e1"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '321'
+    correlation-id: 57246a6b-ae16-4a36-b3e2-483635af90b7
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <nics>
+        <nic href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/2687864c-9729-4e85-87b2-f26359675121" id="2687864c-9729-4e85-87b2-f26359675121">
+            <actions>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/2687864c-9729-4e85-87b2-f26359675121/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/2687864c-9729-4e85-87b2-f26359675121/activate" rel="activate"/>
+            </actions>
+            <name>nic2</name>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/2687864c-9729-4e85-87b2-f26359675121/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/2687864c-9729-4e85-87b2-f26359675121/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/2687864c-9729-4e85-87b2-f26359675121/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a" id="e23898b2-0540-456c-a1ce-0df108c4df9a"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:59:c0:00:05</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/c8df273f-b67c-4527-9423-46b9e4625aed" id="c8df273f-b67c-4527-9423-46b9e4625aed"/>
+        </nic>
+        <nic href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b4179bd8-010b-4266-88c0-9c7762616cb4" id="b4179bd8-010b-4266-88c0-9c7762616cb4">
+            <actions>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b4179bd8-010b-4266-88c0-9c7762616cb4/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b4179bd8-010b-4266-88c0-9c7762616cb4/activate" rel="activate"/>
+            </actions>
+            <name>nic1</name>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b4179bd8-010b-4266-88c0-9c7762616cb4/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b4179bd8-010b-4266-88c0-9c7762616cb4/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b4179bd8-010b-4266-88c0-9c7762616cb4/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a" id="e23898b2-0540-456c-a1ce-0df108c4df9a"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:59:c0:00:08</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/f6898bd4-bcca-4ea4-bedf-3dc976396b36" id="f6898bd4-bcca-4ea4-bedf-3dc976396b36"/>
+        </nic>
+        <nic href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b3eaa4f8-8969-4b73-ae9d-c7f245ca25ff" id="b3eaa4f8-8969-4b73-ae9d-c7f245ca25ff">
+            <actions>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b3eaa4f8-8969-4b73-ae9d-c7f245ca25ff/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b3eaa4f8-8969-4b73-ae9d-c7f245ca25ff/activate" rel="activate"/>
+            </actions>
+            <name>nic3</name>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b3eaa4f8-8969-4b73-ae9d-c7f245ca25ff/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b3eaa4f8-8969-4b73-ae9d-c7f245ca25ff/networkfilterparameters" rel="networkfilterparameters"/>
+            <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/nics/b3eaa4f8-8969-4b73-ae9d-c7f245ca25ff/statistics" rel="statistics"/>
+            <vm href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a" id="e23898b2-0540-456c-a1ce-0df108c4df9a"/>
+            <interface>virtio</interface>
+            <linked>true</linked>
+            <mac>
+                <address>56:6f:59:c0:00:09</address>
+            </mac>
+            <plugged>true</plugged>
+            <vnic_profile href="/ovirt-engine/api/vnicprofiles/265ac89f-98c2-41be-a78b-97852159adb1" id="265ac89f-98c2-41be-a78b-97852159adb1"/>
+        </nic>
+    </nics>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '632'
+    correlation-id: da875b88-19c8-4911-8f01-d4c18f220d9d
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/reporteddevices{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <reported_devices/>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '96'
+    correlation-id: '0591f72e-ff6b-432f-8862-52e2b1416022'
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/snapshots{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <snapshots>
+        <snapshot href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/snapshots/d4ff6fee-a3ba-475e-9d1a-a88a9b295274" id="d4ff6fee-a3ba-475e-9d1a-a88a9b295274">
+            <actions>
+                <link href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/snapshots/d4ff6fee-a3ba-475e-9d1a-a88a9b295274/restore" rel="restore"/>
+            </actions>
+            <description>Active VM</description>
+            <date>2020-02-03T18:00:14.696+01:00</date>
+            <persist_memorystate>false</persist_memorystate>
+            <snapshot_status>ok</snapshot_status>
+            <snapshot_type>active</snapshot_type>
+        </snapshot>
+    </snapshots>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '331'
+    correlation-id: 17183e21-9990-4e69-9f5a-f7c8c5ea949d
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a/diskattachments/313a3fd2-528a-4fbb-9343-5efa9946f3d2" id="313a3fd2-528a-4fbb-9343-5efa9946f3d2">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <read_only>false</read_only>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/313a3fd2-528a-4fbb-9343-5efa9946f3d2" id="313a3fd2-528a-4fbb-9343-5efa9946f3d2"/>
+            <vm href="/ovirt-engine/api/vms/e23898b2-0540-456c-a1ce-0df108c4df9a" id="e23898b2-0540-456c-a1ce-0df108c4df9a"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '320'
+    correlation-id: 69ef4318-9a18-4f47-8617-c00c1f2b9b46
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments/>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '96'
+    correlation-id: 6d1d8725-c639-4d8c-8de1-6e42162e520e
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/diskattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <disk_attachments>
+        <disk_attachment href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59/diskattachments/073751df-8c43-4e9c-bf7b-d7ca7452f775" id="073751df-8c43-4e9c-bf7b-d7ca7452f775">
+            <active>true</active>
+            <bootable>false</bootable>
+            <interface>virtio</interface>
+            <pass_discard>false</pass_discard>
+            <read_only>false</read_only>
+            <uses_scsi_reservation>false</uses_scsi_reservation>
+            <disk href="/ovirt-engine/api/disks/073751df-8c43-4e9c-bf7b-d7ca7452f775" id="073751df-8c43-4e9c-bf7b-d7ca7452f775"/>
+            <template href="/ovirt-engine/api/templates/8e418698-62e0-4260-a111-11109aa80c59" id="8e418698-62e0-4260-a111-11109aa80c59"/>
+            <vm href="/ovirt-engine/api/vms/8e418698-62e0-4260-a111-11109aa80c59" id="8e418698-62e0-4260-a111-11109aa80c59"/>
+        </disk_attachment>
+    </disk_attachments>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '335'
+    correlation-id: bbdb170c-978b-49a8-b99b-665cb16a8785
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506" id="18f2ed09-c043-4709-8c69-b335f1b79506">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/activate" rel="activate"/>
+            </actions>
+            <name>depot-data2</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/18f2ed09-c043-4709-8c69-b335f1b79506/disks" rel="disks"/>
+            <available>522912268288</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>depot.lab.inz.redhat.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/data2</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>12884901888</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee" id="c1b11db0-278c-477c-a594-f149c211d9ee">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/c1b11db0-278c-477c-a594-f149c211d9ee/activate" rel="activate"/>
+            </actions>
+            <name>iso</name>
+            <description></description>
+            <comment></comment>
+            <available>522912268288</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>depot.lab.inz.redhat.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/ISO</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>12884901888</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5" id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/activate" rel="activate"/>
+            </actions>
+            <name>depot-data1</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04/storagedomains/ee04ae85-01ba-4610-86a8-6c17c1b8e4b5/disks" rel="disks"/>
+            <available>522912268288</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>45097156608</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>depot.lab.inz.redhat.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/data1</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>12884901888</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/5ca0335c-be48-4cf4-acd3-283763cb7e04" id="5ca0335c-be48-4cf4-acd3-283763cb7e04"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '798'
+    correlation-id: ec5c2293-1e53-4cfa-971c-8660ae07082b
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/f0bf9fb9-7e8c-4cb2-add7-ab433f30d1fd/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains/>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '95'
+    correlation-id: 6684c4fa-a8ae-4059-821b-7f1934d37eac
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859" id="218bc2c4-de36-4e7b-be7a-49fd5ac57859">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/activate" rel="activate"/>
+            </actions>
+            <name>H1-local-data-first-chunk</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains/218bc2c4-de36-4e7b-be7a-49fd5ac57859/disks" rel="disks"/>
+            <available>4294967296</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>maintenance</status>
+            <storage>
+                <path>/data/host01_local_data_first_chunk_of_the_ones_available</path>
+                <type>localfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>2147483648</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a" id="fcea1e91-aed4-438c-955b-ea462082e59a">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/deactivate" rel="deactivate"/>
+                <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/activate" rel="activate"/>
+            </actions>
+            <name>H1-Local-data-second-chunk</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97/storagedomains/fcea1e91-aed4-438c-955b-ea462082e59a/disks" rel="disks"/>
+            <available>13958643712</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <path>/var/host01_local_data_second_chunk_of_the_ones_available</path>
+                <type>localfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>1073741824</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/2c4d1610-6b88-4330-a745-26e1f2b4ad97" id="2c4d1610-6b88-4330-a745-26e1f2b4ad97"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:12 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '756'
+    correlation-id: b631fdbb-0bef-4bef-b3a2-0c88c207c4b5
+  :message: 
+? https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/f244080d-0788-4714-bf8c-0d85567efda0/disks{}GET
+: - :body: |
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <disks>
+          <disk id="36b02b75-fcbd-42c1-818f-82ec90d4780b">
+              <name>deb10_Disk1</name>
+              <description></description>
+              <actual_size>2147483648</actual_size>
+              <alias>deb10_Disk1</alias>
+              <backup>none</backup>
+              <content_type>data</content_type>
+              <format>raw</format>
+              <image_id>9074ef9f-803f-4521-a7e3-163575122249</image_id>
+              <propagate_errors>false</propagate_errors>
+              <provisioned_size>8589934592</provisioned_size>
+              <shareable>false</shareable>
+              <sparse>true</sparse>
+              <status>ok</status>
+              <storage_type>image</storage_type>
+              <total_size>0</total_size>
+              <wipe_after_delete>true</wipe_after_delete>
+              <snapshot id="f244080d-0788-4714-bf8c-0d85567efda0"/>
+              <storage_domains>
+                  <storage_domain id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+              </storage_domains>
+          </disk>
+          <disk id="55e644df-ca85-4ff4-ab5f-33885e90a17d">
+              <name>Debbie_Disk3</name>
+              <description></description>
+              <actual_size>0</actual_size>
+              <alias>Debbie_Disk3</alias>
+              <backup>none</backup>
+              <content_type>data</content_type>
+              <format>raw</format>
+              <image_id>2b3f5294-0230-4ddb-a0d9-96a0c6d601b2</image_id>
+              <propagate_errors>false</propagate_errors>
+              <provisioned_size>1073741824</provisioned_size>
+              <shareable>false</shareable>
+              <sparse>true</sparse>
+              <status>ok</status>
+              <storage_type>image</storage_type>
+              <total_size>0</total_size>
+              <wipe_after_delete>false</wipe_after_delete>
+              <snapshot id="f244080d-0788-4714-bf8c-0d85567efda0"/>
+              <storage_domains>
+                  <storage_domain id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+              </storage_domains>
+          </disk>
+          <disk id="d9ba0873-5d5e-464a-945d-132bccba49fd">
+              <name>Debbie_Disk2</name>
+              <description></description>
+              <actual_size>0</actual_size>
+              <alias>Debbie_Disk2</alias>
+              <backup>none</backup>
+              <content_type>data</content_type>
+              <format>raw</format>
+              <image_id>264fedcf-1e7f-4fc4-9ba6-48a8f9b1decc</image_id>
+              <propagate_errors>false</propagate_errors>
+              <provisioned_size>1073741824</provisioned_size>
+              <shareable>false</shareable>
+              <sparse>true</sparse>
+              <status>ok</status>
+              <storage_type>image</storage_type>
+              <total_size>0</total_size>
+              <wipe_after_delete>false</wipe_after_delete>
+              <snapshot id="f244080d-0788-4714-bf8c-0d85567efda0"/>
+              <storage_domains>
+                  <storage_domain id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+              </storage_domains>
+          </disk>
+      </disks>
+    :code: 200
+    :headers:
+      date: Tue, 03 Mar 2020 13:13:13 GMT
+      server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+      content-encoding: gzip
+      content-type: application/xml;charset=UTF-8
+      content-length: '631'
+      correlation-id: 3ed06943-f21b-4b8e-9b0d-ab123d3e2181
+    :message: 
+? https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/ca7e8d64-0fc7-45de-b258-ae471ea31056/snapshots/129f9565-c090-44d6-8181-998e2f160c83/disks{}GET
+: - :body: |
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <disks>
+          <disk id="d9ba0873-5d5e-464a-945d-132bccba49fd">
+              <name>Debbie_Disk2</name>
+              <description></description>
+              <actual_size>1073741824</actual_size>
+              <alias>Debbie_Disk2</alias>
+              <backup>none</backup>
+              <content_type>data</content_type>
+              <format>cow</format>
+              <image_id>547539b9-a2af-49b2-8d1e-68a85a0ff9b2</image_id>
+              <propagate_errors>false</propagate_errors>
+              <provisioned_size>1073741824</provisioned_size>
+              <shareable>false</shareable>
+              <sparse>true</sparse>
+              <status>ok</status>
+              <storage_type>image</storage_type>
+              <total_size>0</total_size>
+              <wipe_after_delete>false</wipe_after_delete>
+              <snapshot id="129f9565-c090-44d6-8181-998e2f160c83"/>
+              <storage_domains>
+                  <storage_domain id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+              </storage_domains>
+          </disk>
+          <disk id="55e644df-ca85-4ff4-ab5f-33885e90a17d">
+              <name>Debbie_Disk3</name>
+              <description></description>
+              <actual_size>1073741824</actual_size>
+              <alias>Debbie_Disk3</alias>
+              <backup>none</backup>
+              <content_type>data</content_type>
+              <format>cow</format>
+              <image_id>e4d483dd-d4b3-449c-93bc-f638f6e89903</image_id>
+              <propagate_errors>false</propagate_errors>
+              <provisioned_size>1073741824</provisioned_size>
+              <shareable>false</shareable>
+              <sparse>true</sparse>
+              <status>ok</status>
+              <storage_type>image</storage_type>
+              <total_size>0</total_size>
+              <wipe_after_delete>false</wipe_after_delete>
+              <snapshot id="129f9565-c090-44d6-8181-998e2f160c83"/>
+              <storage_domains>
+                  <storage_domain id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+              </storage_domains>
+          </disk>
+          <disk id="36b02b75-fcbd-42c1-818f-82ec90d4780b">
+              <name>deb10_Disk1</name>
+              <description></description>
+              <actual_size>1073741824</actual_size>
+              <alias>deb10_Disk1</alias>
+              <backup>none</backup>
+              <content_type>data</content_type>
+              <format>cow</format>
+              <image_id>61d498ab-3dc9-4965-83a6-c2090a0d9bec</image_id>
+              <propagate_errors>false</propagate_errors>
+              <provisioned_size>8589934592</provisioned_size>
+              <shareable>false</shareable>
+              <sparse>true</sparse>
+              <status>ok</status>
+              <storage_type>image</storage_type>
+              <total_size>0</total_size>
+              <wipe_after_delete>true</wipe_after_delete>
+              <snapshot id="129f9565-c090-44d6-8181-998e2f160c83"/>
+              <storage_domains>
+                  <storage_domain id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+              </storage_domains>
+          </disk>
+      </disks>
+    :code: 200
+    :headers:
+      date: Tue, 03 Mar 2020 13:13:13 GMT
+      server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+      content-encoding: gzip
+      content-type: application/xml;charset=UTF-8
+      content-length: '621'
+      correlation-id: 56d8a400-5f4d-4473-9bb4-b2a151e16afd
+    :message: 
+? https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/882b9a7c-f3f0-49a3-bda6-1ee289a6adf0/snapshots/4f81c601-d896-4c12-b34e-0bfcabd7d9e1/disks{}GET
+: - :body: |
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <disks>
+          <disk id="f5c0844f-70ee-4e12-a188-0e3dcbb140a6">
+              <name>rhel_seven_Disk1</name>
+              <description></description>
+              <actual_size>2147483648</actual_size>
+              <alias>rhel_seven_Disk1</alias>
+              <backup>none</backup>
+              <content_type>data</content_type>
+              <format>raw</format>
+              <image_id>183d7567-19bc-43bf-aefb-2d39ed33e11a</image_id>
+              <propagate_errors>false</propagate_errors>
+              <provisioned_size>9663676416</provisioned_size>
+              <shareable>false</shareable>
+              <sparse>true</sparse>
+              <status>ok</status>
+              <storage_type>image</storage_type>
+              <total_size>0</total_size>
+              <wipe_after_delete>true</wipe_after_delete>
+              <snapshot id="4f81c601-d896-4c12-b34e-0bfcabd7d9e1"/>
+              <storage_domains>
+                  <storage_domain id="ee04ae85-01ba-4610-86a8-6c17c1b8e4b5"/>
+              </storage_domains>
+          </disk>
+      </disks>
+    :code: 200
+    :headers:
+      date: Tue, 03 Mar 2020 13:13:13 GMT
+      server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+      content-encoding: gzip
+      content-type: application/xml;charset=UTF-8
+      content-length: '473'
+      correlation-id: 867cb76e-cba8-4d3a-8e10-1cdaa26445fd
+    :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/networkattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <network_attachments>
+        <network_attachment href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/networkattachments/55b11f02-55e8-4978-a2c6-806c19a4e19f" id="55b11f02-55e8-4978-a2c6-806c19a4e19f">
+            <in_sync>true</in_sync>
+            <ip_address_assignments>
+                <ip_address_assignment>
+                    <assignment_method>dhcp</assignment_method>
+                    <ip>
+                        <version>v4</version>
+                    </ip>
+                </ip_address_assignment>
+                <ip_address_assignment>
+                    <assignment_method>autoconf</assignment_method>
+                    <ip>
+                        <version>v6</version>
+                    </ip>
+                </ip_address_assignment>
+            </ip_address_assignments>
+            <reported_configurations>
+                <reported_configuration>
+                    <actual_value>1500</actual_value>
+                    <expected_value>1500</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>mtu</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>true</actual_value>
+                    <expected_value>true</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>bridged</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <in_sync>true</in_sync>
+                    <name>vlan</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>LEGACY</actual_value>
+                    <expected_value>LEGACY</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>switchType</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>DHCP</actual_value>
+                    <expected_value>DHCP</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>ipv4_boot_protocol</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>AUTOCONF</actual_value>
+                    <expected_value>AUTOCONF</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>ipv6_boot_protocol</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>192.168.178.1</actual_value>
+                    <in_sync>true</in_sync>
+                    <name>dns_configuration</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>true</actual_value>
+                    <expected_value>true</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>default_route</name>
+                </reported_configuration>
+            </reported_configurations>
+            <host href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0" id="dc0e9719-0189-49b1-81dc-b3db078a8ed0"/>
+            <host_nic href="/ovirt-engine/api/hosts/dc0e9719-0189-49b1-81dc-b3db078a8ed0/nics/04ca5782-debf-4f02-88e2-db5c0c1c38d9" id="04ca5782-debf-4f02-88e2-db5c0c1c38d9"/>
+            <network href="/ovirt-engine/api/networks/080dbd4f-53a7-412d-b3df-38bfc7fe887d" id="080dbd4f-53a7-412d-b3df-38bfc7fe887d"/>
+        </network_attachment>
+    </network_attachments>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:13 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '616'
+    correlation-id: 231bcde8-5d90-40fa-a44d-b395c0406547
+  :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/networkattachments{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <network_attachments>
+        <network_attachment href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/networkattachments/bbc7864b-b52d-40e4-820c-8a8621d579d0" id="bbc7864b-b52d-40e4-820c-8a8621d579d0">
+            <in_sync>true</in_sync>
+            <ip_address_assignments>
+                <ip_address_assignment>
+                    <assignment_method>dhcp</assignment_method>
+                    <ip>
+                        <version>v4</version>
+                    </ip>
+                </ip_address_assignment>
+                <ip_address_assignment>
+                    <assignment_method>autoconf</assignment_method>
+                    <ip>
+                        <version>v6</version>
+                    </ip>
+                </ip_address_assignment>
+            </ip_address_assignments>
+            <reported_configurations>
+                <reported_configuration>
+                    <actual_value>1500</actual_value>
+                    <expected_value>1500</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>mtu</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>true</actual_value>
+                    <expected_value>true</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>bridged</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <in_sync>true</in_sync>
+                    <name>vlan</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>LEGACY</actual_value>
+                    <expected_value>LEGACY</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>switchType</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>DHCP</actual_value>
+                    <expected_value>DHCP</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>ipv4_boot_protocol</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>AUTOCONF</actual_value>
+                    <expected_value>AUTOCONF</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>ipv6_boot_protocol</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>192.168.178.1</actual_value>
+                    <in_sync>true</in_sync>
+                    <name>dns_configuration</name>
+                </reported_configuration>
+                <reported_configuration>
+                    <actual_value>true</actual_value>
+                    <expected_value>true</expected_value>
+                    <in_sync>true</in_sync>
+                    <name>default_route</name>
+                </reported_configuration>
+            </reported_configurations>
+            <host href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e" id="72877001-6012-4921-bdd2-3ff17043083e"/>
+            <host_nic href="/ovirt-engine/api/hosts/72877001-6012-4921-bdd2-3ff17043083e/nics/c21efb3b-372e-420a-aaf2-8f2c2a71511b" id="c21efb3b-372e-420a-aaf2-8f2c2a71511b"/>
+            <network href="/ovirt-engine/api/networks/dac27d35-5858-4663-abd2-bf087050b3eb" id="dac27d35-5858-4663-abd2-bf087050b3eb"/>
+        </network_attachment>
+    </network_attachments>
+  :code: 200
+  :headers:
+    date: Tue, 03 Mar 2020 13:13:18 GMT
+    server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '617'
+    correlation-id: cbab46b3-4397-4f81-8d0e-6a4ab42a289f
+  :message: 

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_multi_external_network_ovn_provider.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresh/refresher_multi_external_network_ovn_provider.yml
@@ -1,0 +1,813 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://engine-43.lab.inz.redhat.com:35357/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":"pass123"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:25 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"expires": "2020-03-07T17:13:25Z", "id": "RRqC92AKC1IZLOxfHXrg1eI9PUV9sdOLEK9TBh9xY56y0Ph7fvIenHvr5AQre6qYjyYh11poVneBt2JqWVLeYA"},
+        "serviceCatalog": [{"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/",
+        "region": "RegionOne", "id": "00000000000000000000000000000001", "internalURL":
+        "https://engine-43.lab.inz.redhat.com:9696/", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/"}],
+        "type": "network", "name": "neutron"}, {"endpoints_links": [], "endpoints":
+        [{"adminURL": "https://engine-43.lab.inz.redhat.com:35357/", "region": "RegionOne",
+        "publicURL": "https://engine-43.lab.inz.redhat.com:35357/", "internalURL": "https://engine-43.lab.inz.redhat.com:35357/",
+        "id": "00000000000000000000000000000002"}], "type": "identity", "name": "keystone"},
+        {"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "region": "RegionOne", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "internalURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/", "id": "00000000000000000000000000000002"}],
+        "type": "compute", "name": "nova"}], "user": {"username": "admin", "roles_links":
+        [], "id": "", "roles": [{"name": "admin"}], "name": "admin"}}}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:39 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - RRqC92AKC1IZLOxfHXrg1eI9PUV9sdOLEK9TBh9xY56y0Ph7fvIenHvr5AQre6qYjyYh11poVneBt2JqWVLeYA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:25 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
+        "https://engine-43.lab.inz.redhat.com:9696/v2.0/", "rel": "self"}]}]}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:39 GMT
+- request:
+    method: post
+    uri: https://engine-43.lab.inz.redhat.com:35357/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":"pass123"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:26 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"expires": "2020-03-07T17:13:26Z", "id": "FgXEqWlDwZM2pk3jPjaj6Fy7ttOAk98svR_pn5YCij96Gmgsej-gZrMI3ipRVJXTR28YIWHE-HjoERE4AXjevg"},
+        "serviceCatalog": [{"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/",
+        "region": "RegionOne", "id": "00000000000000000000000000000001", "internalURL":
+        "https://engine-43.lab.inz.redhat.com:9696/", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/"}],
+        "type": "network", "name": "neutron"}, {"endpoints_links": [], "endpoints":
+        [{"adminURL": "https://engine-43.lab.inz.redhat.com:35357/", "region": "RegionOne",
+        "publicURL": "https://engine-43.lab.inz.redhat.com:35357/", "internalURL": "https://engine-43.lab.inz.redhat.com:35357/",
+        "id": "00000000000000000000000000000002"}], "type": "identity", "name": "keystone"},
+        {"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "region": "RegionOne", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "internalURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/", "id": "00000000000000000000000000000002"}],
+        "type": "compute", "name": "nova"}], "user": {"username": "admin", "roles_links":
+        [], "id": "", "roles": [{"name": "admin"}], "name": "admin"}}}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:40 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/networks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - FgXEqWlDwZM2pk3jPjaj6Fy7ttOAk98svR_pn5YCij96Gmgsej-gZrMI3ipRVJXTR28YIWHE-HjoERE4AXjevg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:26 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"networks": [{"status": "ACTIVE", "name": "extNetwork", "provider:physical_network":
+        "ovirtmgmt", "tenant_id": "00000000000000000000000000000001", "mtu": 1442,
+        "port_security_enabled": true, "provider:network_type": "flat", "id": "688a83e2-c73b-4b37-be7e-4671ac64e4f0"},
+        {"status": "ACTIVE", "name": "extNetwork", "provider:physical_network": "ovirtmgmt",
+        "tenant_id": "00000000000000000000000000000001", "mtu": 1442, "port_security_enabled":
+        true, "provider:network_type": "flat", "id": "c249135d-c8f2-4192-92e8-dcc23c6672b1"},
+        {"status": "ACTIVE", "name": "ext_net", "tenant_id": "00000000000000000000000000000001",
+        "mtu": 1442, "port_security_enabled": true, "id": "f2b8c578-e2b0-47cc-a807-2034aaa37cc8"}]}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:40 GMT
+- request:
+    method: post
+    uri: https://engine-43.lab.inz.redhat.com:35357/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":"pass123"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:27 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"expires": "2020-03-07T17:13:27Z", "id": "lXa9ZNlMdOXkAOdZA7C8rrLINiGnOIPBaK8fFj9kqqNWZ7abbvlxqjuiFvaRCkgfkrroGseO6tgF1WgVO9MxFg"},
+        "serviceCatalog": [{"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/",
+        "region": "RegionOne", "id": "00000000000000000000000000000001", "internalURL":
+        "https://engine-43.lab.inz.redhat.com:9696/", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/"}],
+        "type": "network", "name": "neutron"}, {"endpoints_links": [], "endpoints":
+        [{"adminURL": "https://engine-43.lab.inz.redhat.com:35357/", "region": "RegionOne",
+        "publicURL": "https://engine-43.lab.inz.redhat.com:35357/", "internalURL": "https://engine-43.lab.inz.redhat.com:35357/",
+        "id": "00000000000000000000000000000002"}], "type": "identity", "name": "keystone"},
+        {"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "region": "RegionOne", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "internalURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/", "id": "00000000000000000000000000000002"}],
+        "type": "compute", "name": "nova"}], "user": {"username": "admin", "roles_links":
+        [], "id": "", "roles": [{"name": "admin"}], "name": "admin"}}}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:41 GMT
+- request:
+    method: post
+    uri: https://engine-43.lab.inz.redhat.com:35357/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":"pass123"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:27 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"expires": "2020-03-07T17:13:27Z", "id": "SfRgViX61tjv85xrTmudQvP3qC2RYsYPlxVEoS5asZ7iz2EQ7TkEYJYxgWbflDqPxOSf6xc0V2Gmjzerpx3b_g"},
+        "serviceCatalog": [{"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/",
+        "region": "RegionOne", "id": "00000000000000000000000000000001", "internalURL":
+        "https://engine-43.lab.inz.redhat.com:9696/", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/"}],
+        "type": "network", "name": "neutron"}, {"endpoints_links": [], "endpoints":
+        [{"adminURL": "https://engine-43.lab.inz.redhat.com:35357/", "region": "RegionOne",
+        "publicURL": "https://engine-43.lab.inz.redhat.com:35357/", "internalURL": "https://engine-43.lab.inz.redhat.com:35357/",
+        "id": "00000000000000000000000000000002"}], "type": "identity", "name": "keystone"},
+        {"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "region": "RegionOne", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "internalURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/", "id": "00000000000000000000000000000002"}],
+        "type": "compute", "name": "nova"}], "user": {"username": "admin", "roles_links":
+        [], "id": "", "roles": [{"name": "admin"}], "name": "admin"}}}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:41 GMT
+- request:
+    method: post
+    uri: https://engine-43.lab.inz.redhat.com:35357/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":"pass123"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:27 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"expires": "2020-03-07T17:13:27Z", "id": "IzzzHAtOtvdZ5x3d-D5BF92Gul9JlMM04ouH0oq9l6gkOJqkSXhSxuBEWmgCjOe-otkn5wdflpj6recYFJhe1Q"},
+        "serviceCatalog": [{"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/",
+        "region": "RegionOne", "id": "00000000000000000000000000000001", "internalURL":
+        "https://engine-43.lab.inz.redhat.com:9696/", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/"}],
+        "type": "network", "name": "neutron"}, {"endpoints_links": [], "endpoints":
+        [{"adminURL": "https://engine-43.lab.inz.redhat.com:35357/", "region": "RegionOne",
+        "publicURL": "https://engine-43.lab.inz.redhat.com:35357/", "internalURL": "https://engine-43.lab.inz.redhat.com:35357/",
+        "id": "00000000000000000000000000000002"}], "type": "identity", "name": "keystone"},
+        {"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "region": "RegionOne", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "internalURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/", "id": "00000000000000000000000000000002"}],
+        "type": "compute", "name": "nova"}], "user": {"username": "admin", "roles_links":
+        [], "id": "", "roles": [{"name": "admin"}], "name": "admin"}}}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:41 GMT
+- request:
+    method: post
+    uri: https://engine-43.lab.inz.redhat.com:35357/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":"pass123"}}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:27 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"expires": "2020-03-07T17:13:27Z", "id": "9ny26kPmvQM8RQ1WDf3ti0StOKiC6YDuD-YiXh9qh0gbwFBEaceAlspjgzGD-DUBmxm5DglK_Np5qAhraZKWGA"},
+        "serviceCatalog": [{"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/",
+        "region": "RegionOne", "id": "00000000000000000000000000000001", "internalURL":
+        "https://engine-43.lab.inz.redhat.com:9696/", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/"}],
+        "type": "network", "name": "neutron"}, {"endpoints_links": [], "endpoints":
+        [{"adminURL": "https://engine-43.lab.inz.redhat.com:35357/", "region": "RegionOne",
+        "publicURL": "https://engine-43.lab.inz.redhat.com:35357/", "internalURL": "https://engine-43.lab.inz.redhat.com:35357/",
+        "id": "00000000000000000000000000000002"}], "type": "identity", "name": "keystone"},
+        {"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "region": "RegionOne", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "internalURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/", "id": "00000000000000000000000000000002"}],
+        "type": "compute", "name": "nova"}], "user": {"username": "admin", "roles_links":
+        [], "id": "", "roles": [{"name": "admin"}], "name": "admin"}}}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:41 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:35357/v2.0/tenants
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 9ny26kPmvQM8RQ1WDf3ti0StOKiC6YDuD-YiXh9qh0gbwFBEaceAlspjgzGD-DUBmxm5DglK_Np5qAhraZKWGA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:27 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenants": [{"id": "00000000000000000000000000000001", "enabled":
+        true, "description": "tenant", "name": "tenant"}]}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:41 GMT
+- request:
+    method: post
+    uri: https://engine-43.lab.inz.redhat.com:35357/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":"pass123"},"tenantName":"tenant"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"expires": "2020-03-07T17:13:28Z", "id": "0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ"},
+        "serviceCatalog": [{"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/",
+        "region": "RegionOne", "id": "00000000000000000000000000000001", "internalURL":
+        "https://engine-43.lab.inz.redhat.com:9696/", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/"}],
+        "type": "network", "name": "neutron"}, {"endpoints_links": [], "endpoints":
+        [{"adminURL": "https://engine-43.lab.inz.redhat.com:35357/", "region": "RegionOne",
+        "publicURL": "https://engine-43.lab.inz.redhat.com:35357/", "internalURL": "https://engine-43.lab.inz.redhat.com:35357/",
+        "id": "00000000000000000000000000000002"}], "type": "identity", "name": "keystone"},
+        {"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "region": "RegionOne", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "internalURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/", "id": "00000000000000000000000000000002"}],
+        "type": "compute", "name": "nova"}], "user": {"username": "admin", "roles_links":
+        [], "id": "", "roles": [{"name": "admin"}], "name": "admin"}}}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:41 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"ip_version": 4, "allocation_pools": [{"start": "192.168.179.2",
+        "stop": "192.168.179.255"}], "gateway_ip": "192.168.179.1", "name": "ext_net_sub_net",
+        "enable_dhcp": true, "network_id": "f2b8c578-e2b0-47cc-a807-2034aaa37cc8",
+        "tenant_id": "00000000000000000000000000000001", "cidr": "192.168.179.0/24",
+        "dns_nameservers": ["8.8.8.8"], "id": "20e82d67-156b-4e40-8139-84f7b0b8dcde"},
+        {"ip_version": 4, "allocation_pools": [{"start": "192.168.178.2", "stop":
+        "192.168.178.3"}], "gateway_ip": "192.168.178.1", "name": "ext_net_subnet",
+        "enable_dhcp": true, "network_id": "c249135d-c8f2-4192-92e8-dcc23c6672b1",
+        "tenant_id": "00000000000000000000000000000001", "cidr": "192.168.178.0/30",
+        "dns_nameservers": ["192.168.178.1"], "id": "b34a61e3-87ee-45eb-be3d-43b57ce9d6ab"}]}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/subnets?limit=1000&marker=b34a61e3-87ee-45eb-be3d-43b57ce9d6ab
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": []}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/floatingips?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"floatingips": []}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/ports?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": [{"device_owner": "oVirt", "port_security_enabled": true,
+        "fixed_ips": [{"subnet_id": "20e82d67-156b-4e40-8139-84f7b0b8dcde", "ip_address":
+        "192.168.179.2"}], "id": "e3d43e58-d4fa-4c8a-ba91-db873892ceee", "security_groups":
+        ["Default"], "device_id": "1ab583f4-6636-4b7c-8293-d6c3bae17391", "name":
+        "nic2", "admin_state_up": false, "network_id": "f2b8c578-e2b0-47cc-a807-2034aaa37cc8",
+        "tenant_id": "00000000000000000000000000000001", "mac_address": "56:6f:59:c0:00:00"},
+        {"mac_address": "unknown", "name": "localnet_port", "tenant_id": "00000000000000000000000000000001",
+        "network_id": "688a83e2-c73b-4b37-be7e-4671ac64e4f0", "port_security_enabled":
+        false, "admin_state_up": false, "fixed_ips": [], "id": "e1af28d8-6d13-4e3f-8b08-d93a63a2c0fc",
+        "security_groups": []}, {"mac_address": "unknown", "name": "localnet_port",
+        "tenant_id": "00000000000000000000000000000001", "network_id": "c249135d-c8f2-4192-92e8-dcc23c6672b1",
+        "port_security_enabled": false, "admin_state_up": false, "fixed_ips": [],
+        "id": "d9da3144-379b-4235-aa05-0653c8dd07bb", "security_groups": []}]}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/ports?limit=1000&marker=d9da3144-379b-4235-aa05-0653c8dd07bb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ports": []}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/routers?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"routers": [{"status": "INACTIVE", "external_gateway_info": null,
+        "name": "net1net2", "admin_state_up": true, "tenant_id": "00000000000000000000000000000001",
+        "routes": [], "id": "238ec54a-d0ec-4fb4-be6e-1763f6a2b8f4"}]}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/routers?limit=1000&marker=238ec54a-d0ec-4fb4-be6e-1763f6a2b8f4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"routers": []}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/security-groups?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"security_groups": [{"description": null, "tags": [], "tenant_id":
+        null, "created_at": "2020-02-03T09:21:28.409111", "updated_at": "2020-02-03T09:21:28.409111",
+        "security_group_rules": [{"remote_group_id": null, "direction": "egress",
+        "protocol": null, "description": null, "ethertype": "IPv4", "port_range_max":
+        null, "security_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "port_range_min":
+        null, "remote_ip_prefix": null, "id": "c8bb3d36-c391-4275-809c-4f8dcdbf08ca"},
+        {"remote_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "direction": "ingress",
+        "protocol": null, "description": null, "ethertype": "IPv6", "port_range_max":
+        null, "security_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "port_range_min":
+        null, "remote_ip_prefix": null, "id": "27976b51-d568-43c9-95eb-689c1802e926"},
+        {"remote_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "direction": "ingress",
+        "protocol": null, "description": null, "ethertype": "IPv4", "port_range_max":
+        null, "security_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "port_range_min":
+        null, "remote_ip_prefix": null, "id": "6d4949b6-8a34-48d0-911e-d87358554940"},
+        {"remote_group_id": null, "direction": "egress", "protocol": null, "description":
+        null, "ethertype": "IPv6", "port_range_max": null, "security_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45",
+        "port_range_min": null, "remote_ip_prefix": null, "id": "62ac7692-3d42-4e07-9126-53e6a3ce9052"}],
+        "revision_number": 1, "project_id": null, "id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45",
+        "name": "Default"}]}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/security-groups?limit=1000&marker=1d1c9b20-c74c-4e85-b9ba-5aec43233d45
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"security_groups": []}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: post
+    uri: https://engine-43.lab.inz.redhat.com:35357/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin@internal","password":"pass123"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:28 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"expires": "2020-03-07T17:13:28Z", "id": "bVsPJyrPb3YztAkCOn9i6GAW3wnT83DoGOxvwTA0xkjtJ7pT140ADvaZaSuaFZLcoDkCiorm09eZxNqEaYoecw"},
+        "serviceCatalog": [{"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/",
+        "region": "RegionOne", "id": "00000000000000000000000000000001", "internalURL":
+        "https://engine-43.lab.inz.redhat.com:9696/", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/"}],
+        "type": "network", "name": "neutron"}, {"endpoints_links": [], "endpoints":
+        [{"adminURL": "https://engine-43.lab.inz.redhat.com:35357/", "region": "RegionOne",
+        "publicURL": "https://engine-43.lab.inz.redhat.com:35357/", "internalURL": "https://engine-43.lab.inz.redhat.com:35357/",
+        "id": "00000000000000000000000000000002"}], "type": "identity", "name": "keystone"},
+        {"endpoints_links": [], "endpoints": [{"adminURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "region": "RegionOne", "publicURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/",
+        "internalURL": "https://engine-43.lab.inz.redhat.com:9696/v2.1/", "id": "00000000000000000000000000000002"}],
+        "type": "compute", "name": "nova"}], "user": {"username": "admin", "roles_links":
+        [], "id": "", "roles": [{"name": "admin"}], "name": "admin"}}}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/security-group-rules?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:29 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"security_group_rules": [{"remote_group_id": null, "direction": "egress",
+        "protocol": null, "description": null, "ethertype": "IPv4", "port_range_max":
+        null, "security_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "port_range_min":
+        null, "remote_ip_prefix": null, "id": "c8bb3d36-c391-4275-809c-4f8dcdbf08ca"},
+        {"remote_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "direction": "ingress",
+        "protocol": null, "description": null, "ethertype": "IPv6", "port_range_max":
+        null, "security_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "port_range_min":
+        null, "remote_ip_prefix": null, "id": "27976b51-d568-43c9-95eb-689c1802e926"},
+        {"remote_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "direction": "ingress",
+        "protocol": null, "description": null, "ethertype": "IPv4", "port_range_max":
+        null, "security_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45", "port_range_min":
+        null, "remote_ip_prefix": null, "id": "6d4949b6-8a34-48d0-911e-d87358554940"},
+        {"remote_group_id": null, "direction": "egress", "protocol": null, "description":
+        null, "ethertype": "IPv6", "port_range_max": null, "security_group_id": "1d1c9b20-c74c-4e85-b9ba-5aec43233d45",
+        "port_range_min": null, "remote_ip_prefix": null, "id": "62ac7692-3d42-4e07-9126-53e6a3ce9052"}]}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:42 GMT
+- request:
+    method: get
+    uri: https://engine-43.lab.inz.redhat.com:9696/v2.0/security-group-rules?limit=1000&marker=62ac7692-3d42-4e07-9126-53e6a3ce9052
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0YS3oJFvDgrHNrG7HFsbHRmYpLNrKsYxOap98Gyg-IGUDiI6O6ExEgZDSxImujzBmNh9kGPjyf7WkwTcJCouZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - BaseHTTP/0.3 Python/2.7.5
+      Date:
+      - Tue, 03 Mar 2020 13:13:29 GMT
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"security_group_rules": []}'
+    http_version: null
+  recorded_at: Tue, 03 Mar 2020 13:13:43 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
In ovirt external networks with same name can be defined in the same ems but
not in the same datacenter.
We need a way to let external_distributed_virtual_switches belong to the
owning datacenter

Related to:
  - https://bugzilla.redhat.com/show_bug.cgi?id=1751151
  - https://github.com/ManageIQ/manageiq-providers-ovirt/pull/477
  - https://github.com/ManageIQ/manageiq-providers-ovirt/pull/478