### PR TITLE
Fix metrics connection setup failure

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -291,6 +291,8 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       verify_ssl = opts[:verify_ssl] || 1
       ca_certs = opts[:ca_certs]
 
+      return true if server.blank?
+
       # Decrypt the password:
       password = ManageIQ::Password.try_decrypt(password)
 

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -167,6 +167,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
   context ".raw_connect" do
     let(:options) do
       {
+        :server   => 'ovirt.localdomain',
         :username => 'user',
         :password => 'pword'
       }
@@ -190,9 +191,9 @@ describe ManageIQ::Providers::Redhat::InfraManager do
 
       described_class.raw_connect(options)
     end
-   
+
     it "handle credential validation error" do
-      opts = options.merge({:metrics_server => 'server'}) 
+      opts = options.merge({:metrics_server => 'server'})
 
       allow(described_class).to receive(:raw_connect_v4).and_return(v4_connection)
       allow(v4_connection).to receive(:test).with(hash_including(:raise_exception => true))


### PR DESCRIPTION
When adding the metrics endpoint information the verify credentials step only sends the options from the metrics endpoint tab.

The backend here was assuming that the default API options would always be present and the metrics options sometimes present.

This no longer matches how the UI sends verify credentials tasks now that the endpoints are split up into their own tabs.

Fixes https://github.com/ManageIQ/manageiq-providers-ovirt/issues/550