### PR TITLE
Move ovirt_metrics gem to ovirt gemspec

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ovirt-engine-sdk", "~>4.4.0"
+  spec.add_dependency "ovirt_metrics", "~>3.0.1"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
This gem declaration doesn't belong in the core Gemfile

Required for:
* https://github.com/ManageIQ/manageiq/pull/21589