### PR TITLE
Rename textarea-field to textarea in the DDF provider form

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -180,9 +180,9 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
                         ]
                       },
                       {
-                        :component  => "textarea-field",
-                        :id         => "endpoints.default.certificate_authority",
+                        :component  => "textarea",
                         :name       => "endpoints.default.certificate_authority",
+                        :id         => "endpoints.default.certificate_authority",
                         :label      => _("Trusted CA Certificates"),
                         :rows       => 10,
                         :isRequired => true,


### PR DESCRIPTION
This has been also renamed in the DDFv2, strange, but the `text-field` stayed :confused:

@miq-bot add_label bug

cc @jerryk55 