### PR TITLE
Fix typo in Ovirt VM supports?(:smartstate_analysis)

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared/scanning.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::Ovirt::InfraManager::VmOrTemplateShared::Scanning
       elsif !storage.storage_type_supported_for_ssa?
         "Smartstate Analysis unsupported for storage type %{store_type}" % {:store_type => storage.store_type}
       else
-        unuspported_reason(:action)
+        unsupported_reason(:action)
       end
     end
   end

--- a/spec/models/manageiq/providers/ovirt/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ovirt/infra_manager/vm_spec.rb
@@ -57,6 +57,41 @@ describe ManageIQ::Providers::Ovirt::InfraManager::Vm do
     end
   end
 
+  describe "supports?(:smartstate_analysis)" do
+    let(:vm) { FactoryBot.create(:vm_ovirt, :ext_management_system => ems, :host => host, :storage => storage) }
+
+    context "without a storage" do
+      let(:storage) { nil }
+
+      it "returns false" do
+        expect(vm.supports?(:smartstate_analysis)).to be_falsey
+        expect(vm.unsupported_reason(:smartstate_analysis)).to eq("Vm is not located on a storage")
+      end
+    end
+
+    context "with a storage" do
+      let(:storage) { FactoryBot.create(:storage_ovirt, :store_type => store_type) }
+
+      context "with a supported store_type" do
+        let(:store_type) { "NFS" }
+
+        it "returns false" do
+          expect(vm.supports?(:smartstate_analysis)).to be_truthy
+          expect(vm.unsupported_reason(:smartstate_analysis)).to be_nil
+        end
+      end
+
+      context "with an unsupported store_type" do
+        let(:store_type) { "BAD-STORE-TYPE" }
+
+        it "returns false" do
+          expect(vm.supports?(:smartstate_analysis)).to be_falsey
+          expect(vm.unsupported_reason(:smartstate_analysis)).to eq("Smartstate Analysis unsupported for storage type BAD-STORE-TYPE")
+        end
+      end
+    end
+  end
+
   context "#calculate_power_state" do
     it "returns suspended when suspended" do
       expect(described_class.calculate_power_state('suspended')).to eq('suspended')


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq-providers-ovirt/pull/659 this causes a failure when checking if unsupported_reason is nil
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
