### PR TITLE
Fix EventTargetParser looking for string keys

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/event_target_parser.rb
@@ -12,11 +12,11 @@ class ManageIQ::Providers::Ovirt::InfraManager::EventTargetParser
   def parse
     target_collection = InventoryRefresh::TargetCollection.new(:manager => ems_event.ext_management_system, :event => ems_event)
 
-    data = ems_event.full_data
+    data = ems_event.full_data.deep_symbolize_keys
 
-    add_vm_target(target_collection, data["vm"])             if data["vm"].present?
-    add_template_target(target_collection, data["template"]) if data["template"].present?
-    add_cluster_target(target_collection, data["cluster"])   if data["cluster"].present?
+    add_vm_target(target_collection, data[:vm])             if data[:vm].present?
+    add_template_target(target_collection, data[:template]) if data[:template].present?
+    add_cluster_target(target_collection, data[:cluster])   if data[:cluster].present?
 
     target_collection.targets
   end
@@ -24,17 +24,17 @@ class ManageIQ::Providers::Ovirt::InfraManager::EventTargetParser
   private
 
   def add_vm_target(target_collection, vm_data)
-    ems_ref = ManageIQ::Providers::Ovirt::InfraManager.make_ems_ref(vm_data["href"])
+    ems_ref = ManageIQ::Providers::Ovirt::InfraManager.make_ems_ref(vm_data[:href])
     target_collection.add_target(:association => :vms, :manager_ref => {:ems_ref => ems_ref})
   end
 
   def add_template_target(target_collection, template_data)
-    ems_ref = ManageIQ::Providers::Ovirt::InfraManager.make_ems_ref(template_data["href"])
+    ems_ref = ManageIQ::Providers::Ovirt::InfraManager.make_ems_ref(template_data[:href])
     target_collection.add_target(:association => :miq_templates, :manager_ref => {:ems_ref => ems_ref})
   end
 
   def add_cluster_target(target_collection, cluster_data)
-    ems_ref = ManageIQ::Providers::Ovirt::InfraManager.make_ems_ref(cluster_data["href"])
+    ems_ref = ManageIQ::Providers::Ovirt::InfraManager.make_ems_ref(cluster_data[:href])
     target_collection.add_target(:association => :ems_clusters, :manager_ref => {:ems_ref => ems_ref})
   end
 end


### PR DESCRIPTION
When we moved to kafka event payloads which commonly contained symbol keys were all being returned with string keys due to JSON being the intermediate format across kafka.  We decided to `deep_symbolize_keys` when processing the event payload https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_event_handler/runner.rb#L3 but RHV/Ovirt actually used string keys in their event payloads.

In order to support both kafka and MiqQueue we need to deep_symbolize_keys here

Dependents:
* https://github.com/ManageIQ/manageiq-providers-red_hat_virtualization/pull/51

Fixes https://github.com/ManageIQ/manageiq-providers-ovirt/issues/670
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
