### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Ovirt::InfraManager < ManageIQ::Providers::InfraManager
-  include_concern :ApiIntegration
-  include_concern :AdminUI
+  include ApiIntegration
+  include AdminUI
 
   has_many :cloud_tenants, :foreign_key => :ems_id, :dependent => :destroy
   has_many :vm_and_template_ems_custom_fields, :through => :vms_and_templates, :source => :ems_custom_attributes

--- a/app/models/manageiq/providers/ovirt/infra_manager.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager.rb
@@ -1,26 +1,4 @@
 class ManageIQ::Providers::Ovirt::InfraManager < ManageIQ::Providers::InfraManager
-  require_nested  :Cluster
-  require_nested  :Datacenter
-  require_nested  :EventCatcher
-  require_nested  :EventParser
-  require_nested  :EventTargetParser
-  require_nested  :Folder
-  require_nested  :RefreshWorker
-  require_nested  :Refresher
-  require_nested  :ResourcePool
-  require_nested  :MetricsCapture
-  require_nested  :MetricsCollectorWorker
-  require_nested  :Host
-  require_nested  :Provision
-  require_nested  :ProvisionViaIso
-  require_nested  :ProvisionViaPxe
-  require_nested  :ProvisionWorkflow
-  require_nested  :Snapshot
-  require_nested  :Storage
-  require_nested  :IsoDatastore
-  require_nested  :Template
-  require_nested  :Vm
-  require_nested  :DistributedVirtualSwitch
   include_concern :ApiIntegration
   include_concern :AdminUI
 

--- a/app/models/manageiq/providers/ovirt/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/event_catcher.rb
@@ -1,4 +1,3 @@
 class ManageIQ::Providers::Ovirt::InfraManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
   # might need to set settings name here
 end

--- a/app/models/manageiq/providers/ovirt/infra_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/metrics_collector_worker.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::Ovirt::InfraManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
   self.default_queue_name = "ovirt"
 
   def friendly_name

--- a/app/models/manageiq/providers/ovirt/infra_manager/provision.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/provision.rb
@@ -1,9 +1,9 @@
 class ManageIQ::Providers::Ovirt::InfraManager::Provision < MiqProvision
-  include_concern 'Cloning'
-  include_concern 'Configuration'
-  include_concern 'Placement'
-  include_concern 'StateMachine'
-  include_concern 'Disk'
+  include Cloning
+  include Configuration
+  include Placement
+  include StateMachine
+  include Disk
 
   def destination_type
     "Vm"

--- a/app/models/manageiq/providers/ovirt/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/provision/configuration.rb
@@ -1,8 +1,8 @@
 module ManageIQ::Providers::Ovirt::InfraManager::Provision::Configuration
   extend ActiveSupport::Concern
 
-  include_concern 'Container'
-  include_concern 'Network'
+  include Container
+  include Network
 
   def attach_floppy_payload
     return unless content = customization_template_content

--- a/app/models/manageiq/providers/ovirt/infra_manager/provision_via_iso.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/provision_via_iso.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Ovirt::InfraManager::ProvisionViaIso < ManageIQ::Providers::Ovirt::InfraManager::Provision
-  include_concern 'Cloning'
-  include_concern 'Configuration'
-  include_concern 'StateMachine'
+  include Cloning
+  include Configuration
+  include StateMachine
 end

--- a/app/models/manageiq/providers/ovirt/infra_manager/provision_via_pxe.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/provision_via_pxe.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Ovirt::InfraManager::ProvisionViaPxe < ManageIQ::Providers::Ovirt::InfraManager::Provision
-  include_concern 'Cloning'
-  include_concern 'Configuration'
-  include_concern 'StateMachine'
+  include Cloning
+  include Configuration
+  include StateMachine
 end

--- a/app/models/manageiq/providers/ovirt/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/provision_workflow.rb
@@ -1,8 +1,7 @@
 class ManageIQ::Providers::Ovirt::InfraManager::ProvisionWorkflow < MiqProvisionInfraWorkflow
   include CloudInitTemplateMixin
   include SysprepTemplateMixin
