### PR TITLE
Remove newlines from error message

### DIFF
--- a/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/ovirt/infra_manager/vm_or_template_shared/scanning.rb
@@ -51,11 +51,12 @@ module ManageIQ::Providers::Ovirt::InfraManager::VmOrTemplateShared::Scanning
     sync_stashed_metadata(ost)
   end
 
-  RHEVM_NO_PROXIES_ERROR_MSG = N_('VMs must be scanned from an EVM server whose host is attached to the same
-  storage as the VM unless overridden via SmartProxy affinity.
-  Please verify that:
-  1) Direct LUNs are attached to ManageIQ appliance
-  2) Management Relationship is set for the ManageIQ appliance')
+  RHEVM_NO_PROXIES_ERROR_MSG = N_(
+    "VMs must be scanned from an appliances whose host is attached to the same " \
+    "storage as the VM unless overridden via SmartProxy affinity. Please verify " \
+    "that direct LUNs are attached to the appliance and that the management " \
+    "relationship is set for the appliance."
+  )
 
   def proxies4job(_job = nil)
     _log.debug "Enter (RHEVM)"


### PR DESCRIPTION
Newlines can cause trouble with translations as well as presentation in the UI. This particular string doesn't actually need the newlines, so this commit changes it to just not have them.

Alternative to ManageIQ/manageiq#23213

@agrare Please review.  cc @jrafanie 

I think this will also require a change in the ui-classic repo, since this string actually appears in the test snapshots.  Think it will be easier to make the PR if we merge this first however.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
