### PR TITLE
Subclass IsoDatastore and transfer from core

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager.rb
@@ -17,6 +17,7 @@ class ManageIQ::Providers::Ovirt::InfraManager < ManageIQ::Providers::InfraManag
   require_nested  :ProvisionWorkflow
   require_nested  :Snapshot
   require_nested  :Storage
+  require_nested  :IsoDatastore
   require_nested  :Template
   require_nested  :Vm
   require_nested  :DistributedVirtualSwitch
@@ -27,6 +28,8 @@ class ManageIQ::Providers::Ovirt::InfraManager < ManageIQ::Providers::InfraManag
   has_many :vm_and_template_ems_custom_fields, :through => :vms_and_templates, :source => :ems_custom_attributes
   has_many :external_distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system
   has_many :external_distributed_virtual_lans, -> { distinct }, :through => :external_distributed_virtual_switches, :source => :lans
+  has_many :iso_datastores, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system
+  has_many :iso_images, :through => :storages
 
   include HasNetworkManagerMixin
 
@@ -42,7 +45,7 @@ class ManageIQ::Providers::Ovirt::InfraManager < ManageIQ::Providers::InfraManag
   end
 
   supports :create_iso_datastore do
-    unsupported_reason_add(:create_iso_datastore, _("Already has an ISO datastore")) if iso_datastore
+    unsupported_reason_add(:create_iso_datastore, _("Already has an ISO datastore")) unless iso_datastores.empty?
   end
 
   def ensure_managers

--- a/app/models/manageiq/providers/ovirt/infra_manager/iso_datastore.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/iso_datastore.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore < ManageIQ::Providers::Ovirt::InfraManager::Storage
+  belongs_to :ext_management_system, :foreign_key => :ems_id
+
+  def self.display_name(number = 1)
+    n_('ISO Datastore', 'ISO Datastores', number)
+  end
+end

--- a/app/models/manageiq/providers/ovirt/infra_manager/iso_datastore.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/iso_datastore.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore < ManageIQ::Providers::Ovirt::InfraManager::Storage
+  supports :iso_datastore
+
   belongs_to :ext_management_system, :foreign_key => :ems_id
 
   def self.display_name(number = 1)

--- a/app/models/manageiq/providers/ovirt/infra_manager/ovirt_services.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/ovirt_services.rb
@@ -352,7 +352,8 @@ module ManageIQ::Providers::Ovirt::InfraManager::OvirtServices
 
         sd_service = ems_service.system_service.storage_domains_service.storage_domain_service(iso_sd.id)
         iso_images = sd_service.files_service.list
-        iso_images.collect(&:name)
+
+        iso_images
       end
     rescue OvirtSDK4::Error => err
       name = ext_management_system.try(:name)

--- a/app/models/manageiq/providers/ovirt/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ovirt/inventory/collector/infra_manager.rb
@@ -42,6 +42,10 @@ class ManageIQ::Providers::Ovirt::Inventory::Collector::InfraManager < ManageIQ:
     collected_inventory[:template]
   end
 
+  def advertised_images
+    manager.ovirt_services.advertised_images
+  end
+
   def collect_networks
     collected_inventory[:network]
   end

--- a/app/models/manageiq/providers/ovirt/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ovirt/inventory/collector/target_collection.rb
@@ -150,6 +150,10 @@ class ManageIQ::Providers::Ovirt::Inventory::Collector::TargetCollection < Manag
     t
   end
 
+  def advertised_images
+    []
+  end
+
   def parse_targets!
     target.targets.each do |t|
       case t

--- a/app/models/manageiq/providers/ovirt/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/ovirt/inventory/persister/infra_manager.rb
@@ -21,6 +21,7 @@ class ManageIQ::Providers::Ovirt::Inventory::Persister::InfraManager < ManageIQ:
     add_collection(infra, :networks)
     add_collection(infra, :operating_systems)
     add_collection(infra, :vms)
+    add_collection(infra, :iso_images)
 
     add_miq_templates
     add_resource_pools

--- a/spec/factories/iso_datastore.rb
+++ b/spec/factories/iso_datastore.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :iso_datastore, :class => 'ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore', :parent => :storage_redhat
+end

