### PR TITLE
Fix for datacenters being recreated every refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -28,7 +28,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       if is_external
         datacenter = network.data_center
         ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(datacenter.href)
-        parent_datacenter = persister.datacenters.lazy_find(ems_ref)
+        parent_datacenter = persister.ems_folders.lazy_find(ems_ref)
 
         attrs_to_assign[:parent] = parent_datacenter
       end
@@ -126,12 +126,12 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
       )
 
       uid = datacenter.id
-      persister.datacenters.find_or_build(ems_ref).assign_attributes(
-        :name        => datacenter.name,
+      persister.ems_folders.find_or_build(ems_ref).assign_attributes(
+        :name    => datacenter.name,
         :type    => 'ManageIQ::Providers::Redhat::InfraManager::Datacenter',
-        :ems_ref     => ems_ref,
-        :uid_ems     => uid,
-        :parent      => persister.ems_folders.lazy_find("root_dc"),
+        :ems_ref => ems_ref,
+        :uid_ems => uid,
+        :parent  => persister.ems_folders.lazy_find("root_dc")
       )
 
       host_folder_uid = "#{uid}_host"
@@ -140,7 +140,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :type    => 'ManageIQ::Providers::Redhat::InfraManager::Folder',
         :uid_ems => host_folder_uid,
         :hidden  => true,
-        :parent  => persister.datacenters.lazy_find(ems_ref),
+        :parent  => persister.ems_folders.lazy_find(ems_ref)
       )
 
       vm_folder_uid = "#{uid}_vm"
@@ -149,7 +149,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :type    => 'ManageIQ::Providers::Redhat::InfraManager::Folder',
         :uid_ems => vm_folder_uid,
         :hidden  => true,
-        :parent  => persister.datacenters.lazy_find(ems_ref),
+        :parent  => persister.ems_folders.lazy_find(ems_ref)
       )
     end
   end

--- a/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister/infra_manager.rb
@@ -22,7 +22,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
     add_collection(infra, :operating_systems)
     add_collection(infra, :vms)
 
-    add_datacenters
     add_miq_templates
     add_resource_pools
     add_snapshots
@@ -66,20 +65,6 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
     end
   end
 
-  def add_datacenters
-    add_collection(infra, :datacenters) do |builder|
-      builder.add_properties(:arel => manager.datacenters)
-
-      if targeted?
-        builder.add_targeted_arel(
-          lambda do |_inventory_collection|
-            manager.datacenters.where(:ems_ref => references(:datacenters))
-          end
-        )
-      end
-    end
-  end
-
   def add_storages
     add_collection(infra, :storages) do |builder|
       if targeted?
@@ -111,7 +96,7 @@ class ManageIQ::Providers::Redhat::Inventory::Persister::InfraManager < ManageIQ
 
   def add_parent_blue_folders
     add_collection(infra, :parent_blue_folders) do |builder|
-      dependency_collections = %i[clusters ems_folders datacenters hosts resource_pools storages distributed_virtual_switches external_distributed_virtual_switches]
+      dependency_collections = %i[clusters ems_folders hosts resource_pools storages distributed_virtual_switches external_distributed_virtual_switches]
       dependency_attributes = dependency_collections.each_with_object({}) do |collection, hash|
         hash[collection] = ->(persister) { [persister.collections[collection]].compact }
       end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
@@ -47,6 +47,20 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(Host.where(:uid_ems => "ce40bb38-f10a-43f3-8e15-d0ffad692a19").count).to eq 1
   end
 
+  it "will perform a refresh and preserve an existing datacenter" do
+    dc = FactoryBot.create(
+      :datacenter_redhat,
+      :ext_management_system => @ems,
+      :ems_ref               => "/api/datacenters/944df9ee-3274-43c4-908f-8c35e59e483b",
+      :uid_ems               => "944df9ee-3274-43c4-908f-8c35e59e483b"
+    )
+
+    EmsRefresh.refresh(@ems)
+    @ems.reload
+
+    expect(@ems.datacenters.first).to eq(dc)
+  end
+
   it "will perform a refresh and reconnect a vm" do
     @vm = FactoryBot.create(:vm_redhat,
                              :ext_management_system => nil,


### PR DESCRIPTION
Datacenters subclass EmsFolders and thus can't be two separate collections since they are the same table.

If you had for example two folders and a datacenter the persister.ems_folders collection would have the two folder inventory objects but the query manager.ems_folders would return three records including the datacenter.

This meant that the datacenter was being deleted by the ems_folders inventory collection, then the datacenters inventory collection was creating it.

This fix is to save all records for the table in the base collection and manually set the STI :type column (which was actually already being done).

Fixes https://github.com/ManageIQ/manageiq-providers-ovirt/issues/539