### PR TITLE
Delay load the ovirt_metrics and ovirtsdk4 client libraries

### DIFF
--- a/app/models/manageiq/providers/ovirt/connection_manager.rb
+++ b/app/models/manageiq/providers/ovirt/connection_manager.rb
@@ -1,5 +1,3 @@
-require 'ovirtsdk4'
-
 #
 # This class is a responsible for managing a set of `OvirtSDK4::Connection` objects. Each connection is
 # identified by the `id` attribute of the corresponding EMS, or by `nil` if there is no such EMS created yet.
@@ -28,6 +26,8 @@ class ManageIQ::Providers::Ovirt::ConnectionManager
   # @api private
   #
   def initialize
+    require 'ovirtsdk4'
+
     # This hash stores the connections that have already been created. The keys of the hash will be the
     # identifiers of the EMSs, and the values will be instances of the `Entry` class.
     @registry = {}

--- a/app/models/manageiq/providers/ovirt/discovery.rb
+++ b/app/models/manageiq/providers/ovirt/discovery.rb
@@ -1,5 +1,4 @@
 require 'manageiq/network_discovery/port'
-require 'ovirtsdk4'
 
 module ManageIQ
   module Providers
@@ -18,6 +17,8 @@ module ManageIQ
           private
 
           def ovirt_exists?(host, logger = nil)
+            require 'ovirtsdk4'
+
             opts = {
               :host => host,
               :log  => logger

--- a/app/models/manageiq/providers/ovirt/infra_manager/admin_ui.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/admin_ui.rb
@@ -2,7 +2,6 @@ module ManageIQ::Providers::Ovirt::InfraManager::AdminUI
   extend ActiveSupport::Concern
 
   require 'openssl'
-  require 'ovirtsdk4'
   require 'uri'
   require 'json'
 
@@ -25,6 +24,8 @@ module ManageIQ::Providers::Ovirt::InfraManager::AdminUI
   end
 
   def generate_admin_ui_url
+    require 'ovirtsdk4'
+
     $rhevm_log.info("Generating oVirt Admin UI URL for EMS with identifier '#{id}'.")
 
     # Get the credentials of the provider:

--- a/app/models/manageiq/providers/ovirt/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/api_integration.rb
@@ -1,7 +1,5 @@
 require 'openssl'
-require 'ovirt_metrics'
 require 'resolv'
-require 'ovirtsdk4'
 
 module ManageIQ::Providers::Ovirt::InfraManager::ApiIntegration
   extend ActiveSupport::Concern
@@ -96,6 +94,8 @@ module ManageIQ::Providers::Ovirt::InfraManager::ApiIntegration
   end
 
   def verify_credentials_for_rhevm_metrics(options = {})
+    require 'ovirt_metrics'
+
     OvirtMetrics.connect(rhevm_metrics_connect_options(options))
     OvirtMetrics.connected?
   rescue StandardError => error
@@ -165,6 +165,8 @@ module ManageIQ::Providers::Ovirt::InfraManager::ApiIntegration
     end
 
     def handle_credentials_verification_error(err)
+      require 'ovirtsdk4'
+
       case err
       when SocketError, Errno::EHOSTUNREACH, Errno::ENETUNREACH
         _log.warn($ERROR_INFO)
@@ -351,6 +353,8 @@ module ManageIQ::Providers::Ovirt::InfraManager::ApiIntegration
         :database => database
       }
       begin
+        require 'ovirt_metrics'
+
         OvirtMetrics.connect(opts)
         OvirtMetrics.connected?
       rescue StandardError => error
@@ -399,6 +403,7 @@ module ManageIQ::Providers::Ovirt::InfraManager::ApiIntegration
     end
 
     def default_history_database_name
+      require 'ovirt_metrics'
       OvirtMetrics::DEFAULT_HISTORY_DATABASE_NAME
     end
 

--- a/app/models/manageiq/providers/ovirt/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/event_parser.rb
@@ -82,6 +82,8 @@ module ManageIQ::Providers::Ovirt::InfraManager::EventParser
   end
 
   def self.ovirtobj_to_hash(obj)
+    require 'ovirtsdk4'
+
     obj.instance_variables.each_with_object({}) do |k, h|
       val = obj.instance_variable_get(k)
 

--- a/app/models/manageiq/providers/ovirt/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/metrics_capture.rb
@@ -31,6 +31,7 @@ class ManageIQ::Providers::Ovirt::InfraManager::MetricsCapture < ManageIQ::Provi
   #
 
   def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
+    require 'ovirt_metrics'
     target_description = "[#{target.class.name}], [#{target.id}], [#{target.name}]"
     unless target.ext_management_system.has_authentication_type?(:metrics)
       _log.warn("No C&U credentials defined for: #{target_description} returning empty stats")

--- a/app/models/manageiq/providers/ovirt/infra_manager/ovirt_services.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/ovirt_services.rb
@@ -1,4 +1,3 @@
-require 'ovirtsdk4'
 require 'yaml'
 
 module ManageIQ::Providers::Ovirt::InfraManager::OvirtServices
@@ -11,6 +10,7 @@ module ManageIQ::Providers::Ovirt::InfraManager::OvirtServices
     attr_reader :ext_management_system
 
     def initialize(args)
+      require 'ovirtsdk4'
       @ext_management_system = args[:ems]
     end
 


### PR DESCRIPTION
Requiring both of these libraries loads 61 files and consumes 10+ MB.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