--- a/spec/models/manageiq/providers/ovirt/infra_manager/iso_datastore_spec.rb
+++ b/spec/models/manageiq/providers/ovirt/infra_manager/iso_datastore_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore do
+  include Spec::Support::ArelHelper
+
+  let(:ems) { FactoryBot.create(:ems_redhat) }
+  let(:iso_datastore) { FactoryBot.create(:iso_datastore, :ext_management_system => ems, :name => ems.name) }
+
+  describe "#advertised_images" do
+    subject(:advertised_images) { ems.ovirt_services.advertised_images }
+
+    context "ems is rhv" do
+      context "supports api4" do
+        it "send the method to ovirt services v4" do
+          expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4)
+            .to receive(:advertised_images)
+          advertised_images
+        end
+      end
+    end
+
+    describe "#name" do
+      it "has a name" do
+        expect(iso_datastore.name).to eq(ems.name)
+      end
+
+      it "fetches name via sql" do
+        iso_datastore
+        expect(virtual_column_sql_value(Storage, "name")).to eq(ems.name)
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/ovirt/infra_manager/ovirt_services/v4_spec.rb
+++ b/spec/models/manageiq/providers/ovirt/infra_manager/ovirt_services/v4_spec.rb
@@ -40,7 +40,8 @@ describe ManageIQ::Providers::Ovirt::InfraManager::OvirtServices::V4 do
       context "there are iso domains attached to the data-center" do
         context "there are active iso domains" do
           it 'returns iso images from an active domain' do
