### PR TITLE
Fix RHV `#find_destination_in_vmdb` looking for the wrong type

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/provision/cloning.rb
@@ -10,11 +10,8 @@ module ManageIQ::Providers::Ovirt::InfraManager::Provision::Cloning
   end
 
   def find_destination_in_vmdb(ems_ref)
-    if source.template?
-      ManageIQ::Providers::Ovirt::InfraManager::Vm.find_by(:name => dest_name, :ems_ref => ems_ref)
-    else
-      ManageIQ::Providers::Ovirt::InfraManager::Template.find_by(:name => dest_name, :ems_ref => ems_ref)
-    end
+    assoc = source.template? ? ems.vms : ems.miq_templates
+    assoc.find_by(:name => dest_name, :ems_ref => ems_ref)
   end
 
   def prepare_for_clone_task


### PR DESCRIPTION
Fix RHV provisioning when calling `#find_destination_in_vmdb` due to looking for the wrong class name.