### PR TITLE
Add Missing Protocol to Native Console API Response

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm/remote_console.rb
@@ -62,7 +62,8 @@ class ManageIQ::Providers::Ovirt::InfraManager::Vm
       {
         :connection => conn,
         :type       => 'application/x-virt-viewer',
-        :name       => 'console.vv'
+        :name       => 'console.vv',
+        :proto      => 'native'
       }
     end
 


### PR DESCRIPTION
Related to: https://github.com/ManageIQ/manageiq-ui-service/pull/1839

Adds the `:proto` object to the API response in order to match other remote console responses and match existing service ui code/design.