### PR TITLE
Delegate refresh_ems class method to parent infra manager

### DIFF
--- a/app/models/manageiq/providers/ovirt/network_manager.rb
+++ b/app/models/manageiq/providers/ovirt/network_manager.rb
@@ -20,6 +20,10 @@ class ManageIQ::Providers::Ovirt::NetworkManager < ManageIQ::Providers::NetworkM
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Ovirt::InfraManager
+  end
+
   def self.hostname_required?
     false
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,8 +55,9 @@
     :pipeline: 40
     :connections: 10
     :allow_targeted_refresh: true
-  :redhat_network:
+  :ovirt_network:
     :is_admin: false
+    :refresh_interval: 0
 :log:
   :level_rhevm: info
 :workers:


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare