### PR TITLE
Hosts should be disconnected not deleted

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_target_host_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_target_host_4_spec.rb
@@ -33,10 +33,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
                                :ems_cluster           => @cluster)
   end
 
-  it "should remove a host using graph refresh" do
+  it "should disconnect a host using graph refresh" do
     EmsRefresh.refresh(@host)
     @ems.reload
-
-    expect(Host.count).to eq(0)
+    expect(Host.first).to be_archived
   end
 end


### PR DESCRIPTION
Hosts are supposed to be disconnected so that they can be reconnected in the future.  https://github.com/ManageIQ/manageiq/pull/20588 fixed this in core and this test should be updated to match

Fixes https://travis-ci.com/github/ManageIQ/manageiq-providers-ovirt/jobs/396112357#L2106-L2115