### PR TITLE
[WIP] Ovirt::NetworkManager belongs to a parent manager

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -10,6 +10,7 @@ class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::Network
   require_nested :Refresher
   require_nested :SecurityGroup
 
+  include BelongsToParentManagerMixin
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin
 


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/20229
Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/136