### PR TITLE
Fix linter warnings

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -5,13 +5,17 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
   include_concern 'Network'
 
   def attach_floppy_payload
-    return unless content = customization_template_content
+    content = customization_template_content
+    return unless content
+
     filename = customization_template.default_filename
     with_provider_destination { |d| d.attach_floppy(filename => content) }
   end
 
   def configure_cloud_init
-    return unless content = customization_template_content
+    content = customization_template_content
+    return unless content
+
     with_provider_destination { |d| d.update_cloud_init!(content) }
 
     ems_api_version = source.ext_management_system.api_version

--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -390,7 +390,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :uid_ems          => vm.id,
         :connection_state => "connected",
         :vendor           => "redhat",
-        :name             => URI.decode(vm.name),
+        :name             => URI.decode_www_form_component(vm.name),
         :location         => "#{vm.id}.ovf",
         :template         => template,
         :memory_limit     => extract_vm_memory_policy(vm, :max),
@@ -521,7 +521,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
     end
   end
 
-  def vm_hardware_guest_devices(persister_hardware, vm, addresses, host)
+  def vm_hardware_guest_devices(persister_hardware, vm, addresses, _host)
     networks = {}
     addresses.each do |mac, address|
       network = persister.networks.lazy_find_by(


### PR DESCRIPTION
This PR addresses most of the rubocop linter warnings. Specifically:

* ~~Disable the Lint/RescueException warning since we can't risk the breakage.~~
* Change what could be confused for conditionals into clearer code.
* Replace the long deprecated `URI.decode` with `URI.decode_www_form_component`
* Mark an unused variable in the `vm_hardware_guest_devices` method.

The one thing I couldn't fix was the call to `URI.escape` in the vm_import.rb file because of the second argument. I haven't found a replacement for it, except in the `Addressable` library, but that would mean adding a dependency.