### PR TITLE
Fix default api verification always succeeding

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -233,7 +233,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
         :password         => ManageIQ::Password.try_decrypt(password),
         :server           => server,
         :port             => port,
-        :verify_ssl       => verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE,
+        :verify_ssl       => verify_ssl,
         :ca_certs         => ca_certs,
         :metrics_username => metrics_username,
         :metrics_password => ManageIQ::Password.try_decrypt(metrics_password),
@@ -321,9 +321,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       begin
         connection = raw_connect_v4(opts)
         connection.test(:raise_exception => true)
-        return true
-      rescue OvirtSDK4::Error => error
-        raise error if /error.*sso/i.match?(error.message)
+        true
       end
     end
 


### PR DESCRIPTION
The `verify_credentials` was assuming the `verify_ssl` option was a boolean not an integer (also updated with the DDF changes), which meant that `verify_ssl ? VERIFY_PEER : VERIFY_NONE` was always returning VERIFY_PEER even if you wanted VERIFY_NONE.

Which didn't matter anyway because the exception handler would only raise if the exception string matched `/error.*sso/i` which it wouldn't if you had anything other than a username/password exception.  This meant you could point the RHV provider to literally anything and it would verify successfully :scream: 