### PR TITLE
Sync the tenant_id when creating a NetworkManager

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -49,6 +49,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
       network_manager.name = "#{name} Network Manager"
       network_manager.zone_id = zone_id
       network_manager.provider_region = provider_region
+      network_manager.tenant_id = tenant_id
       network_manager.save!
     end
   end


### PR DESCRIPTION
The tenant_id is usually set by the TenancyMixin based on the current user but the Ovirt NetworkManager is created during refresh so it doesn't match the InfraManager#tenant_id