### PR TITLE
[WIP] Don't delegate NetworkManager#authentication_check

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -20,9 +20,6 @@ class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::Network
 
   delegate :zone,
            :guest_devices,
-           :authentication_check, # TODO: fix it, auth shouldn't be done via the parent
-           :authentication_status,
-           :authentication_status_ok?,
            :authentications,
            :authentication_for_summary,
            :to        => :parent_manager,


### PR DESCRIPTION
The Ovirt OVN NetworkManager uses OpenStack APIs to connect, therefore we shouldn't simply use the ovirt/rhv API auth check to indicate if we are able to connect to an OVN network manager.