### PR TITLE
inherit ExternalDistributedVirtualSwitch from right class

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/external_distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/external_distributed_virtual_switch.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Ovirt::InfraManager::ExternalDistributedVirtualSwitch < ManageIQ::Providers::InfraManager::DistributedVirtualSwitch
+class ManageIQ::Providers::Ovirt::InfraManager::ExternalDistributedVirtualSwitch < ManageIQ::Providers::InfraManager::ExternalDistributedVirtualSwitch
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :external_distributed_virtual_switches, :class_name => "ManageIQ::Providers::Ovirt::InfraManager"
 
   include RelationshipMixin


### PR DESCRIPTION
Added a new STI model to avoid recreating records with ExternalDistributedVirtualSwitch in database every time when refresher running

https://github.com/ManageIQ/manageiq/pull/23000