### PR TITLE
[IVANCHUK] html5 console will be disabled by default

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
@@ -1,12 +1,17 @@
 class ManageIQ::Providers::Redhat::InfraManager::Vm
   module RemoteConsole
     def console_supported?(type)
-      %w(SPICE VNC).include?(type.upcase)
+      return true if type.upcase == 'NATIVE'
+
+      %w[SPICE VNC].include?(type.upcase) && html5_console_enabled?
     end
 
     def validate_remote_console_acquire_ticket(protocol, options = {})
       raise(MiqException::RemoteConsoleNotSupportedError,
             "#{protocol} protocol not enabled for this vm") unless protocol.to_sym == :html5
+
+      raise(MiqException::RemoteConsoleNotSupportedError,
+            "Html5 console is disabled by default, check settings to enable it") unless html5_console_enabled?
 
       raise(MiqException::RemoteConsoleNotSupportedError,
             "#{protocol} remote console requires the vm to be registered with a management system.") if ext_management_system.nil?
@@ -39,5 +44,11 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm
 
       MiqTask.generic_action_with_callback(task_opts, queue_opts)
     end
+  end
+
+  private
+
+  def html5_console_enabled?
+    !!::Settings.ems.ems_redhat&.consoles&.html5_enabled
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,8 @@
     :product_version_to_api_version_regexps:
       :'^3\..*$': 3
       :'^4\..*$': 3 4
+    :consoles:
+      :html5_enabled: false
     :resolve_ip_addresses: true
     :inventory:
       :read_timeout: 1.hour

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm/remote_console_spec.rb
@@ -1,0 +1,57 @@
+describe ManageIQ::Providers::Redhat::InfraManager::Vm::RemoteConsole do
+  let(:user) { FactoryBot.create(:user) }
+  let(:ems) { FactoryBot.create(:ems_redhat) }
+  let(:vm) { FactoryBot.create(:vm_redhat, :ext_management_system => ems) }
+
+  context '#console_supported?' do
+    it 'html5 disabled in settings' do
+      ::Settings.ems.ems_redhat.consoles.html5_enabled = false
+
+      expect(vm.console_supported?('spice')).to be false
+      expect(vm.console_supported?('vnc')).to be false
+      expect(vm.console_supported?('native')).to be true
+    end
+
+    it 'html5 enabled in settings' do
+      ::Settings.ems.ems_redhat.consoles.html5_enabled = true
+
+      expect(vm.console_supported?('spice')).to be true
+      expect(vm.console_supported?('vnc')).to be true
+      expect(vm.console_supported?('native')).to be true
+    end
+  end
+
+  context '#validate_remote_console_acquire_ticket' do
+    it 'no errors for html5 console enabled' do
+      ::Settings.ems.ems_redhat.consoles.html5_enabled = true
+
+      expect { vm.validate_remote_console_acquire_ticket('html5') }.not_to raise_error
+    end
+
+    context 'errors' do
+      it 'html5 disabled by default in settings' do
+        ::Settings.ems.ems_redhat.consoles.html5_enabled = false
+
+        expect { vm.validate_remote_console_acquire_ticket('html5') }
+          .to raise_error(MiqException::RemoteConsoleNotSupportedError,
+                          /Html5 console is disabled by default/)
+      end
+
+      it 'vm with no ems' do
+        ::Settings.ems.ems_redhat.consoles.html5_enabled = true
+        vm.update_attribute(:ext_management_system, nil)
+
+        expect { vm.validate_remote_console_acquire_ticket('html5') }
+          .to raise_error(MiqException::RemoteConsoleNotSupportedError, /registered with a management system/)
+      end
+
+      it 'vm not running' do
+        ::Settings.ems.ems_redhat.consoles.html5_enabled = true
+        vm.update_attribute(:raw_power_state, 'poweredOff')
+
+        expect { vm.validate_remote_console_acquire_ticket('html5') }
+          .to raise_error(MiqException::RemoteConsoleNotSupportedError, /vm to be running/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Html5 is not officially supported anymore in RHV. We can disable it by default using a property in the settings file.
In this way the feature can be enabled at user own risk.

(cherry picked from commit e4158a0abf53ca7ae9028c36943825299a69b20a)

We need this change in ivanchuk for https://bugzilla.redhat.com/show_bug.cgi?id=1862600 so that the html5 console button is properly disabled in UI for RHV virtual machines.

I'm creating a separate backport PR, since a plain cherry-pick won't work here (the commit depends on another commits from native console work, which we still do not have in ivanchuk).