### PR TITLE
[WIP] Remove unsupported html5 console support

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm/remote_console.rb
@@ -1,48 +1,7 @@
 class ManageIQ::Providers::Ovirt::InfraManager::Vm
   module RemoteConsole
     def console_supported?(type)
-      return true if type.upcase == 'NATIVE'
-
-      %w[SPICE VNC].include?(type.upcase) && html5_console_enabled?
-    end
-
-    def validate_remote_console_acquire_ticket(protocol, options = {})
-      raise(MiqException::RemoteConsoleNotSupportedError,
-            "#{protocol} protocol not enabled for this vm") unless protocol.to_sym == :html5
-
-      raise(MiqException::RemoteConsoleNotSupportedError,
-            "Html5 console is disabled by default, check settings to enable it") unless html5_console_enabled?
-
-      raise(MiqException::RemoteConsoleNotSupportedError,
-            "#{protocol} remote console requires the vm to be registered with a management system.") if ext_management_system.nil?
-
-      options[:check_if_running] = true unless options.key?(:check_if_running)
-      raise(MiqException::RemoteConsoleNotSupportedError,
-            "#{protocol} remote console requires the vm to be running.") if options[:check_if_running] && state != "on"
-    end
-
-    def remote_console_acquire_ticket(userid, originating_server, console_type)
-      validate_remote_console_acquire_ticket(console_type)
-      ext_management_system.ovirt_services.remote_console_acquire_ticket(self, userid, originating_server)
-    end
-
-    def remote_console_acquire_ticket_queue(protocol, userid)
-      task_opts = {
-        :action => "acquiring Vm #{name} #{protocol.to_s.upcase} remote console ticket for user #{userid}",
-        :userid => userid
-      }
-
-      queue_opts = {
-        :class_name  => self.class.name,
-        :instance_id => id,
-        :method_name => 'remote_console_acquire_ticket',
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => my_zone,
-        :args        => [userid, MiqServer.my_server.id, protocol]
-      }
-
-      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+      type.upcase == 'NATIVE'
     end
 
     def validate_native_console_support
@@ -83,11 +42,5 @@ class ManageIQ::Providers::Ovirt::InfraManager::Vm
 
       MiqTask.generic_action_with_callback(task_opts, queue_opts)
     end
-  end
-
-  private
-
-  def html5_console_enabled?
-    !!::Settings.ems.ems_ovirt&.consoles&.html5_enabled
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,8 +1,6 @@
 ---
 :ems:
   :ems_ovirt:
-    :consoles:
-      :html5_enabled: false
     :resolve_ip_addresses: true
     :inventory:
       :read_timeout: 1.hour


### PR DESCRIPTION
Spice/VNC html5 type consoles were last supported in RHEV 4.1 which reached end-of-life on May 31, 2022: https://access.redhat.com/support/policy/updates/rhev

HTML5 type consoles were disabled by default in https://github.com/ManageIQ/manageiq-providers-ovirt/pull/458