-
-  include_concern "DialogFieldValidation"
+  include DialogFieldValidation
 
   SYSPREP_TIMEZONES = {
     '001' => '(UTC-12:00) Dateline Standard Time',

--- a/app/models/manageiq/providers/ovirt/infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Ovirt::InfraManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/ovirt/infra_manager/scanning.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/scanning.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Ovirt::InfraManager::Scanning
-  require_nested :Job
 end

--- a/app/models/manageiq/providers/ovirt/infra_manager/template.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/template.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Ovirt::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
-  include_concern 'ManageIQ::Providers::Ovirt::InfraManager::VmOrTemplateShared'
+  include ManageIQ::Providers::Ovirt::InfraManager::VmOrTemplateShared
 
   supports :provisioning do
     if ext_management_system

--- a/app/models/manageiq/providers/ovirt/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm.rb
@@ -1,8 +1,8 @@
 class ManageIQ::Providers::Ovirt::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
-  include_concern 'Operations'
-  include_concern 'RemoteConsole'
-  include_concern 'Reconfigure'
-  include_concern 'ManageIQ::Providers::Ovirt::InfraManager::VmOrTemplateShared'
+  include Operations
+  include RemoteConsole
+  include Reconfigure
+  include ManageIQ::Providers::Ovirt::InfraManager::VmOrTemplateShared
 
   supports :capture
   supports :migrate do

--- a/app/models/manageiq/providers/ovirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm/operations.rb
@@ -1,11 +1,10 @@
 module ManageIQ::Providers::Ovirt::InfraManager::Vm::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'Configuration'
-  include_concern 'Guest'
-  include_concern 'Power'
-  include_concern 'Relocation'
-  include_concern 'Snapshot'
+  include Configuration
+  include Guest
+  include Power
+  include Relocation
+  include Snapshot
 
   included do
     supports :terminate do

--- a/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared.rb
@@ -1,4 +1,4 @@
 module ManageIQ::Providers::Ovirt::InfraManager::VmOrTemplateShared
   extend ActiveSupport::Concern
-  include_concern 'Scanning'
+  include Scanning
 end

--- a/app/models/manageiq/providers/ovirt/inventory.rb
+++ b/app/models/manageiq/providers/ovirt/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Ovirt::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name

--- a/app/models/manageiq/providers/ovirt/inventory/collector.rb
+++ b/app/models/manageiq/providers/ovirt/inventory/collector.rb
@@ -1,8 +1,5 @@
 class ManageIQ::Providers::Ovirt::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   # TODO: review the changes here and find common parts with ManageIQ::Providers::Ovirt::InfraManager::Inventory::Strategies::V4
-  require_nested :InfraManager
-  require_nested :TargetCollection
-
   attr_reader :clusters
   attr_reader :networks
   attr_reader :storagedomains

--- a/app/models/manageiq/providers/ovirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/ovirt/inventory/parser.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Ovirt::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :InfraManager
 end

--- a/app/models/manageiq/providers/ovirt/inventory/persister.rb
+++ b/app/models/manageiq/providers/ovirt/inventory/persister.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Ovirt::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :InfraManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/ovirt/network_manager.rb
+++ b/app/models/manageiq/providers/ovirt/network_manager.rb
@@ -1,13 +1,4 @@
 class ManageIQ::Providers::Ovirt::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :FloatingIp
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :SecurityGroup
-
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin
 

--- a/app/models/manageiq/providers/ovirt/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/ovirt/network_manager/cloud_network.rb
@@ -1,6 +1,4 @@
 ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Ovirt::NetworkManager::CloudNetwork < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork
-  require_nested :Private
-  require_nested :Public
 end

--- a/app/models/manageiq/providers/ovirt/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ovirt/network_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Ovirt::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_ovirt_network
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854
