### PR TITLE
Use default host_verify_credentials

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/host.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/host.rb
@@ -3,20 +3,6 @@ class ManageIQ::Providers::Ovirt::InfraManager::Host < ::Host
     ManageIQ::Providers::Ovirt::InfraManager::OvirtServices::V4.new(:ems => ext_management_system).get_host_proxy(self, connection)
   end
 
-  def verify_credentials(auth_type = nil, options = {})
-    raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(auth_type)
-    if auth_type.to_s != 'ipmi' && os_image_name !~ /linux_*/
-      raise MiqException::MiqHostError, "Logon to platform [#{os_image_name}] not supported"
-    end
-    case auth_type.to_s
-    when 'ipmi' then verify_credentials_with_ipmi(auth_type)
-    else
-      verify_credentials_with_ssh(auth_type, options)
-    end
-
-    true
-  end
-
   supports :capture
   supports :quick_stats do
     unless ext_management_system.supports?(:quick_stats)


### PR DESCRIPTION
part of: https://github.com/ManageIQ/manageiq/pull/22336

The default verify_credentials used to be ws, but is now ssh. This code wants the new default behavior.

Deleting this copy/paste code