### PR TITLE
drop use of unuspported_reason_add

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager.rb
@@ -26,11 +26,11 @@ class ManageIQ::Providers::Ovirt::InfraManager < ManageIQ::Providers::InfraManag
   supports :admin_ui do
     # Link to oVirt Admin UI is supported for Engine version 4.1.8 or better.
     # See https://bugzilla.redhat.com/1512989 for details.
-    unsupported_reason_add(:admin_ui, _('Admin UI is supported on version >= 4.1.8')) unless version_at_least?('4.1.8')
+    _('Admin UI is supported on version >= 4.1.8') unless version_at_least?('4.1.8')
   end
 
   supports :create_iso_datastore do
-    unsupported_reason_add(:create_iso_datastore, _("Already has an ISO datastore")) unless iso_datastores.empty?
+    _("Already has an ISO datastore") unless iso_datastores.empty?
   end
 
   def ensure_managers

--- a/app/models/manageiq/providers/ovirt/infra_manager/host.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/host.rb
@@ -7,18 +7,18 @@ class ManageIQ::Providers::Ovirt::InfraManager::Host < ::Host
   supports :capture
   supports :quick_stats do
     unless ext_management_system.supports?(:quick_stats)
-      unsupported_reason_add(:quick_stats, 'oVirt API version does not support quick_stats')
+      'oVirt API version does not support quick_stats'
     end
   end
 
   supports :enter_maint_mode do
-    unsupported_reason_add(:enter_maint_mode, _('The Host is not connected to an active provider')) unless has_active_ems?
-    unsupported_reason_add(:enter_maint_mode, _('The Host is not powered on')) unless power_state == 'on'
+    return _('The Host is not connected to an active provider') unless has_active_ems?
+    return _('The Host is not powered on') unless power_state == 'on'
   end
 
   supports :exit_maint_mode do
-    unsupported_reason_add(:enter_maint_mode, _('The Host is not connected to an active provider')) unless has_active_ems?
-    unsupported_reason_add(:enter_maint_mode, _('The Host is not in maintenance mode')) unless power_state == 'maintenance'
+    _('The Host is not connected to an active provider') unless has_active_ems?
+    _('The Host is not in maintenance mode') unless power_state == 'maintenance'
   end
 
   def enter_maint_mode

--- a/app/models/manageiq/providers/ovirt/infra_manager/template.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/template.rb
@@ -3,9 +3,9 @@ class ManageIQ::Providers::Ovirt::InfraManager::Template < ManageIQ::Providers::
 
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
+      ext_management_system.unsupported_reason(:provisioning)
     else
-      unsupported_reason_add(:provisioning, _('not connected to ems'))
+      _('not connected to ems')
     end
   end
 

--- a/app/models/manageiq/providers/ovirt/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm.rb
@@ -7,40 +7,39 @@ class ManageIQ::Providers::Ovirt::InfraManager::Vm < ManageIQ::Providers::InfraM
   supports :capture
   supports :migrate do
     if blank? || orphaned? || archived?
-      unsupported_reason_add(:migrate, "Migrate operation in not supported.")
+      "Migrate operation in not supported."
     elsif !ext_management_system.supports?(:migrate)
-      unsupported_reason_add(:migrate, 'oVirt API version does not support migrate')
+      'oVirt API version does not support migrate'
     end
   end
 
   supports :reconfigure_disks do
     if storage.blank?
-      unsupported_reason_add(:reconfigure_disks, _('storage is missing'))
+      _('storage is missing')
     elsif ext_management_system.blank?
-      unsupported_reason_add(:reconfigure_disks, _('The virtual machine is not associated with a provider'))
+      _('The virtual machine is not associated with a provider')
     elsif !ext_management_system.supports?(:reconfigure_disks)
-      unsupported_reason_add(:reconfigure_disks, _('The provider does not support reconfigure disks'))
+      _('The provider does not support reconfigure disks')
     end
   end
 
   supports_not :reset
   supports :publish do
     if blank? || orphaned? || archived?
-      unsupported_reason_add(:publish, _('Publish operation in not supported'))
+      _('Publish operation in not supported')
     elsif ext_management_system.blank?
