### PR TITLE
Allow minor relases of ovirt_metrics such as 3.1 for rails 6.1 support

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ovirt-engine-sdk", "~>4.4.0"
-  spec.add_dependency "ovirt_metrics", "~>3.0.3"
+  spec.add_dependency "ovirt_metrics", "~>3.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
We shouldn't require such a pessimistic version constraint here.