### PR TITLE
Add all_valid_ems_in_zone to Network EventCatcher

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/event_catcher.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Redhat::NetworkManager::EventCatcher < ::MiqEventCatcher
+  include ManageIQ::Providers::Openstack::EventCatcherMixin
+
   require_nested :Runner
 
   def self.settings_name


### PR DESCRIPTION
Check if the events service is available before starting the OVN network event catcher and spinning restarting the event monitor.

```
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner#start_event_monitor) EMS [RHVdev1.rtp.raleigh.ibm.com] as [admin@internal] Validating Connection/Credentials
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager#with_provider_connection) Connecting through ManageIQ::Providers::Redhat::NetworkManager: [rhvdev1 Network Manager]
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner#start_event_monitor) EMS [RHVdev1.rtp.raleigh.ibm.com] as [admin@internal] Starting Event Monitor Thread
WARN -- evm: MIQ(OpenstackNullEventMonitor#initialize) There was an problem establishing a connection to the AMQP service on . Check the evm.log for more details.
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner#start_event_monitor) EMS [RHVdev1.rtp.raleigh.ibm.com] as [admin@internal] Started Event Monitor Thread
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner#do_work) EMS [RHVdev1.rtp.raleigh.ibm.com] as [admin@internal] Event Monitor Thread gone. Restarting...
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner#start_event_monitor) EMS [RHVdev1.rtp.raleigh.ibm.com] as [admin@internal] Validating Connection/Credentials
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager#with_provider_connection) Connecting through ManageIQ::Providers::Redhat::NetworkManager: [rhvdev1 Network Manager]
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner#start_event_monitor) EMS [RHVdev1.rtp.raleigh.ibm.com] as [admin@internal] Starting Event Monitor Thread
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner#start_event_monitor) EMS [RHVdev1.rtp.raleigh.ibm.com] as [admin@internal] Started Event Monitor Thread
INFO -- evm: MIQ(ManageIQ::Providers::Redhat::NetworkManager::EventCatcher::Runner#do_work) EMS [RHVdev1.rtp.raleigh.ibm.com] as [admin@internal] Event Monitor Thread gone. Restarting.
```

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/804

I think there could be a follow-up to the core EventCatcher::Runner to have maybe an exponential backoff when the event monitor thread is gone to prevent spinning.

This happens after the validate_credentials check which is indicative of a bug in the provider's implementation not checking if events will work but still would be a safer addition.

Follow-ups:
- Exponential backoff in base EventCatcher restarting the event monitor thread
- Fix OpenStack validation to check for events service availability
- I'm not sure it is possible to configure Events for the native Ovirt OVN Network provider so this whole class might go away, but for backport wanted to keep it simpler