### PR TITLE
The RHV NetworkManager is not standalone

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -13,8 +13,6 @@ class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::Network
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin
 
-  supports :create
-
   has_many :public_networks,  :foreign_key => :ems_id, :dependent => :destroy,
            :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public"
   has_many :private_networks, :foreign_key => :ems_id, :dependent => :destroy,


### PR DESCRIPTION
The NetworkManager for RHV is not supported for create by itself and can only be created as part of a RHV/Ovirt InfraManager.