-      unsupported_reason_add(:publish, _('The virtual machine is not associated with a provider'))
+      _('The virtual machine is not associated with a provider')
     elsif !ext_management_system.supports?(:publish)
-      unsupported_reason_add(:publish, _('This feature is not supported by the api version of the provider'))
+      _('This feature is not supported by the api version of the provider')
     elsif power_state != "off"
-      unsupported_reason_add(:publish, _('The virtual machine must be down'))
+      _('The virtual machine must be down')
     end
   end
 
   supports :reconfigure_network_adapters
 
-  # supports :reconfigure_disksize
   supports :reconfigure_disksize do
-    unsupported_reason_add(:reconfigure_disksize, 'Cannot resize disks of a VM with snapshots') if snapshots.count > 1
+    'Cannot resize disks of a VM with snapshots' if snapshots.count > 1
   end
 
   POWER_STATES = {

--- a/app/models/manageiq/providers/ovirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm/operations.rb
@@ -7,9 +7,7 @@ module ManageIQ::Providers::Ovirt::InfraManager::Vm::Operations
   include Snapshot
 
   included do
-    supports :terminate do
-      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports?(:control)
-    end
+    supports(:terminate) { unsupported_reason(:control) }
   end
 
   def raw_destroy

--- a/app/models/manageiq/providers/ovirt/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm/operations/guest.rb
@@ -3,13 +3,19 @@ module ManageIQ::Providers::Ovirt::InfraManager::Vm::Operations::Guest
 
   included do
     supports :shutdown_guest do
-      unsupported_reason_add(:shutdown_guest, unsupported_reason(:control)) unless supports?(:control)
-      unsupported_reason_add(:shutdown_guest, _("The VM is not powered on")) unless current_state == "on"
+      if current_state == "on"
+        unsupported_reason(:control)
+      else
+        _("The VM is not powered on")
+      end
     end
 
     supports :reboot_guest do
-      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports?(:control)
-      unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+      if current_state == "on"
+        unsupported_reason(:control)
+      else
+        _("The VM is not powered on")
+      end
     end
   end
 

--- a/app/models/manageiq/providers/ovirt/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm/operations/snapshot.rb
@@ -3,19 +3,11 @@ module ManageIQ::Providers::Ovirt::InfraManager::Vm::Operations::Snapshot
 
   included do
     supports :snapshots do
-      if supports?(:control)
-        unless ext_management_system.supports?(:snapshots)
-          unsupported_reason_add(:snapshots, ext_management_system.unsupported_reason(:snapshots))
-        end
-      else
-        unsupported_reason_add(:snapshots, unsupported_reason(:control))
-      end
+      unsupported_reason(:control) || ext_management_system.unsupported_reason(:snapshots)
     end
 
     supports :revert_to_snapshot do
-      unless allowed_to_revert?
-        unsupported_reason_add(:revert_to_snapshot, revert_unsupported_message)
-      end
+      revert_unsupported_message unless allowed_to_revert?
     end
 
     supports_not :remove_all_snapshots, :reason => N_("Removing all snapshots is currently not supported")

--- a/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared/scanning.rb
@@ -3,14 +3,12 @@ module ManageIQ::Providers::Ovirt::InfraManager::VmOrTemplateShared::Scanning
 
   included do
     supports :smartstate_analysis do
-      feature_supported, reason = check_feature_support('smartstate_analysis')
-      unless feature_supported
-        unsupported_reason_add(:smartstate_analysis, reason)
-      end
       if storage.nil?
-        unsupported_reason_add(:smartstate_analysis, "Vm is not located on a storage")
+        "Vm is not located on a storage"
       elsif !storage.storage_type_supported_for_ssa?
-        unsupported_reason_add(:smartstate_analysis, "Smartstate Analysis unsupported for storage type %{store_type}" % {:store_type => storage.store_type})
+        "Smartstate Analysis unsupported for storage type %{store_type}" % {:store_type => storage.store_type}
+      else
+        unuspported_reason(:action)
       end
     end
   end


### PR DESCRIPTION
@agrare please take a look at this one. The patterns are different from the other providers

feels like a number of these could just delegate the reason to the failed supports check

---
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
