### PR TITLE
Remove owner_load_ldap from dialogs

### DIFF
--- a/content/miq_dialogs/miq_provision_ovirt_dialogs_clone_to_template.yaml
+++ b/content/miq_dialogs/miq_provision_ovirt_dialogs_clone_to_template.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/content/miq_dialogs/miq_provision_ovirt_dialogs_clone_to_vm.yaml
+++ b/content/miq_dialogs/miq_provision_ovirt_dialogs_clone_to_vm.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/content/miq_dialogs/miq_provision_ovirt_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ovirt_dialogs_template.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false


### PR DESCRIPTION
owner_load_ldap depends on MiqLdap which is no longer supported

Part of ManageIQ/manageiq#21127