-            expect(advertised_images).to match_array(%w[iso_1 iso_2])
+            res = advertised_images.map { |img| img.name  }
+            expect(res).to match_array(%w[iso_1 iso_2])
           end
         end
 

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_lans_refresh_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_lans_refresh_recording.yml
@@ -10647,3 +10647,470 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vms/21f55c51-a9ed
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60b7
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 958175b1-bcb7-4d19-bf1a-d8c29ddadbbf
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 0733c314-26e7-41c3-b7f5-8e46213cc321
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 5628f41a-d9a5-4944-91d3-81815658c01e
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 76ce04f5-8c83-4b78-9f8c-e22ccb2921a2
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 9a2e3301-6272-49c5-83cd-c3ea31442530
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 5e3f5a57-3612-47ce-aab3-0b69248d6dde
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 23d28580-3d36-4b3c-85bb-c55e3d8a60ba
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 3ce4f325-a35c-46dd-aca3-83d57f38e021
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_host.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_host.yml
@@ -6833,3 +6833,702 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vms/0a221304-b874
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:01 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: c6634867-df3e-437c-be01-bb5d85c1ea56
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:13 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 148a8b14-fddc-4fcf-be49-1a03a5c901e5
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:17 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: d545be44-b182-4201-9c65-3e91f77c07a0
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:01 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: ffe2e99d-303f-49e2-b80a-ae6984ab55a1
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:13 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 013b28f6-baf8-4774-a27d-fdded7bf65fc
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:17 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 210317eb-0093-4148-a237-119f24c9f962
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:48:59 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: fee4142f-9877-4145-842f-ddd94cc1c629
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:01 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: fd59d244-d350-4a00-869e-765862e34812
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:10 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: e1542b2a-4043-4af8-a6e2-007af236974f
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:13 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 8fdf624d-eff8-464d-8a8e-4f3ebf1f343a
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:14 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 899a8d6c-6fa1-49e5-8264-f5bebcd1df1d
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:17 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: c546dfd3-2a47-4a02-8f14-ca659605e73f
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_template.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_template.yml
@@ -5676,3 +5676,470 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vms/0a221304-b874
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 958175b1-bcb7-4d19-bf1a-d8c29ddadbbf
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 0733c314-26e7-41c3-b7f5-8e46213cc321
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 5628f41a-d9a5-4944-91d3-81815658c01e
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 76ce04f5-8c83-4b78-9f8c-e22ccb2921a2
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 9a2e3301-6272-49c5-83cd-c3ea31442530
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 5e3f5a57-3612-47ce-aab3-0b69248d6dde
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 23d28580-3d36-4b3c-85bb-c55e3d8a60ba
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 3ce4f325-a35c-46dd-aca3-83d57f38e021
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_template_with_host.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_template_with_host.yml
@@ -5682,3 +5682,470 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vms/0a221304-b874
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 958175b1-bcb7-4d19-bf1a-d8c29ddadbbf
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 0733c314-26e7-41c3-b7f5-8e46213cc321
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 5628f41a-d9a5-4944-91d3-81815658c01e
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 76ce04f5-8c83-4b78-9f8c-e22ccb2921a2
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 9a2e3301-6272-49c5-83cd-c3ea31442530
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 5e3f5a57-3612-47ce-aab3-0b69248d6dde
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 23d28580-3d36-4b3c-85bb-c55e3d8a60ba
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 3ce4f325-a35c-46dd-aca3-83d57f38e021
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_after_full.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_after_full.yml
@@ -5624,3 +5624,470 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vms/a1293e54-dae8
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 958175b1-bcb7-4d19-bf1a-d8c29ddadbbf
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 0733c314-26e7-41c3-b7f5-8e46213cc321
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 5628f41a-d9a5-4944-91d3-81815658c01e
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 76ce04f5-8c83-4b78-9f8c-e22ccb2921a2
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 9a2e3301-6272-49c5-83cd-c3ea31442530
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 5e3f5a57-3612-47ce-aab3-0b69248d6dde
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 23d28580-3d36-4b3c-85bb-c55e3d8a60ba
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 3ce4f325-a35c-46dd-aca3-83d57f38e021
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_deleted_snapshot.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_deleted_snapshot.yml
@@ -5885,3 +5885,470 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vms/0a221304-b874
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 958175b1-bcb7-4d19-bf1a-d8c29ddadbbf
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 0733c314-26e7-41c3-b7f5-8e46213cc321
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 5628f41a-d9a5-4944-91d3-81815658c01e
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 76ce04f5-8c83-4b78-9f8c-e22ccb2921a2
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 9a2e3301-6272-49c5-83cd-c3ea31442530
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 5e3f5a57-3612-47ce-aab3-0b69248d6dde
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 23d28580-3d36-4b3c-85bb-c55e3d8a60ba
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 3ce4f325-a35c-46dd-aca3-83d57f38e021
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_removal.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_removal.yml
@@ -4309,3 +4309,470 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vms/da4646ea-6038
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 958175b1-bcb7-4d19-bf1a-d8c29ddadbbf
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 0733c314-26e7-41c3-b7f5-8e46213cc321
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 5628f41a-d9a5-4944-91d3-81815658c01e
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 76ce04f5-8c83-4b78-9f8c-e22ccb2921a2
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 9a2e3301-6272-49c5-83cd-c3ea31442530
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 5e3f5a57-3612-47ce-aab3-0b69248d6dde
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 23d28580-3d36-4b3c-85bb-c55e3d8a60ba
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 3ce4f325-a35c-46dd-aca3-83d57f38e021
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_with_host.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_graph_target_vm_with_host.yml
@@ -5677,3 +5677,470 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vms/a1293e54-dae8
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 958175b1-bcb7-4d19-bf1a-d8c29ddadbbf
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 0733c314-26e7-41c3-b7f5-8e46213cc321
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 5628f41a-d9a5-4944-91d3-81815658c01e
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 76ce04f5-8c83-4b78-9f8c-e22ccb2921a2
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 9a2e3301-6272-49c5-83cd-c3ea31442530
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 5e3f5a57-3612-47ce-aab3-0b69248d6dde
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 23d28580-3d36-4b3c-85bb-c55e3d8a60ba
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:54:18 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 3ce4f325-a35c-46dd-aca3-83d57f38e021
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_recording.yml
@@ -3963,3 +3963,1862 @@ https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/vms/0a221304-b874
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:44 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: e86ed725-dc22-4fd8-af09-ce63a77717d3
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:51 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: dba22e8f-fea4-471c-a0aa-e5c04d76abc0
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:51:00 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: bb9929b3-3b7d-41d3-8f37-f9f85dd97192
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:03 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 3bf1cde1-4472-4f69-a877-33942fae402a
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 1ceecf32-7e05-4a03-87b1-c92dc955a661
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:28 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: cd14b2b2-e51e-46f3-acb8-ddfa82a5cb64
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: c1c0f2df-e327-42e0-95a6-1a861eaa7ccb
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:58 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 4de5b7c4-9a9f-4015-81f8-03fd08908f25
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 8f48c1e1-83c9-42b2-b546-095333da3dc5
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:45 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 298d767f-6343-4493-a6cf-a9514cf883f8
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:49 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 3d232589-d466-4a61-ae59-e55232c0994a
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:52 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: bedfaf2a-17d5-4940-a8fd-473253614475
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:58 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 16903fc5-f391-4ef7-a280-a5632554a7b4
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:51:00 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: a2f1d28b-d382-498a-acf0-1afeff5f5873
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:00 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 67d25f10-7d64-4c2c-b6a4-3e833d16d7a2
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:04 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: a7cbe236-6ba0-4f98-959d-14925a5c52f8
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:12 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: da5a82de-c485-403b-86b8-9073b542ed85
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 1be01f1b-f662-495c-8e98-23bf7c289fc9
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:24 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 5ea641cf-2828-4861-8a71-89b288f89857
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:28 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 119afe7c-ed4d-4d8c-9d5e-d7bce1af88d8
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:38 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 4c02db52-fd20-45c0-b8b2-81bba5b496e3
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 304183db-869a-4260-a70e-143dfc9b3511
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:53 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: db8095af-9a7f-45f8-85d1-29fe4add7615
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:58 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 220501fa-d608-4803-ab84-e65e3313e9b3
+  :message:
+https://pluto-vdsg.eng.lab.tlv.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:45 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 230297bd-a173-4a20-8e73-cc48710637eb
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:52 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 0f890ce8-5fa8-4bf1-86a6-f8a61dc3c230
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:51:00 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 5f0e00ec-91f2-48f1-a8f0-6fa190b7085c
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:04 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: c0ab30c7-613e-41df-b480-7bc1eceb171c
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:15 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: f6ad0e01-3e3d-4be2-a826-7c1bafae5758
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:28 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: d4ada055-da4f-40d9-a8d1-ff7b12618052
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:42 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: d39026d1-df68-4b0c-bcd2-c517c6defb25
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:55:58 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: ecd31f1d-de6b-4fbe-8d81-7fcf6d52278c
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_recording_custom_attrs.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/ovirt_sdk_refresh_recording_custom_attrs.yml
@@ -7724,3 +7724,1398 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/e23898b2-0540-456c
     content-length: '3057'
     correlation-id: 37873fd5-9e54-4804-bb81-c271d753795d
   :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:56 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 1acb9c94-3448-4c1a-8801-a27f9bdb31b2
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:04 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 472db986-2a46-46a6-8c82-389d6a35b667
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:12 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 1d09d965-f12a-4fe9-8985-b7e4bb1773b7
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:29 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 9b3558a7-8472-4f76-8f61-deb5e7cfdf83
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:41 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: f7b81954-593a-447f-92ce-1c8bc3b71211
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:54 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: d8f58738-1a97-40de-abe9-cc46845edfe1
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:54 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 43a41cb0-7666-4438-b20f-f4e6d6c279d8
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:56 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: b2dac53a-621c-4a82-8bf0-1234a86cb9a4
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:01 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 686b7334-cad0-4f6c-b6ef-f247e6785597
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:04 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 7d12f82d-5458-4b06-97ac-36ef531acedd
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:10 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: ad9db70b-ce4d-48ac-9b9b-facd4502e1e5
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:13 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 82e3edcd-092a-4b2d-b603-6cf0562ea784
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:26 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 377915ba-1a90-4e5f-b640-fc89dcc83943
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:29 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: '09a15c97-487f-4895-a288-94a087cfb98a'
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:38 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: fb9c874f-b682-4b2a-972b-d53811e00774
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:41 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 361ed318-592b-4a67-b7c5-3dccc5d1f38d
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:51 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: a1f7ee85-2f98-41e6-9fa7-0c62602c9085
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:54 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 61a8ebe6-6811-4bf7-9484-3d04a799d570
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:56 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: d30ccf3d-b88e-412f-a509-94dbd876f301
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:04 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 43a2935f-dbd1-439e-b170-dc718072ccae
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:50:13 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 392dcfe7-aa04-4ea5-be49-1c582e5514fe
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:29 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: b1eb6379-1b35-4405-9d98-58c484d95233
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:41 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: b6cd0eff-5341-40bf-83c1-e85c82364b5a
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:55 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 63678895-7321-4f2e-83ea-1e0484571004
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/refresher_multi_datacenter_network_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/refresher_multi_datacenter_network_recording.yml
@@ -4916,3 +4916,702 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/e23898b2-0540-456c
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:01 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: c6634867-df3e-437c-be01-bb5d85c1ea56
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:13 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 148a8b14-fddc-4fcf-be49-1a03a5c901e5
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:17 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: d545be44-b182-4201-9c65-3e91f77c07a0
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:01 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: ffe2e99d-303f-49e2-b80a-ae6984ab55a1
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:13 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 013b28f6-baf8-4774-a27d-fdded7bf65fc
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:17 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 210317eb-0093-4148-a237-119f24c9f962
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:48:59 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: fee4142f-9877-4145-842f-ddd94cc1c629
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:01 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: fd59d244-d350-4a00-869e-765862e34812
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:10 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: e1542b2a-4043-4af8-a6e2-007af236974f
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:56:13 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 8fdf624d-eff8-464d-8a8e-4f3ebf1f343a
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:14 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 899a8d6c-6fa1-49e5-8264-f5bebcd1df1d
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:17 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: c546dfd3-2a47-4a02-8f14-ca659605e73f
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/refresher_network_ports_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/refresher_network_ports_recording.yml
@@ -5386,3 +5386,238 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/vms/e23898b2-0540-456c
     content-length: '91'
     correlation-id: 5fd783a5-b92a-44a8-a985-555a9abe60a8
   :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:57 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: a24b0636-c3a9-47d9-8135-2c6723ffde9f
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:55 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: e7e0ce7c-b5c1-4d64-9ff4-2ff8fd11c2b9
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:57 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: dce551ba-b644-4a18-89f7-f2cf33344832
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:58 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: d700b5c0-1f34-4482-9583-5d18709b661b
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/refresher_reconfigure_with_no_restart_needed_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/refresher_reconfigure_with_no_restart_needed_recording.yml
@@ -4830,3 +4830,470 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a
     content-length: '712'
     correlation-id: 52d18d19-6577-4a92-aad6-833350790ad8
   :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:27 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 7f38255b-77c0-43e4-9935-6ad64bac8068
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:52 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: ab3780a5-0ebb-42f6-ab3f-4838568d7d5f
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:25 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 46fa1dfd-3c4f-4b31-856b-62fcb1c5f23a
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:27 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 927063d3-3829-4298-bab9-ac33a96bc779
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:49 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 717a2874-24b9-47a9-8683-967bacd5c3b6
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:52 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 98c4f1be-1653-4818-a249-5693bcdaee7f
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:28 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: d88a3139-2f3a-4000-92f5-6961e2b1efdc
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:52 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 339ad354-a34d-4a2d-9a49-e49229489aee
+  :message:

