### PR TITLE
Set the monitor_running event to unblock the main thread

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -21,8 +21,8 @@ class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ
 
   def monitor_events
     event_monitor_handle.start
+    event_monitor_running
     event_monitor_handle.each_batch do |events|
-      event_monitor_running
       @queue.enq events
       sleep_poll_normal
     end


### PR DESCRIPTION
Without setting the monitor_running concurrent event the main event_catcher worker thread doesn't ever leave the do_before_work_loop which means it can't be shutdown cleanly until the first event is raised.

Related to: https://github.com/ManageIQ/manageiq-providers-amazon/pull/633