### PR TITLE
[WIP] Handle `nil` storage domain store type

### DIFF
--- a/app/models/manageiq/providers/ovirt/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ovirt/inventory/parser/infra_manager.rb
@@ -82,7 +82,7 @@ class ManageIQ::Providers::Ovirt::Inventory::Parser::InfraManager < ManageIQ::Pr
 
   def storagedomains
     collector.storagedomains.each do |storagedomain|
-      storage_type = storagedomain.dig(:storage, :type).upcase
+      storage_type = storagedomain.dig(:storage, :type)&.upcase
       ems_ref = ManageIQ::Providers::Ovirt::InfraManager.make_ems_ref(storagedomain.try(:href))
       location = case storage_type
                  when 'LOCALFS', 'ISO'


### PR DESCRIPTION
Handle the case where `storagedomain` store type is `nil` which would fall into the using the volume_group id for the location.

We do use `Storage#store_type` for other things (namely smartstate analysis) so I don't think we should just leave it blank but this fixes the exception blocking refresh.

Fixes https://github.com/ManageIQ/manageiq-providers-ovirt/issues/697
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