--- a/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/refresher_reconfigure_with_restart_needed_recording.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ovirt/infra_manager/refresh/refresher_reconfigure_with_restart_needed_recording.yml
@@ -4981,3 +4981,470 @@ https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/cfbc93a
       content-length: '85'
       correlation-id: 30d889c8-08ef-4168-9798-2793b4d9328c
     :message: 
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters{:search=>"status=up"}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:27 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: 7f38255b-77c0-43e4-9935-6ad64bac8068
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/setmaster" rel="setmaster"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/cleanfinishedtasks" rel="cleanfinishedtasks"/>
+            </actions>
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/quotas" rel="quotas"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/qoss" rel="qoss"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/iscsibonds" rel="iscsibonds"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/permissions" rel="permissions"/>
+            <local>false</local>
+            <quota_mode>enabled</quota_mode>
+            <status>up</status>
+            <storage_format>v5</storage_format>
+            <supported_versions>
+                <version>
+                    <major>4</major>
+                    <minor>6</minor>
+                </version>
+            </supported_versions>
+            <version>
+                <major>4</major>
+                <minor>6</minor>
+            </version>
+            <mac_pool href="/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e" id="58ca604b-017d-0374-0220-00000000014e"/>
+        </data_center>
+    </data_centers>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:52 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '498'
+    correlation-id: ab3780a5-0ebb-42f6-ab3f-4838568d7d5f
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:25 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 46fa1dfd-3c4f-4b31-856b-62fcb1c5f23a
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:27 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 927063d3-3829-4298-bab9-ac33a96bc779
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:49 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 717a2874-24b9-47a9-8683-967bacd5c3b6
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <storage_domains>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b" id="ce478559-cbab-42e3-80fb-d0457904666b">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/deactivate" rel="deactivate"/>
+            </actions>
+            <name>domain0</name>
+            <description></description>
+            <comment></comment>
+            <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/ce478559-cbab-42e3-80fb-d0457904666b/disks" rel="disks"/>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>1010391056384</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>true</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/domain0</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v5</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>data</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+        <storage_domain href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427">
+            <actions>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/activate" rel="activate"/>
+                <link href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52/storagedomains/298209d2-9413-4f6b-86ac-987401792427/deactivate" rel="deactivate"/>
+            </actions>
+            <name>iso-domain</name>
+            <description></description>
+            <comment></comment>
+            <available>758061727744</available>
+            <backup>false</backup>
+            <block_size>512</block_size>
+            <committed>0</committed>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+            <discard_after_delete>false</discard_after_delete>
+            <external_status>ok</external_status>
+            <master>false</master>
+            <status>active</status>
+            <storage>
+                <address>agrare-rhv-nfs.fyre.ibm.com</address>
+                <nfs_version>auto</nfs_version>
+                <path>/exports/rhv/iso</path>
+                <type>nfs</type>
+            </storage>
+            <storage_format>v1</storage_format>
+            <supports_discard>false</supports_discard>
+            <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+            <type>iso</type>
+            <used>313532612608</used>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <wipe_after_delete>false</wipe_after_delete>
+            <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            <data_centers>
+                <data_center href="/ovirt-engine/api/datacenters/d8fbd54e-d237-11ec-941a-6cae8b4e2d52" id="d8fbd54e-d237-11ec-941a-6cae8b4e2d52"/>
+            </data_centers>
+        </storage_domain>
+    </storage_domains>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:52 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '739'
+    correlation-id: 98c4f1be-1653-4818-a249-5693bcdaee7f
+  :message:
+https://engine-43.lab.inz.redhat.com:443/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files{}GET:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:49:28 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: d88a3139-2f3a-4000-92f5-6961e2b1efdc
+  :message:
+- :body: |
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <files>
+        <file href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427/files/ubuntu-22.04.1-live-server-amd64.iso" id="ubuntu-22.04.1-live-server-amd64.iso">
+            <name>ubuntu-22.04.1-live-server-amd64.iso</name>
+            <storage_domain href="/ovirt-engine/api/storagedomains/298209d2-9413-4f6b-86ac-987401792427" id="298209d2-9413-4f6b-86ac-987401792427"/>
+        </file>
+    </files>
+  :code: 200
+  :headers:
+    date: Mon, 12 Dec 2022 15:57:52 GMT
+    server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+      Python/3.6
+    content-encoding: gzip
+    content-type: application/xml;charset=UTF-8
+    content-length: '229'
+    correlation-id: 339ad354-a34d-4a2d-9a49-e49229489aee
+  :message:


### PR DESCRIPTION
- since iso datastores are only used by oVirt/RHV, we can move its model from core and into the provider plugin
- iso datastores will be modelled as `Storage` objects with STI `:type => ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore`
- `synchronize_advertised_images` functionality is now in a refresh and the images will be persisted

Depends on:
- [ ] https://github.com/ManageIQ/manageiq/pull/22239
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/672
- [ ] https://github.com/ManageIQ/manageiq-api/pull/1186
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8548
- [ ] https://github.com/ManageIQ/manageiq-providers-red_hat_virtualization/pull/17
- [x] https://github.com/ManageIQ/manageiq/pull/22258

TODO:
- [X] `IsoDatastore` references in UI
- [x] supports :iso_datastore feature
- [x] Test with `manageiq-providers-red_hat_virtualization`

Ref:
- https://github.com/ManageIQ/manageiq/issues/19440

@miq-bot add_label enhancement
@miq-bot assign @agrare 