### PR TITLE
Make the default credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -153,6 +153,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
                     :name                   => 'endpoints.default.valid',
                     :skipSubmit             => true,
                     :validationDependencies => %w[type zone_id],
+                    :isRequired             => true,
                     :fields                 => [
                       {
                         :component  => "text-field",


### PR DESCRIPTION
When you try to add a provider without filling out the `Metrics` and `RSA Key Pair` information, the `Save` button is greyed out. This is because all three `validate-provider-credentials` components are required by default. I made [some changes in the UI](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347) to have the [opposite default behavior and exposed a new attribute if we want to have it explicitly required. These two changes in combination should make only the `Default` credentials to be required.

@mzazrivec this should fix your issue
@miq-bot add_label bug