### PR TITLE
Update cpu affinity to include both virtual and host cpu

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -374,7 +374,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       parent_folder = persister.ems_folders.lazy_find("#{datacenter_id}_vm")
       resource_pool = persister.resource_pools.lazy_find("#{vm.cluster.id}_respool") unless template
       host          = persister.hosts.lazy_find(host_ems_ref) if host_ems_ref.present?
-      cpu_affinity  = vm.cpu&.cpu_tune&.vcpu_pins&.map(&:vcpu)&.join(',')
+      cpu_affinity  = vm.cpu&.cpu_tune&.vcpu_pins&.map{ |pin| "#{pin.vcpu}##{pin.cpu_set}" }&.join(",")
 
       storages, disks = storages(vm)
 

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -374,7 +374,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       parent_folder = persister.ems_folders.lazy_find("#{datacenter_id}_vm")
       resource_pool = persister.resource_pools.lazy_find("#{vm.cluster.id}_respool") unless template
       host          = persister.hosts.lazy_find(host_ems_ref) if host_ems_ref.present?
-      cpu_affinity  = vm.cpu&.cpu_tune&.vcpu_pins&.map{ |pin| "#{pin.vcpu}##{pin.cpu_set}" }&.join(",")
+      cpu_affinity  = vm.cpu&.cpu_tune&.vcpu_pins&.map { |pin| "#{pin.vcpu}##{pin.cpu_set}" }&.join(",")
 
       storages, disks = storages(vm)
 


### PR DESCRIPTION
Followup PR for https://github.com/ManageIQ/manageiq-providers-ovirt/pull/502, customer requested both virtual and physical cpu information be included.

Result will still be a comma separated string, e.g. `"0#3,1#2"` to keep it at least somewhat consistent with the current vmware provider format (the other provider where this is set). In the future this format may be changed, but for now this is it.