### PR TITLE
MiqHashStruct was replaced with OpenStruct in provisioning

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
@@ -32,7 +32,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
     it "for ISO and PXE provisioning" do
       result = workflow.allowed_storages
       expect(result.length).to eq(2)
-      result.each { |storage| expect(storage).to be_kind_of(MiqHashStruct) }
+      result.each { |storage| expect(storage).to be_kind_of(OpenStruct) }
       result.each { |storage| expect(storage.storage_domain_type).to eq("data") }
     end
 
@@ -43,7 +43,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
 
       result = workflow.allowed_storages
       expect(result.length).to eq(1)
-      result.each { |storage| expect(storage).to be_kind_of(MiqHashStruct) }
+      result.each { |storage| expect(storage).to be_kind_of(OpenStruct) }
       result.each { |storage| expect(storage.storage_domain_type).to eq("data") }
     end
   end


### PR DESCRIPTION
In core the use of MiqHashStruct was replaced with OpenStruct in miq_provision_virt_workflow so we need to change the expectations here to match.

Test failures: https://travis-ci.com/github/ManageIQ/manageiq-providers-ovirt/jobs/364034924#L2046-L2060

Introduced by: https://github.com/ManageIQ/manageiq/pull/20374