### PR TITLE
Remove return from supports block

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/host.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/host.rb
@@ -12,13 +12,19 @@ class ManageIQ::Providers::Ovirt::InfraManager::Host < ::Host
   end
 
   supports :enter_maint_mode do
-    return _('The Host is not connected to an active provider') unless has_active_ems?
-    return _('The Host is not powered on') unless power_state == 'on'
+    if !has_active_ems?
+      _('The Host is not connected to an active provider')
+    elsif power_state != 'on'
+      _('The Host is not powered on')
+    end
   end
 
   supports :exit_maint_mode do
-    _('The Host is not connected to an active provider') unless has_active_ems?
-    _('The Host is not in maintenance mode') unless power_state == 'maintenance'
+    if !has_active_ems?
+      _('The Host is not connected to an active provider')
+    elsif power_state != 'maintenance'
+      _('The Host is not in maintenance mode')
+    end
   end
 
   def enter_maint_mode


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/22898 (as a followup)

Introduced by https://github.com/ManageIQ/manageiq-providers-ovirt/pull/659

You can not have a return in a block. It causes a LongJump error Besides, it tries to return from inside the calling block - not what we want.

Fixes a missed unsupported reason check
