### PR TITLE
Refactor create cloud subnet queue

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -103,23 +103,6 @@ class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::Network
     CloudSubnet.raw_create_cloud_subnet(self, options)
   end
 
-  def create_cloud_subnet_queue(userid, options = {})
-    task_opts = {
-      :action => "creating Cloud Subnet for user #{userid}",
-      :userid => userid
-    }
-    queue_opts = {
-      :class_name  => self.class.name,
-      :method_name => 'create_cloud_subnet',
-      :instance_id => id,
-      :priority    => MiqQueue::HIGH_PRIORITY,
-      :role        => 'ems_operations',
-      :zone        => my_zone,
-      :args        => [options]
-    }
-    MiqTask.generic_action_with_callback(task_opts, queue_opts)
-  end
-
   def create_network_router(options)
     NetworkRouter.raw_create_network_router(self, options)
   end


### PR DESCRIPTION
- `create_cloud_subnet_queue` method lives in the provider code but it is unnecessary and can be moved to core

Depends on:

* [x] [Refactor create cloud subnet queue from providers](https://github.com/ManageIQ/manageiq/pull/21313)