### PR TITLE
supports :catalog

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -30,6 +30,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
 
   include HasNetworkManagerMixin
 
+  supports :catalog
   supports :metrics
   supports :provisioning
   supports :vm_import do


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/pull/21505

```diff
- responds_to?(:catalog_type)
+ supports?(:catalog)
```
