### PR TITLE
Collect tools status information

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/collector.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector.rb
@@ -157,7 +157,7 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManageIQ::Providers::I
     end
   end
 
-  def collect_guest_applications(vm)
+  def collect_vm_guest_applications(vm)
     manager.with_provider_connection do |connection|
       connection.follow_link(vm.applications)
     end

--- a/app/models/manageiq/providers/redhat/inventory/collector.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector.rb
@@ -10,6 +10,7 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManageIQ::Providers::I
   attr_reader :hosts
   attr_reader :vms
   attr_reader :templates
+  attr_reader :applications
 
   def initialize(manager, _target)
     super
@@ -25,6 +26,7 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManageIQ::Providers::I
     @hosts          = []
     @vms            = []
     @templates      = []
+    @applications   = []
   end
 
   def collect_clusters
@@ -152,6 +154,12 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManageIQ::Providers::I
       disk_attachments.collect do |disk_attachment|
         connection.follow_link(disk_attachment.disk)
       end
+    end
+  end
+
+  def collect_vm_applications(vm)
+    manager.with_provider_connection do |connection|
+      connection.follow_link(vm.applications)
     end
   end
 

--- a/app/models/manageiq/providers/redhat/inventory/collector.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector.rb
@@ -10,7 +10,7 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManageIQ::Providers::I
   attr_reader :hosts
   attr_reader :vms
   attr_reader :templates
-  attr_reader :applications
+  attr_reader :guest_applications
 
   def initialize(manager, _target)
     super
@@ -19,14 +19,14 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManageIQ::Providers::I
   end
 
   def initialize_inventory_sources
-    @clusters       = []
-    @networks       = []
-    @storagedomains = []
-    @datacenters    = []
-    @hosts          = []
-    @vms            = []
-    @templates      = []
-    @applications   = []
+    @clusters           = []
+    @networks           = []
+    @storagedomains     = []
+    @datacenters        = []
+    @hosts              = []
+    @vms                = []
+    @templates          = []
+    @guest_applications = []
   end
 
   def collect_clusters
@@ -157,7 +157,7 @@ class ManageIQ::Providers::Redhat::Inventory::Collector < ManageIQ::Providers::I
     end
   end
 
-  def collect_vm_applications(vm)
+  def collect_guest_applications(vm)
     manager.with_provider_connection do |connection|
       connection.follow_link(vm.applications)
     end

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -403,7 +403,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :storage          => storages.first,
         :parent           => parent_folder,
         :resource_pool    => resource_pool,
-        :cpu_affinity     => cpu_affinity
+        :cpu_affinity     => cpu_affinity,
         :guest_applications => applications
       }
 

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -403,6 +403,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :storage          => storages.first,
         :parent           => parent_folder,
         :resource_pool    => resource_pool,
+        :cpu_affinity     => cpu_affinity
         :guest_applications => applications
       }
 

--- a/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
@@ -21,7 +21,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
     add_collection(infra, :networks)
     add_collection(infra, :operating_systems)
     add_collection(infra, :vms)
-    add_collection(infra, :guest_applications)
 
     add_datacenters
     add_miq_templates

--- a/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
@@ -21,6 +21,7 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
     add_collection(infra, :networks)
     add_collection(infra, :operating_systems)
     add_collection(infra, :vms)
+    add_collection(infra, :guest_applications)
 
     add_datacenters
     add_miq_templates


### PR DESCRIPTION
~~This is a work in progress for https://bugzilla.redhat.com/show_bug.cgi?id=1846624~~

As per discussions on gitter, I was originally just going to look at a the applications list for a given VM and check for the "ovirt-guest-agent". However, I noticed that we collect more information for SCVMM:

https://github.com/ManageIQ/manageiq-providers-scvmm/blob/master/app/models/manageiq/providers/microsoft/infra_manager/parser_mixin.rb#L107-L116

That lead me to look at the schema to see if we had a table we could link to instead of storing information directly on the vms table, and I found the `guest_applications` table which has a relationship to either the `vms` table or the `hosts` table.

So, for now the plan is to get information into the `guest_applications` table, then use `vm.guest_applications.any?{ |ga| ga.name =~ /guest-agent/ }` to set `tools_status`.

Draft in progress for now. I'm not sure how to handle `guest_applications` in the Persister since that table doesn't have an `ems_ref` field.