### PR TITLE
Add cpu_affinity for vms

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -374,6 +374,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       parent_folder = persister.ems_folders.lazy_find("#{datacenter_id}_vm")
       resource_pool = persister.resource_pools.lazy_find("#{vm.cluster.id}_respool") unless template
       host          = persister.hosts.lazy_find(host_ems_ref) if host_ems_ref.present?
+      cpu_affinity  = vm.cpu.cpu_tune&.vcpu_pins&.map(&:vcpu)&.join(',')
 
       storages, disks = storages(vm)
 
@@ -400,7 +401,8 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :storages         => storages,
         :storage          => storages.first,
         :parent           => parent_folder,
-        :resource_pool    => resource_pool
+        :resource_pool    => resource_pool,
+        :cpu_affinity     => cpu_affinity
       }
 
       attrs_to_assign[:restart_needed] = vm.next_run_configuration_exists unless template

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -374,7 +374,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       parent_folder = persister.ems_folders.lazy_find("#{datacenter_id}_vm")
       resource_pool = persister.resource_pools.lazy_find("#{vm.cluster.id}_respool") unless template
       host          = persister.hosts.lazy_find(host_ems_ref) if host_ems_ref.present?
-      cpu_affinity  = vm.cpu.cpu_tune&.vcpu_pins&.map(&:vcpu)&.join(',')
+      cpu_affinity  = vm.cpu&.cpu_tune&.vcpu_pins&.map(&:vcpu)&.join(',')
 
       storages, disks = storages(vm)
 


### PR DESCRIPTION
This PR adds cpu affinity information for vms, aka cpu pinning, as a comma separated list of virtual cpu's that are pinned to a cpu set.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1846623