### PR TITLE
Update ovirt-engine-sdk to 4.6

### DIFF
--- a/manageiq-providers-ovirt.gemspec
+++ b/manageiq-providers-ovirt.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ovirt-engine-sdk", "~>4.4.0"
+  spec.add_dependency "ovirt-engine-sdk", "~>4.6.0"
   spec.add_dependency "ovirt_metrics", "~>3.2"
 
   spec.add_development_dependency "manageiq-style"


### PR DESCRIPTION
Updating gem because it fixes some issues with ruby 3.3 building

Gem released Feb 1, 2024


I have no idea if I'm breaking anything here.
Just trying to make ruby 3.2 compile