### PR TITLE
Implement cloud tenant mapping for ovirt provider

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
@@ -65,6 +65,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
 
   def cloud_tenant_mapper(name)
     name_parts = name.split(::Settings.ems.ems_ovirt.cloud_tenant_mapper.separator)
-    CloudTenant.find_by(:name => name_parts[::Settings.ems.ems_ovirt.cloud_tenant_mapper.account])
+    CloudTenant.find_by(:name => name_parts[::Settings.ems.ems_ovirt.cloud_tenant_mapper.tenant])
   end
 end

--- a/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
@@ -37,7 +37,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
 
   def network_routers
     collector.network_routers.each do |nr|
-      subnet = persister.cloud_subnets.find_or_build(s.id)
+      network_router = persister.network_routers.find_or_build(nr.id)
       tenant = cloud_tenant_mapper(nr.name)
       network_router.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(nr.tenant_id)
     end

--- a/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
@@ -21,29 +21,41 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
 
   def cloud_networks
     collector.cloud_networks.each do |n|
+      network = persister.cloud_networks.find_or_build(n["id"])
       tenant = cloud_tenant_mapper(n["name"])
-      network.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(n["tenant_id"])
+      tenant ?
+        network.cloud_tenant = tenant :
+        network.cloud_tenant = persister.cloud_tenants.lazy_find(n["tenant_id"])
     end
   end
 
   def cloud_subnets
     collector.cloud_subnets.each do |s|
+      subnet = persister.cloud_subnets.find_or_build(s.id)
       tenant = cloud_tenant_mapper(s.name)
-      subnet.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(s.tenant_id)
+      tenant ?
+        subnet.cloud_tenant = tenant :
+        subnet.cloud_tenant = persister.cloud_tenants.lazy_find(s.tenant_id)
     end
   end
 
   def network_routers
     collector.network_routers.each do |nr|
+      network_router = persister.network_routers.find_or_build(nr.id)
       tenant = cloud_tenant_mapper(nr.name)
-      network_router.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(nr.tenant_id)
+      tenant ?
+        network_router.cloud_tenant = tenant :
+        network_router.cloud_tenant = persister.cloud_tenants.lazy_find(nr.tenant_id)
     end
   end
 
   def security_groups
     collector.security_groups.each do |s|
+      security_group = persister.security_groups.find_or_build(s.id)
       tenant = cloud_tenant_mapper(s.name)
-      security_group.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(s.tenant_id)
+      tenant ?
+        security_group.cloud_tenant = tenant :
+        security_group.cloud_tenant = persister.cloud_tenants.lazy_find(s.tenant_id)
     end
   end
 

--- a/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
@@ -23,9 +23,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
     collector.cloud_networks.each do |n|
       network = persister.cloud_networks.find_or_build(n["id"])
       tenant = cloud_tenant_mapper(n["name"])
-      tenant ?
-        network.cloud_tenant = tenant :
-        network.cloud_tenant = persister.cloud_tenants.lazy_find(n["tenant_id"])
+      network.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(n["tenant_id"])
     end
   end
 
@@ -33,19 +31,15 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
     collector.cloud_subnets.each do |s|
       subnet = persister.cloud_subnets.find_or_build(s.id)
       tenant = cloud_tenant_mapper(s.name)
-      tenant ?
-        subnet.cloud_tenant = tenant :
-        subnet.cloud_tenant = persister.cloud_tenants.lazy_find(s.tenant_id)
+      subnet.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(s.tenant_id)
     end
   end
 
   def network_routers
     collector.network_routers.each do |nr|
-      network_router = persister.network_routers.find_or_build(nr.id)
+      subnet = persister.cloud_subnets.find_or_build(s.id)
       tenant = cloud_tenant_mapper(nr.name)
-      tenant ?
-        network_router.cloud_tenant = tenant :
-        network_router.cloud_tenant = persister.cloud_tenants.lazy_find(nr.tenant_id)
+      network_router.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(nr.tenant_id)
     end
   end
 
@@ -53,9 +47,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
     collector.security_groups.each do |s|
       security_group = persister.security_groups.find_or_build(s.id)
       tenant = cloud_tenant_mapper(s.name)
-      tenant ?
-        security_group.cloud_tenant = tenant :
-        security_group.cloud_tenant = persister.cloud_tenants.lazy_find(s.tenant_id)
+      security_group.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(s.tenant_id)
     end
   end
 
