### PR TITLE
Fix VM Reconfigure for stopped VMs

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm/reconfigure.rb
@@ -24,7 +24,13 @@ module ManageIQ::Providers::Ovirt::InfraManager::Vm::Reconfigure
   end
 
   def available_vlans
-    vlans = host.lans.pluck(:name)
+    vlans = if host
+              host.lans.pluck(:name)
+            elsif parent_cluster
+              parent_cluster.lans.pluck(:name)
+            else
+              []
+            end
 
     vlans.sort.concat(available_external_vlans)
   end


### PR DESCRIPTION
Ovirt VMs have no host assigned when they are not running.  This causes an exception to be raised when trying to reconfigure a VM that isn't running because we are using the host for the list of available lans.