### PR TITLE
[MORPHY] Create aliases for Redhat::NetworkManager subclasses

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -1,8 +1,14 @@
 class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::NetworkManager
+  require_nested :CloudNetwork
+  require_nested :CloudSubnet
   require_nested :EventCatcher
   require_nested :EventParser
+  require_nested :FloatingIp
+  require_nested :NetworkPort
+  require_nested :NetworkRouter
   require_nested :RefreshWorker
   require_nested :Refresher
+  require_nested :SecurityGroup
 
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_network.rb
@@ -1,0 +1,1 @@
+ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork = ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_subnet.rb
@@ -1,0 +1,1 @@
+ManageIQ::Providers::Redhat::NetworkManager::CloudSubnet = ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet

--- a/app/models/manageiq/providers/redhat/network_manager/floating_ip.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/floating_ip.rb
@@ -1,0 +1,1 @@
+ManageIQ::Providers::Redhat::NetworkManager::FloatingIp = ManageIQ::Providers::Openstack::NetworkManager::FloatingIp

--- a/app/models/manageiq/providers/redhat/network_manager/network_port.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/network_port.rb
@@ -1,0 +1,1 @@
+ManageIQ::Providers::Redhat::NetworkManager::NetworkPort = ManageIQ::Providers::Openstack::NetworkManager::NetworkPort

--- a/app/models/manageiq/providers/redhat/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/network_router.rb
@@ -1,0 +1,1 @@
+ManageIQ::Providers::Redhat::NetworkManager::NetworkRouter = ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter

--- a/app/models/manageiq/providers/redhat/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/security_group.rb
@@ -1,0 +1,1 @@
+ManageIQ::Providers::Redhat::NetworkManager::SecurityGroup = ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup


### PR DESCRIPTION
There is code which expects that `ext_management_system.class::Model` exists, this clashes with the Redhat::NetworkManager subclasses which previously had classes but the openstack parser never set any records to use it.

On master we fixed the parser to set the correct `:type` and added a data-migration to fix existing records.  On morphy we couldn't run a data-migration so we just used the openstack types, this left us with the issue raised by https://github.com/ManageIQ/manageiq-providers-ovirt/pull/569 which expects the classes to exist.

Creating aliases of these classes will let e.g. `CloudNetwork.class_by_ems` work and also return records (previously e.g. `ManageIQ::Providers::Ovirt::NetworkManager::CloudNetwork.all` would always return `[]` because `:type` was never set to that).

Fixes https://github.com/ManageIQ/manageiq-providers-ovirt/issues/578