### PR TITLE
Fix metrics_endpoint info not passed to check_connect_metrics

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -224,8 +224,8 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       )
 
       metrics_username, metrics_password = metrics_authentication&.values_at("userid", "password")
-      metrics_port, metrics_database = metrics_endpoint&.values_at(
-        "metrics_port", "metrics_database"
+      metrics_server, metrics_port, metrics_database = metrics_endpoint&.values_at(
+        "hostname", "port", "path"
       )
 
       !!raw_connect(
@@ -237,6 +237,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
         :ca_certs         => ca_certs,
         :metrics_username => metrics_username,
         :metrics_password => ManageIQ::Password.try_decrypt(metrics_password),
+        :metrics_server   => metrics_server,
         :metrics_port     => metrics_port,
         :metrics_database => metrics_database
       )


### PR DESCRIPTION
The `check_connect_metrics` method returns true if the server is nil, the expectation being that no metrics endpoint info was passed by the user.

The metrics endpoint keys in the options have changed since the DDF changes, which resulted in the metrics_server _always_ being nil. This meant that no matter what info was passed in the form it would verity successfully.

Fixes https://github.com/ManageIQ/manageiq-providers-ovirt/issues/526