### PR TITLE
Fix metrics/keypair endpoint selector

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -236,12 +236,22 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
                 :title     => _('Metrics'),
                 :fields    => [
                   {
-                    :component => 'select',
-                    :name      => 'metricsEnable',
-                    :label     => _('Enabled'),
-                    :options   => [
-                      {:label => _('Disabled'), :value => 'disabled'},
-                      {:label => _('Enabled'), :value => 'enabled'},
+                    :component    => 'protocol-selector',
+                    :id           => 'metricsEnable',
+                    :name         => 'metricsEnable',
+                    :skipSubmit   => true,
+                    :initialValue => 'disabled',
+                    :label        => _('Enabled'),
+                    :options      => [
+                      {
+                        :label => _('Disabled'),
+                        :value => 'disabled'
+                      },
+                      {
+                        :label => _('Enabled'),
+                        :value => 'enabled',
+                        :pivot => 'endpoints.metrics.hostname'
+                      },
                     ],
                   },
                   {
@@ -302,12 +312,22 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
                 :title     => _('RSA key pair'),
                 :fields    => [
                   {
-                    :component => 'select',
-                    :name      => 'keypairEnable',
-                    :label     => _('Enabled'),
-                    :options   => [
-                      {:label => _('Disabled'), :value => 'disabled'},
-                      {:label => _('Enabled'), :value => 'enabled'},
+                    :component    => 'protocol-selector',
+                    :id           => 'keypairEnable',
+                    :name         => 'keypairEnable',
+                    :skipSubmit   => true,
+                    :initialValue => 'disabled',
+                    :label        => _('Enabled'),
+                    :options      => [
+                      {
+                        :label => _('Disabled'),
+                        :value => 'disabled'
+                      },
+                      {
+                        :label => _('Enabled'),
+                        :value => 'enabled',
+                        :pivot => 'authentications.ssh_keypair.userid'
+                      },
                     ],
                   },
                   {


### PR DESCRIPTION
Fix issues with the metrics and keypair selector being posted to the API and not loading the proper value on edit.

Tested with https://github.com/ManageIQ/manageiq-ui-classic/pull/8312 reverted
Follow-up to: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/606

Dependents:
* https://github.com/ManageIQ/manageiq-ui-classic/pull/8330