### PR TITLE
Check supported storage type for vm Smartstate analysis scan

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared/scanning.rb
@@ -7,6 +7,11 @@ module ManageIQ::Providers::Ovirt::InfraManager::VmOrTemplateShared::Scanning
       unless feature_supported
         unsupported_reason_add(:smartstate_analysis, reason)
       end
+      if storage.nil?
+        unsupported_reason_add(:smartstate_analysis, "Vm is not located on a storage")
+      elsif !storage.storage_type_supported_for_ssa?
+        unsupported_reason_add(:smartstate_analysis, "Smartstate Analysis unsupported for storage type %{store_type}" % {:store_type => storage.store_type})
+      end
     end
   end
 


### PR DESCRIPTION
Checking if vm storage type is supported for smartstate analysis scans when checking if vm supports smartstate analysis

@miq-bot add_label bug
@miq-bot assign @agrare 