### PR TITLE
Add support for creating cloud network/subnets/routers

### DIFF
--- a/app/models/manageiq/providers/ovirt/network_manager.rb
+++ b/app/models/manageiq/providers/ovirt/network_manager.rb
@@ -13,6 +13,9 @@ class ManageIQ::Providers::Ovirt::NetworkManager < ManageIQ::Providers::NetworkM
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin
 
+  supports :create_network_router
+  supports :cloud_subnet_create
+
   has_many :public_networks,  :foreign_key => :ems_id, :dependent => :destroy,
            :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public"
   has_many :private_networks, :foreign_key => :ems_id, :dependent => :destroy,


### PR DESCRIPTION
Add Ovirt OVN/NetworkManager support for creating cloud networks, subnets, and routers.

The OVN API is an Openstack Neutron compatible API so we can re-use the CRUD methods from the Openstack subclass.

Fixes https://github.com/ManageIQ/manageiq/issues/22109#issuecomment-1262262868

![Screenshot from 2022-11-09 16-46-36](https://user-images.githubusercontent.com/12851112/200948837-e43c7d76-78d3-498b-a37d-d6a86f86fc9d.png)

![Screenshot from 2022-11-09 16-46-55](https://user-images.githubusercontent.com/12851112/200948845-ffb85ec1-8b3b-46d0-953e-b6507bdcfb73.png)

![Screenshot from 2022-11-09 16-47-12](https://user-images.githubusercontent.com/12851112/200948859-b71c9442-914e-481c-8f2d-ec677caf5a0f.png)

![Screenshot from 2022-11-09 16-48-13](https://user-images.githubusercontent.com/12851112/200948922-351059eb-4df8-4950-8735-9ab95a188657.png)
