### PR TITLE
Replace lazy_find_by with simple lazy_find

### DIFF
--- a/app/models/manageiq/providers/ovirt/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ovirt/inventory/parser/infra_manager.rb
@@ -524,7 +524,7 @@ class ManageIQ::Providers::Ovirt::Inventory::Parser::InfraManager < ManageIQ::Pr
   def vm_hardware_guest_devices(persister_hardware, vm, addresses, host)
     networks = {}
     addresses.each do |mac, address|
-      network = persister.networks.lazy_find_by(
+      network = persister.networks.lazy_find(
         :hardware    => persister_hardware,
         :ipaddress   => address[:ipaddress],
         :ipv6address => address[:ipv6address]


### PR DESCRIPTION
The lazy_find_by method is no different from the lazy_find method now and will be removed in an upcoming inventory_refresh release