### PR TITLE
Targeted refresh should default to enabled

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,6 +55,7 @@
   :rhevm:
     :pipeline: 40
     :connections: 10
+    :allow_targeted_refresh: true
   :redhat_network:
     :is_admin: false
 :log:


### PR DESCRIPTION
The `ExtManagementSystem#allow_targeted_refresh?` check looks to `Settings.ems_refresh.emstype.allow_targeted_refresh` to indicate if targeted refresh is supported.  For Ovirt this was returning `nil` and thus wasn't supported