### PR TITLE
Look for qemu-guest-agent for tools status as well

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -422,7 +422,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
   def get_tools_status(vm)
     apps = Array.wrap(collector.collect_vm_guest_applications(vm))
-    apps.any? { |app| app.name.include?('ovirt-guest-agent') } ? 'installed' : 'not installed'
+    apps.any? { |app| app.name.include?('ovirt-guest-agent') || app.name.include?('qemu-guest-agent'} } ? 'installed' : 'not installed'
   end
 
   def storages(vm)

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -422,7 +422,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
 
   def get_tools_status(vm)
     apps = Array.wrap(collector.collect_vm_guest_applications(vm))
-    apps.any? { |app| app.name.include?('ovirt-guest-agent') || app.name.include?('qemu-guest-agent'} } ? 'installed' : 'not installed'
+    apps.any? { |app| app.name.include?('ovirt-guest-agent') || app.name.include?('qemu-guest-agent') } ? 'installed' : 'not installed'
   end
 
   def storages(vm)


### PR DESCRIPTION
Apparently RHEL8 uses "qemu-guest-agent" as the name for guest tools instead of "ovirt-guest-agent", so this PR updates the code to look for both.

Followup to https://github.com/ManageIQ/manageiq-providers-ovirt/pull/505

Part of https://bugzilla.redhat.com/show_bug.cgi?id=1846624