@@ -73,6 +65,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
 
   def cloud_tenant_mapper(name)
     name_parts = name.split(::Settings.ems.ems_ovirt.cloud_tenant_mapper.separator)
-    CloudTenant.find_by(:name => name_parts[::Settings.ems.ems_ovirt.cloud_tenant_mapper.tenant])
+    CloudTenant.find_by(:name => name_parts[::Settings.ems.ems_ovirt.cloud_tenant_mapper.account])
   end
 end

--- a/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
@@ -60,7 +60,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
   end
 
   def cloud_tenant_mapper(name)
-    name_parts = name.split(::Settings.ems_ovirt.cloud_tenant_mapper.separator)
-    CloudTenant.find_by(:name => name_parts[::Settings.ems_ovirt.cloud_tenant_mapper.account])
+    name_parts = name.split(::Settings.ems.ems_ovirt.cloud_tenant_mapper.separator)
+    CloudTenant.find_by(:name => name_parts[::Settings.ems.ems_ovirt.cloud_tenant_mapper.account])
   end
 end

--- a/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
@@ -2,6 +2,10 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
   def parse
     super
     cloud_tenants
+    cloud_networks
+    cloud_subnets
+    network_routers
+    security_groups
   end
 
   def cloud_tenants
@@ -15,6 +19,34 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
     end
   end
 
+  def cloud_networks
+    collector.cloud_networks.each do |n|
+      tenant = cloud_tenant_mapper(n["name"])
+      network.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(n["tenant_id"])
+    end
+  end
+
+  def cloud_subnets
+    collector.cloud_subnets.each do |s|
+      tenant = cloud_tenant_mapper(s.name)
+      subnet.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(s.tenant_id)
+    end
+  end
+
+  def network_routers
+    collector.network_routers.each do |nr|
+      tenant = cloud_tenant_mapper(nr.name)
+      network_router.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(nr.tenant_id)
+    end
+  end
+
+  def security_groups
+    collector.security_groups.each do |s|
+      tenant = cloud_tenant_mapper(s.name)
+      security_group.cloud_tenant = tenant || persister.cloud_tenants.lazy_find(s.tenant_id)
+    end
+  end
+
   def find_device_object(network_port)
     super || find_ovirt_device_object(network_port)
   end
@@ -25,5 +57,10 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
     nil unless network_port.device_owner&.downcase == 'ovirt'
 
     persister.guest_devices.lazy_find({:uid_ems => network_port.device_id}, {:ref => :by_uid_ems})
+  end
+
+  def cloud_tenant_mapper(name)
+    name_parts = name.split(::Settings.ems_ovirt.cloud_tenant_mapper.separator)
+    CloudTenant.find_by(:name => name_parts[::Settings.ems_ovirt.cloud_tenant_mapper.account])
   end
 end

--- a/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/network_manager.rb
@@ -61,6 +61,6 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::NetworkManager < ManageIQ:
 
   def cloud_tenant_mapper(name)
     name_parts = name.split(::Settings.ems.ems_ovirt.cloud_tenant_mapper.separator)
-    CloudTenant.find_by(:name => name_parts[::Settings.ems.ems_ovirt.cloud_tenant_mapper.account])
+    CloudTenant.find_by(:name => name_parts[::Settings.ems.ems_ovirt.cloud_tenant_mapper.tenant])
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,6 +45,10 @@
           - security_group.update.end
     :connection_manager:
       :purge_interval: 1.hour
+    :cloud_tenant_mapper:
+      :separator: _
+      :location: 0
+      :tenant: 1
 :http_proxy:
   :rhevm:
     :host:


### PR DESCRIPTION
ManageIQ supports bundle OVN + Ovirt, but Ovirt doesn't support CloudTenant mapping.
The main idea of this peace of code: with Tenant we create CloudTenant in database. And when we refresh cloud_networks, cloud_subnets, network_routers, security_groups we associate it with created CloudTenant (we use name as unique key, cause manageiq doesn't support duplicates name).
In my idea, all ovn networks can have location prefix, account(tenant) name and name.
Like this:
  - zby_icdc_private
  - xby_icdc_edge
 
  Users can define custom separator and custom structure of name
The main problem of existing arch. - we can't control object viewing via API. With this patch we can use RBAC.
FYI: This code tested in latest Jansa