### PR TITLE
Add an event_target_parser for graph targeted refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   require_nested  :Datacenter
   require_nested  :EventCatcher
   require_nested  :EventParser
+  require_nested  :EventTargetParser
   require_nested  :Folder
   require_nested  :RefreshWorker
   require_nested  :Refresher

--- a/app/models/manageiq/providers/redhat/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_target_parser.rb
@@ -1,0 +1,40 @@
+class ManageIQ::Providers::Redhat::InfraManager::EventTargetParser
+  attr_reader :ems_event
+
+  # @param ems_event [EmsEvent] EmsEvent object
+  def initialize(ems_event)
+    @ems_event = ems_event
+  end
+
+  # Parses all targets that are present in the EmsEvent given in the initializer
+  #
+  # @return [Array] Array of InventoryRefresh::Target objects
+  def parse
+    target_collection = InventoryRefresh::TargetCollection.new(:manager => ems_event.ext_management_system, :event => ems_event)
+
+    data = ems_event.full_data
+
+    add_vm_target(target_collection, data["vm"])             if data["vm"].present?
+    add_template_target(target_collection, data["template"]) if data["template"].present?
+    add_cluster_target(target_collection, data["cluster"])   if data["cluster"].present?
+
+    target_collection.targets
+  end
+
+  private
+
+  def add_vm_target(target_collection, vm_data)
+    ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm_data["href"])
+    target_collection.add_target(:association => :vms, :manager_ref => {:ems_ref => ems_ref})
+  end
+
+  def add_template_target(target_collection, template_data)
+    ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(template_data["href"])
+    target_collection.add_target(:association => :miq_templates, :manager_ref => {:ems_ref => ems_ref})
+  end
+
+  def add_cluster_target(target_collection, cluster_data)
+    ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(cluster_data["href"])
+    target_collection.add_target(:association => :ems_clusters, :manager_ref => {:ems_ref => ems_ref})
+  end
+end

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_target_parser_spec.rb
@@ -1,0 +1,49 @@
+describe ManageIQ::Providers::Redhat::InfraManager::EventTargetParser do
+  let!(:ems) { FactoryBot.create(:ems_redhat) }
+  let(:event_type) { "USER_ADD_VM" }
+  let(:ems_event) do
+    FactoryBot.create(:ems_event, :ext_management_system => ems, :event_type => event_type, :full_data => event_data, :source => "RHEVM")
+  end
+
+  context "with a vm target" do
+    let(:event_data) { {"name"=>"USER_ADD_VM", "vm" => {"href" => "/ovirt-engine/api/vms/3f1286a4-e16a-44b6-a0c1-2c88837b1313"}} }
+
+    it "parses USER_ADD_VM" do
+      parsed_targets = described_class.new(ems_event).parse
+
+      expect(parsed_targets.count).to eq(1)
+
+      vm_target = parsed_targets.first
+      expect(vm_target.association).to eq(:vms)
+      expect(vm_target.manager_ref).to eq(:ems_ref => "/api/vms/3f1286a4-e16a-44b6-a0c1-2c88837b1313")
+    end
+  end
+
+  context "with a template target" do
+    let(:event_data) { {"name"=>"USER_ADD_VM", "template" => {"href" => "/ovirt-engine/api/templates/c6e9bf1b-5673-4156-bf83-e8454cdff500"}} }
+
+    it "parses USER_ADD_VM" do
+      parsed_targets = described_class.new(ems_event).parse
+
+      expect(parsed_targets.count).to eq(1)
+
+      template_target = parsed_targets.first
+      expect(template_target.association).to eq(:miq_templates)
+      expect(template_target.manager_ref).to eq(:ems_ref => "/api/templates/c6e9bf1b-5673-4156-bf83-e8454cdff500")
+    end
+  end
+
+  context "with a cluster target" do
+    let(:event_data) { {"name"=>"USER_ADD_VM", "cluster" => {"href" => "/ovirt-engine/api/clusters/1d67acd6-9717-11e8-bec7-001a4a161155"}} }
+
+    it "parses USER_ADD_VM" do
+      parsed_targets = described_class.new(ems_event).parse
+
+      expect(parsed_targets.count).to eq(1)
+
+      cluster_target = parsed_targets.first
+      expect(cluster_target.association).to eq(:ems_clusters)
+      expect(cluster_target.manager_ref).to eq(:ems_ref => "/api/clusters/1d67acd6-9717-11e8-bec7-001a4a161155")
+    end
+  end
+end


### PR DESCRIPTION
Targeted refresh for graph refresh uses an event_target_parser to build up a set of refresh targets from an ems_event.

https://github.com/ManageIQ/manageiq/issues/19999