### PR TITLE
[JANSA] Bump ovirt-engine-sdk to 4.4.0

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.3.0"
+  s.add_runtime_dependency "ovirt-engine-sdk", "~>4.4.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Bump ovirt-engine-sdk to 4.4.0

(cherry picked from commit c9a538c2320801e3af2cedb68c7b6e4181d8a20d)